### PR TITLE
feat: add install script for one-liner setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,30 @@ Personal dotfiles managed with [chezmoi](https://www.chezmoi.io/) and [devbox](h
 
 ## Quick Start
 
-### New Machine Setup
+### New Machine Setup (One-liner)
+
+```bash
+# Personal
+curl -fsSL https://raw.githubusercontent.com/paveg/dots/main/install.sh | bash
+
+# Work environment
+curl -fsSL https://raw.githubusercontent.com/paveg/dots/main/install.sh | BUSINESS_USE=1 bash
+```
+
+### Manual Setup
 
 ```bash
 # Install devbox
 curl -fsSL https://get.jetify.com/devbox | bash
 
+# Load devbox into current shell (required before using devbox commands)
+eval "$(devbox global shellenv)"
+
 # Install chezmoi via devbox
 devbox global add chezmoi
+
+# Reload to get chezmoi in PATH
+eval "$(devbox global shellenv)"
 
 # Apply dotfiles (you'll be prompted for name and email)
 chezmoi init --apply paveg/dots
@@ -198,11 +214,12 @@ direnv allow
 ### SSH/Remote Server Setup
 
 ```bash
-# On remote server
-curl -fsSL https://get.jetify.com/devbox | bash
-devbox global add chezmoi neovim tmux ghq fzf ripgrep fd bat eza zoxide starship lazygit direnv delta
+# One-liner
+curl -fsSL https://raw.githubusercontent.com/paveg/dots/main/install.sh | bash
 
-chezmoi init --apply paveg/dots
+# Then install tools
+eval "$(devbox global shellenv)"
+devbox global add neovim tmux ghq fzf ripgrep fd bat eza zoxide starship lazygit direnv delta
 ```
 
 **Note:** Ghostty config is automatically skipped on SSH sessions (detected via `$SSH_CLIENT`).

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Bootstrap script for paveg/dots
+# Usage: curl -fsSL https://raw.githubusercontent.com/paveg/dots/main/install.sh | bash
+# With work environment: curl -fsSL ... | BUSINESS_USE=1 bash
+
+set -e
+
+echo "==> Installing dotfiles..."
+
+# Install devbox if not present
+if ! command -v devbox &> /dev/null; then
+  echo "==> Installing devbox..."
+  curl -fsSL https://get.jetify.com/devbox | bash
+fi
+
+# Set up devbox shellenv
+eval "$(devbox global shellenv 2>/dev/null || true)"
+
+# Install chezmoi via devbox if not present
+if ! command -v chezmoi &> /dev/null; then
+  echo "==> Installing chezmoi via devbox..."
+  devbox global add chezmoi
+  eval "$(devbox global shellenv)"
+fi
+
+# Apply dotfiles
+echo "==> Applying dotfiles..."
+if [[ -n "$BUSINESS_USE" ]]; then
+  BUSINESS_USE=1 chezmoi init --apply paveg/dots
+else
+  chezmoi init --apply paveg/dots
+fi
+
+echo "==> Done! Restart your shell or run: exec zsh"


### PR DESCRIPTION
## Summary
- Add `install.sh` bootstrap script for one-liner installation
- Update README with one-liner install commands
- Add missing `eval "$(devbox global shellenv)"` steps to manual instructions

## Problem
After installing devbox, `devbox global add chezmoi` and `chezmoi` commands fail because devbox shellenv is not loaded into the current shell:

```
zsh: command not found: chezmoi
```

## Solution
Add a bootstrap script that handles the full installation flow:

```bash
# Personal
curl -fsSL https://raw.githubusercontent.com/paveg/dots/main/install.sh | bash

# Work environment
curl -fsSL https://raw.githubusercontent.com/paveg/dots/main/install.sh | BUSINESS_USE=1 bash
```

## Test plan
- [ ] Test one-liner install on fresh Linux system
- [ ] Verify manual instructions work with new `eval` steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)