### PR TITLE
chore(git): ignore superpowers docs and claude worktrees

### DIFF
--- a/dot_config/git/ignore
+++ b/dot_config/git/ignore
@@ -38,3 +38,6 @@ devbox.lock
 **/.claude/settings.local.json
 
 sourcemaps
+
+docs/superpowers/
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Add `docs/superpowers/` and `.claude/worktrees/` to global git ignore

## Test plan
- [ ] `just test` passes
- [ ] `just diff` shows expected chezmoi changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)