### PR TITLE
chore(npm): set minimum-release-age to 10080 minutes (7 days)

### DIFF
--- a/dot_npmrc.tmpl
+++ b/dot_npmrc.tmpl
@@ -8,7 +8,7 @@ use-lockfile-v9=true
 # Supply chain security
 # Wait 3 days (72 hours) before installing new packages
 # This helps protect against supply chain attacks
-minimum-release-age=3 days
+minimum-release-age=10080
 
 # Performance optimizations
 prefer-frozen-lockfile=true


### PR DESCRIPTION
## Summary
- pnpm's `minimum-release-age` expects an integer number of minutes, so the prior `3 days` string was not honored as intended
- Set the quarantine window to `10080` (7 days in minutes) for a stronger supply-chain buffer

## Test plan
- [ ] `just test` passes
- [ ] `just apply` writes the expected value to `~/.npmrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)