### PR TITLE
feat: add Go binaries to PATH globally

### DIFF
--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -43,6 +43,9 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 # Local binaries
 export PATH="$HOME/.local/bin:$PATH"
 
+# Go binaries (default GOPATH is ~/go)
+export PATH="${PATH}:${HOME}/go/bin"
+
 # ghq root
 export GHQ_ROOT="$HOME/repos"
 


### PR DESCRIPTION
## Summary

- Add `$HOME/go/bin` to PATH in zshenv for Go tools installed via `go install`
- Uses the default GOPATH location (`~/go`) without subprocess overhead

## Test plan

- [ ] Run `just test` to verify syntax
- [ ] Apply with `just apply` and verify `echo $PATH` includes `~/go/bin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)