### PR TITLE
feat: add Claude Code configuration and atuin shell history

### DIFF
--- a/.claude/rules/chezmoi-templates.md
+++ b/.claude/rules/chezmoi-templates.md
@@ -1,0 +1,31 @@
+---
+paths: "**/*.tmpl"
+---
+
+# Chezmoi Template Rules
+
+## Template Syntax
+
+- Use Go template syntax: `{{ .variable }}`, `{{- ... -}}` for whitespace control
+- Access chezmoi data via `.chezmoi.os`, `.chezmoi.arch`, `.chezmoi.homeDir`
+- Custom data defined in `.chezmoi.yaml.tmpl` accessed via `.name`, `.email`, `.business_use`, etc.
+
+## Conditional Patterns
+
+```
+{{- if .business_use }}
+# Work-specific content
+{{- end }}
+
+{{- if eq .chezmoi.os "darwin" }}
+# macOS-specific content
+{{- end }}
+```
+
+## Testing Changes
+
+Always test template changes with both environments:
+```bash
+chezmoi execute-template < file.tmpl              # Test with current config
+BUSINESS_USE=1 chezmoi init --source=. --dry-run  # Test business mode
+```

--- a/.claude/rules/lua.md
+++ b/.claude/rules/lua.md
@@ -1,0 +1,22 @@
+---
+paths: "dot_config/nvim/**/*.lua"
+---
+
+# Neovim Lua Rules
+
+## Formatting
+
+- Format with stylua (config in `.stylua.toml`)
+- Run `just fmt` before committing
+
+## Plugin Structure
+
+Plugins are organized in `dot_config/nvim/lua/plugins/`:
+- One file per plugin category (ui.lua, editor.lua, lsp.lua, etc.)
+- Uses lazy.nvim plugin manager with lazy-loading
+
+## Style
+
+- Prefer `vim.keymap.set()` over `vim.api.nvim_set_keymap()`
+- Use `<leader>` (Space) for custom keybindings
+- Group related options with comments

--- a/.claude/rules/zsh.md
+++ b/.claude/rules/zsh.md
@@ -1,0 +1,23 @@
+---
+paths: "dot_zsh*.tmpl"
+---
+
+# Zsh Configuration Rules
+
+## Structure
+
+- `dot_zshenv.tmpl` - Environment variables only (loaded for all shells)
+- `dot_zshrc.tmpl` - Interactive shell config (aliases, functions, plugins)
+
+## Syntax Checking
+
+Chezmoi templates break zsh syntax checking. CI removes template syntax before checking:
+```bash
+sed 's/{{[^}]*}}//g' file.tmpl > /tmp/check.zsh && zsh -n /tmp/check.zsh
+```
+
+## Performance
+
+- Shell startup target: ~50ms
+- Uses zinit turbo mode for deferred plugin loading
+- Cache init scripts in `~/.cache/zsh/init/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Personal dotfiles managed with [chezmoi](https://www.chezmoi.io/) and [devbox](https://www.jetify.com/devbox). Files prefixed with `dot_` become dotfiles (e.g., `dot_zshrc.tmpl` → `~/.zshrc`).
+
+## Commands
+
+```bash
+just test        # Run all checks (lint + format)
+just fmt         # Format all files (Lua, JSON)
+just fmt-check   # Check formatting without changes
+just lint        # Check zsh and lua syntax
+just apply       # Apply dotfiles via chezmoi
+just diff        # Show pending chezmoi changes
+```
+
+## Architecture
+
+- **chezmoi templates** (`.tmpl` files): Use Go template syntax `{{ .variable }}` for conditional content
+- **devbox.json**: Defines CLI tools installed via devbox global
+- **justfile**: Task runner for formatting, linting, and chezmoi operations
+
+### Key Data Variables (defined in `.chezmoi.yaml.tmpl`)
+
+| Variable | Description |
+|----------|-------------|
+| `.business_use` | `true` if `BUSINESS_USE=1` was set during init |
+| `.osid` | OS identifier (e.g., `darwin`, `linux-ubuntu`) |
+| `.name`, `.email`, `.work_email` | User info prompted on first run |
+
+### Configuration Directories
+
+- `dot_config/nvim/` - Neovim config (kickstart-based, uses lazy.nvim)
+- `dot_config/git/` - Git config with conditional includes for work/personal
+- `dot_config/ghostty/` - Terminal emulator config
+- `private_dot_ssh/` - SSH config (common settings only)
+
+## CI
+
+GitHub Actions runs on every push/PR to main:
+- Format check (stylua for Lua, JSON validation)
+- Lint (zsh syntax, lua syntax)
+- Chezmoi dry-run on Linux and macOS (both personal and business modes)
+- Neovim startup test

--- a/dot_config/atuin/config.toml
+++ b/dot_config/atuin/config.toml
@@ -1,0 +1,92 @@
+# Atuin configuration
+# https://docs.atuin.sh/configuration/config/
+
+# =============================================================================
+# Search behavior
+# =============================================================================
+# Search mode: prefix, fulltext, fuzzy, skim
+search_mode = "fuzzy"
+
+# Filter mode: global, host, session, directory
+filter_mode = "global"
+
+# Filter mode for shell up arrow
+filter_mode_shell_up_arrow = "session"
+
+# Enable ctrl+d to exit
+exit_mode = "return-query"
+
+# =============================================================================
+# UI settings (matching fzf style)
+# =============================================================================
+# Style: auto, full, compact
+style = "compact"
+
+# Inline height (number of lines, ~60% of typical terminal)
+inline_height = 30
+
+# Show help row at bottom
+show_help = true
+
+# Show preview of full command
+show_preview = true
+
+# Show tabs for filter modes
+show_tabs = true
+
+# Invert the UI (search at top like fzf --reverse)
+invert = true
+
+# Border around UI
+border = true
+
+# Rounded border style (matching fzf)
+border_style = "rounded"
+
+# History format
+history_format = "{time} {command}"
+
+# Cursor style: default, underscore, line, beam
+cursor_style = "line"
+
+# Maximum preview height
+max_preview_height = 4
+
+# =============================================================================
+# Sync settings
+# =============================================================================
+# Local history only (no sync)
+auto_sync = false
+
+# Uncomment to enable cloud sync:
+# auto_sync = true
+# sync_frequency = "5m"
+# sync_address = "https://api.atuin.sh"
+
+# =============================================================================
+# Catppuccin Mocha colors (matching fzf/ghostty theme)
+# =============================================================================
+[colors]
+# Base colors
+normal = "#cdd6f4"           # Text
+selected = "#f5e0dc"         # Rosewater (highlighted item)
+selected_background = "#45475a"  # Surface1 (selection bg)
+
+# UI elements
+prompt = "#cba6f7"           # Mauve
+border = "#313244"           # Surface0
+guide = "#45475a"            # Surface1
+info = "#cba6f7"             # Mauve
+preview_border = "#313244"   # Surface0
+preview_label = "#cdd6f4"    # Text
+
+# Syntax highlighting
+keyword = "#f38ba8"          # Red
+hostname = "#89b4fa"         # Blue
+directory = "#a6e3a1"        # Green
+duration = "#f9e2af"         # Yellow
+time = "#6c7086"             # Overlay0
+
+# Highlights
+title = "#f38ba8"            # Red
+cursor = "#f5e0dc"           # Rosewater

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -145,6 +145,17 @@ zinit wait"1" lucid light-mode for \
   ' \
     zdharma-continuum/null
 
+# atuin (turbo) - shell history (load after fzf to override Ctrl+R)
+zinit wait"2" lucid light-mode for \
+  atload'
+    if (( $+commands[atuin] )); then
+      _atuin_cache="${XDG_CACHE_HOME}/zsh/init/atuin.zsh"
+      [[ -f "$_atuin_cache" ]] || atuin init zsh --disable-up-arrow > "$_atuin_cache"
+      source "$_atuin_cache"
+    fi
+  ' \
+    zdharma-continuum/null
+
 # fzf (turbo)
 zinit wait"1" lucid light-mode for \
   atload'
@@ -173,8 +184,7 @@ zinit wait"1" lucid light-mode for \
       export FZF_ALT_C_COMMAND="fd --type d --hidden --follow --exclude .git"
       export FZF_ALT_C_OPTS="--preview '\''eza --tree --icons --level=2 --color=always {} | head -50'\''"
 
-      # History search (Ctrl+R)
-      export FZF_CTRL_R_OPTS="--preview '\''echo {}'\''"
+      # Note: Ctrl+R history search is handled by atuin
     fi
   ' \
     zdharma-continuum/null
@@ -374,6 +384,7 @@ dots() {
   ~/.config/starship.toml  Prompt
   ~/.config/lazygit/   Git TUI (conventional commits)
   ~/.config/ghostty/   Terminal (Catppuccin Mocha)
+  ~/.config/atuin/     Shell history (fuzzy search)
 
 🔧 Local Config (per-machine, not tracked)
   ~/.env.local         Environment variables
@@ -383,9 +394,9 @@ dots() {
 ⌨️  Key Bindings
   Ctrl+g       Repository navigation (ghq + fzf)
   Ctrl+t       File search with preview (fzf)
-  Ctrl+r       History search (fzf)
+  Ctrl+r       History search (atuin)
   Alt+c        Directory navigation (fzf)
-  Ctrl+u/d     Scroll preview (fzf)
+  Ctrl+u/d     Scroll preview (fzf/atuin)
   z <dir>      Smart cd (zoxide)
 
 🛠️  Commands
@@ -429,6 +440,7 @@ zsh-clear-cache() {
   rm -f "${XDG_CACHE_HOME}/devbox/shellenv.zsh"
   rm -rf "${XDG_DATA_HOME}/zinit"
   echo "All cache cleared. Restart shell to reinstall zinit."
+  echo "Note: atuin history is preserved in ~/.local/share/atuin/"
 }
 
 zsh-update-cache() {


### PR DESCRIPTION
## Summary

- Add CLAUDE.md with universal project guidance (commands, architecture overview)
- Add .claude/rules/ directory with path-specific rules for chezmoi templates, Lua, and zsh files
- Integrate atuin for enhanced shell history search with fuzzy finding
- Update zsh config to use atuin for Ctrl+R instead of fzf

## Test plan

- [ ] Verify `just test` passes
- [ ] Test atuin integration by pressing Ctrl+R in terminal
- [ ] Verify other fzf bindings (Ctrl+t, Alt+c) still work
- [ ] Check Claude Code loads CLAUDE.md and rules correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)