### PR TITLE
fix: install script Nix dependency and Ghostty terminal fallback

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -7,6 +7,14 @@ export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
 export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 
 # =============================================================================
+# Terminal compatibility (Ghostty fallback)
+# =============================================================================
+# Fall back to xterm-256color if terminfo is missing (e.g., SSH to older servers)
+if [[ "$TERM" == "xterm-ghostty" ]] && ! infocmp xterm-ghostty &>/dev/null; then
+  export TERM=xterm-256color
+fi
+
+# =============================================================================
 # Instant prompt (show prompt immediately, load rest async)
 # =============================================================================
 if [[ -r "${XDG_CACHE_HOME}/starship/init.zsh" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -7,14 +7,26 @@ set -e
 
 echo "==> Installing dotfiles..."
 
+# Install Nix if not present (required by devbox)
+if ! command -v nix &> /dev/null; then
+  echo "==> Installing Nix..."
+  curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
+  # Source nix for current session
+  if [[ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]]; then
+    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+  fi
+fi
+
 # Install devbox if not present
 if ! command -v devbox &> /dev/null; then
   echo "==> Installing devbox..."
-  curl -fsSL https://get.jetify.com/devbox | bash
+  curl -fsSL https://get.jetify.com/devbox | bash -s -- -f
 fi
 
-# Set up devbox shellenv
-eval "$(devbox global shellenv 2>/dev/null || true)"
+# Set up devbox shellenv (only if nix is available)
+if command -v nix &> /dev/null; then
+  eval "$(devbox global shellenv 2>/dev/null || true)"
+fi
 
 # Install chezmoi via devbox if not present
 if ! command -v chezmoi &> /dev/null; then


### PR DESCRIPTION
## Summary
- Install Nix before devbox (devbox requires Nix to function properly)
- Add `-f` flag for non-interactive devbox installation
- Only run `devbox global shellenv` when Nix is available (prevents "Nix: command not found" error)
- Add terminal compatibility fallback for `xterm-ghostty` in zshrc

## Details

### Install script fixes
The install script was failing with `bash: line 18: Nix: command not found` because:
1. Devbox requires Nix to be installed first
2. `devbox global shellenv` outputs error text when Nix is missing, which gets interpreted as a bash command when passed to `eval`

### Ghostty terminal fallback
When SSH'ing to servers without Ghostty's terminfo installed, the connection would fail with:
```
missing or unsuitable terminal: xterm-ghostty
```

The fix automatically detects if terminfo is missing and falls back to `xterm-256color`.

## Test plan
- [ ] Run `curl -fsSL https://raw.githubusercontent.com/paveg/dots/main/install.sh | bash` on a fresh machine
- [ ] SSH to a server without Ghostty terminfo and verify terminal works

🤖 Generated with [Claude Code](https://claude.com/claude-code)