### PR TITLE
feat: enhance fzf with preview, keybindings, and Catppuccin theme

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -144,9 +144,29 @@ zinit wait"1" lucid light-mode for \
       _fzf_cache="${XDG_CACHE_HOME}/zsh/init/fzf.zsh"
       [[ -f "$_fzf_cache" ]] || fzf --zsh > "$_fzf_cache"
       source "$_fzf_cache"
-      export FZF_DEFAULT_OPTS="--height 40% --layout=reverse --border"
+
+      # Catppuccin Mocha colors
+      export FZF_DEFAULT_OPTS=" \
+        --height 60% --layout=reverse --border=rounded \
+        --margin=1 --padding=1 \
+        --color=bg+:#313244,bg:#1e1e2e,spinner:#f5e0dc,hl:#f38ba8 \
+        --color=fg:#cdd6f4,header:#f38ba8,info:#cba6f7,pointer:#f5e0dc \
+        --color=marker:#b4befe,fg+:#cdd6f4,prompt:#cba6f7,hl+:#f38ba8 \
+        --color=selected-bg:#45475a \
+        --preview-window=right:50%:border-left \
+        --bind=ctrl-u:preview-half-page-up,ctrl-d:preview-half-page-down"
+
+      # File search (Ctrl+T)
       export FZF_DEFAULT_COMMAND="fd --type f --hidden --follow --exclude .git"
       export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+      export FZF_CTRL_T_OPTS="--preview '\''bat --color=always --style=numbers --line-range :300 {} 2>/dev/null || cat {}'\''"
+
+      # Directory search (Alt+C)
+      export FZF_ALT_C_COMMAND="fd --type d --hidden --follow --exclude .git"
+      export FZF_ALT_C_OPTS="--preview '\''eza --tree --icons --level=2 --color=always {} | head -50'\''"
+
+      # History search (Ctrl+R)
+      export FZF_CTRL_R_OPTS="--preview '\''echo {}'\''"
     fi
   ' \
     zdharma-continuum/null
@@ -354,7 +374,10 @@ dots() {
 
 ⌨️  Key Bindings
   Ctrl+g       Repository navigation (ghq + fzf)
+  Ctrl+t       File search with preview (fzf)
   Ctrl+r       History search (fzf)
+  Alt+c        Directory navigation (fzf)
+  Ctrl+u/d     Scroll preview (fzf)
   z <dir>      Smart cd (zoxide)
 
 🛠️  Commands


### PR DESCRIPTION
## Summary
- Add Catppuccin Mocha color scheme for fzf
- Add file preview with bat (`Ctrl+T`)
- Add directory navigation with tree preview (`Alt+C`)
- Add preview scroll keybindings (`Ctrl+U/D`)

## New Keybindings

| Key | Description |
|-----|-------------|
| `Ctrl+T` | File search with bat preview |
| `Alt+C` | Directory navigation with tree preview |
| `Ctrl+R` | History search |
| `Ctrl+U` | Scroll preview up |
| `Ctrl+D` | Scroll preview down |

## Test plan
- [ ] Test `Ctrl+T` shows file preview with syntax highlighting
- [ ] Test `Alt+C` shows directory tree preview
- [ ] Test `Ctrl+R` history search works
- [ ] Verify Catppuccin colors display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)