### PR TITLE
chore(zsh): speed up startup by skipping compaudit

### DIFF
--- a/dot_config/zsh/split/plugins.zsh
+++ b/dot_config/zsh/split/plugins.zsh
@@ -14,11 +14,10 @@ source "${ZINIT_HOME}/zinit.zsh"
 # Turbo-loaded plugins
 # =============================================================================
 zinit wait lucid blockf light-mode for \
-  atload"zicompinit; zicdreplay" \
+  atload"autoload -Uz compinit && compinit -C -d \${XDG_CACHE_HOME:-\$HOME/.cache}/zsh/.zcompdump && zicdreplay" \
     zsh-users/zsh-completions
 
 zinit wait lucid light-mode for \
-  atinit"ZINIT[COMPINIT_OPTS]=-C; zicompinit; zicdreplay" \
     zdharma-continuum/fast-syntax-highlighting
 
 zinit wait lucid light-mode for \

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -170,7 +170,12 @@ fi
 # =============================================================================
 # bun completions
 # =============================================================================
-[[ -s "$HOME/.bun/_bun" ]] && source "$HOME/.bun/_bun"
+# Pre-load compinit with -C so _bun's internal fallback (which calls plain
+# `compinit`, triggering compaudit ~13ms) is skipped via its `command -v` guard.
+if [[ -s "$HOME/.bun/_bun" ]]; then
+  autoload -Uz compinit && compinit -C -d "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/.zcompdump"
+  source "$HOME/.bun/_bun"
+fi
 
 # =============================================================================
 # pnpm setup
@@ -185,6 +190,11 @@ esac
 # Vite+ bin
 # =============================================================================
 [[ -f "$HOME/.vite-plus/env" ]] && source "$HOME/.vite-plus/env"
+
+# =============================================================================
+# CF CLI completions (shipped via Vite+)
+# =============================================================================
+[[ -f "$HOME/.config/cf/completions/_cf.zsh" ]] && source "$HOME/.config/cf/completions/_cf.zsh"
 
 {{- if not .business_use }}
 {{- if and (ne .grafana_instance_id "") (ne .grafana_api_token "") }}


### PR DESCRIPTION
## Summary
- Pre-load \`compinit -C\` before sourcing \`~/.bun/_bun\` so bun's internal fallback (which calls plain \`compinit\` and triggers \`compaudit\` ~13ms) is skipped via its \`command -v compinit\` guard.
- Inline \`compinit -C -d \$XDG_CACHE_HOME/zsh/.zcompdump\` into the zsh-completions \`atload\` to bypass zinit's cached \`zicompinit\` wrapper (which had stale ice params without \`-C\`).
- Drop the redundant \`atinit\` \`zicompinit\` on fast-syntax-highlighting (compinit was being called twice).
- Add CF CLI completion (shipped via Vite+).

## Test plan
- [x] \`zsh-bench\` before: ~90ms, after: ~77ms
- [x] \`zprofiler | head\` shows \`compaudit\` gone, \`compinit\` down from ~23ms (incl. audit) to 9.4ms
- [x] Tab completion works for: \`bun\`, \`cf\`, \`gh\`, \`chezmoi\`, \`kubectl\`
- [x] \`chezmoi apply\` succeeds