### PR TITLE
feat: update devbox, neovim config, and shell env for Claude Code compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ brew install --cask font-udev-gothic-nf
 
 ```bash
 # Install all CLI tools via devbox global
-devbox global add neovim git tmux ghq fzf ripgrep fd bat eza zoxide starship lazygit direnv jq yq delta
+devbox global add go nodejs python neovim git tmux ghq fzf ripgrep fd bat eza zoxide starship lazygit direnv jq yq delta
 ```
 
 ## Structure
@@ -96,6 +96,9 @@ dots/
 
 | Tool | Description |
 |------|-------------|
+| go | Go language (for gopls LSP) |
+| nodejs | Node.js (for ts_ls, pyright LSP) |
+| python | Python (for python development) |
 | neovim | Editor |
 | tmux | Terminal multiplexer |
 | ghq | Repository management |
@@ -247,7 +250,7 @@ curl -fsSL https://raw.githubusercontent.com/paveg/dots/main/install.sh | bash
 
 # Then install tools
 eval "$(devbox global shellenv)"
-devbox global add neovim tmux ghq fzf ripgrep fd bat eza zoxide starship lazygit direnv delta
+devbox global add go nodejs python neovim tmux ghq fzf ripgrep fd bat eza zoxide starship lazygit direnv delta
 ```
 
 **Note:** Ghostty config is automatically skipped on SSH sessions (detected via `$SSH_CLIENT`).

--- a/devbox.json
+++ b/devbox.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json",
   "packages": [
+    "go@latest",
+    "nodejs@latest",
+    "python@latest",
     "neovim@latest",
     "git@latest",
     "tmux@latest",

--- a/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dot_config/nvim/lua/plugins/lsp.lua
@@ -68,11 +68,9 @@ return {
       local capabilities = vim.lsp.protocol.make_client_capabilities()
       capabilities = vim.tbl_deep_extend("force", capabilities, require("cmp_nvim_lsp").default_capabilities())
 
-      -- Setup servers
-      local lspconfig = require("lspconfig")
-
+      -- Setup servers using vim.lsp.config (Neovim 0.11+)
       -- Lua
-      lspconfig.lua_ls.setup({
+      vim.lsp.config.lua_ls = {
         capabilities = capabilities,
         settings = {
           Lua = {
@@ -89,15 +87,15 @@ return {
             },
           },
         },
-      })
+      }
 
       -- TypeScript
-      lspconfig.ts_ls.setup({
+      vim.lsp.config.ts_ls = {
         capabilities = capabilities,
-      })
+      }
 
       -- Go
-      lspconfig.gopls.setup({
+      vim.lsp.config.gopls = {
         capabilities = capabilities,
         settings = {
           gopls = {
@@ -108,17 +106,20 @@ return {
             gofumpt = true,
           },
         },
-      })
+      }
 
       -- Rust
-      lspconfig.rust_analyzer.setup({
+      vim.lsp.config.rust_analyzer = {
         capabilities = capabilities,
-      })
+      }
 
       -- Python
-      lspconfig.pyright.setup({
+      vim.lsp.config.pyright = {
         capabilities = capabilities,
-      })
+      }
+
+      -- Enable all configured servers
+      vim.lsp.enable({ "lua_ls", "ts_ls", "gopls", "rust_analyzer", "pyright" })
     end,
   },
 

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -46,6 +46,17 @@ export PATH="$HOME/.local/bin:$PATH"
 # Go binaries (default GOPATH is ~/go)
 export PATH="${PATH}:${HOME}/go/bin"
 
+# Devbox global (must be in zshenv for non-interactive shells like Claude Code)
+_devbox_cache="${XDG_CACHE_HOME}/devbox/shellenv.zsh"
+if [[ -f "$_devbox_cache" ]]; then
+  source "$_devbox_cache"
+elif command -v devbox &>/dev/null; then
+  mkdir -p "${XDG_CACHE_HOME}/devbox"
+  devbox global shellenv > "$_devbox_cache"
+  source "$_devbox_cache"
+fi
+unset _devbox_cache
+
 # ghq root
 export GHQ_ROOT="$HOME/repos"
 

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -75,19 +75,6 @@ setopt AUTO_CD AUTO_PUSHD PUSHD_IGNORE_DUPS INTERACTIVE_COMMENTS NO_BEEP
 bindkey -e
 
 # =============================================================================
-# Devbox (PATH setup - must be synchronous)
-# =============================================================================
-_devbox_cache="${XDG_CACHE_HOME}/devbox/shellenv.zsh"
-if [[ -f "$_devbox_cache" ]]; then
-  source "$_devbox_cache"
-elif (( $+commands[devbox] )); then
-  mkdir -p "${XDG_CACHE_HOME}/devbox"
-  devbox global shellenv > "$_devbox_cache"
-  source "$_devbox_cache"
-fi
-unset _devbox_cache
-
-# =============================================================================
 # Zinit
 # =============================================================================
 ZINIT_HOME="${XDG_DATA_HOME}/zinit/zinit.git"


### PR DESCRIPTION
## Summary

- Add `go`, `nodejs`, `python` to devbox.json for LSP servers (gopls, ts_ls, pyright)
- Update README.md with new devbox packages documentation
- Move devbox shellenv from `.zshrc` to `.zshenv` for non-interactive shells (fixes Claude Code not finding devbox tools)
- Update `lsp.lua` to use `vim.lsp.config` API (Neovim 0.11+)
- Replace `nvim-treesitter-textobjects` with `mini.ai` for compatibility with latest nvim-treesitter

## Test plan

- [ ] Run `just test` to verify syntax
- [ ] Apply dotfiles and verify devbox tools are available in non-interactive shells
- [ ] Open Neovim and verify LSP servers start without errors
- [ ] Test textobjects (`af`, `if`, `ac`, `ic`) work with mini.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)