### PR TITLE
fix: add XDG fallback defaults to prevent permission errors

### DIFF
--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -8,8 +8,8 @@ export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
 export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 
-# Zsh config location
-export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
+# Zsh config location (disabled - using ~/.zshrc directly for simplicity)
+# export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
 
 # Locale
 export LANG=en_US.UTF-8

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -1,8 +1,16 @@
 # =============================================================================
+# XDG Base Directory (fallback if .zshenv not sourced)
+# =============================================================================
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+
+# =============================================================================
 # Instant prompt (show prompt immediately, load rest async)
 # =============================================================================
-if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/starship/init.zsh" ]]; then
-  source "${XDG_CACHE_HOME:-$HOME/.cache}/starship/init.zsh"
+if [[ -r "${XDG_CACHE_HOME}/starship/init.zsh" ]]; then
+  source "${XDG_CACHE_HOME}/starship/init.zsh"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Add XDG Base Directory fallback exports at top of `.zshrc` to handle cases where `.zshenv` is not sourced first
- Disable `ZDOTDIR` in `.zshenv` to keep `.zshrc` at `~/.zshrc` for simplicity

## Problem
When `.zshenv` is not sourced before `.zshrc`, XDG variables would be empty, causing paths like `${XDG_CACHE_HOME}/devbox` to resolve to just `/devbox`, resulting in permission denied errors:

```
mkdir: cannot create directory '/devbox': Permission denied
mkdir: cannot create directory '/zinit': Permission denied
mkdir: cannot create directory '/zsh': Permission denied
```

## Test plan
- [ ] Run `chezmoi apply` on a fresh system
- [ ] Verify no permission errors on shell startup
- [ ] Verify zinit, devbox, and starship initialize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)