### PR TITLE
feat(zsh): add rgn live-grep shortcut (rg + fzf → nvim)

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -18,6 +18,10 @@ background-opacity = 0.95
 maximize = true
 macos-titlebar-style = tabs
 
+# Left Option -> Alt (enables terminal Alt-keybindings like Alt+R/Alt+C)
+# Right Option still inserts macOS special chars (®, ™, …)
+macos-option-as-alt = left
+
 # Shell
 command = zsh -l
 shell-integration = detect

--- a/dot_config/zsh/split/functions.zsh
+++ b/dot_config/zsh/split/functions.zsh
@@ -217,6 +217,7 @@ dots() {
   Ctrl+t       File search with preview (fzf)
   Ctrl+r       History search (atuin)
   Alt+c        Directory navigation (fzf)
+  Alt+r        Live grep -> nvim (rg + fzf)
   Ctrl+u/d     Scroll preview (fzf/atuin)
   z <dir>      Smart cd (zoxide)
 
@@ -231,6 +232,7 @@ dots() {
 
 🛠️  Commands
   repos        Jump to repository (ghq + fzf)
+  rgn          Live grep -> open in nvim (rg + fzf, Tab: multi-select)
   rub          Remove merged git branches
   lg           lazygit
   kctx         Switch kube context (fzf)
@@ -359,6 +361,57 @@ kinfo() {
   echo "Context:   $(kubectl config current-context 2>/dev/null || echo 'none')"
   echo "Namespace: $(kubectl config view --minify -o jsonpath='{..namespace}' 2>/dev/null || echo 'default')"
 }
+
+# =============================================================================
+# ripgrep + fzf -> nvim (live grep, multi-select, open at line)
+# =============================================================================
+# Usage: rgn [pattern]        # typing live-reloads rg
+#        Tab                  # multi-select matches
+#        Enter                # open selected file(s) in nvim at the match line
+#        Alt-/                # toggle preview
+# Keybinding: Alt+R
+rgn() {
+  if ! (( $+commands[rg] && $+commands[fzf] )); then
+    echo "Error: rgn requires rg and fzf" >&2
+    return 1
+  fi
+
+  local rg_cmd='rg --column --line-number --no-heading --color=always --smart-case'
+  local initial="${*:-}"
+  local selections
+
+  # : | ... starts fzf with an empty list; start/change bindings drive rg.
+  selections=$(
+    : | fzf --ansi --multi \
+        --disabled --query "$initial" \
+        --delimiter : --prompt 'rg> ' \
+        --header 'Tab: multi-select / Enter: open / Alt-/: toggle preview' \
+        --bind "start:reload:$rg_cmd -- {q} 2>/dev/null || true" \
+        --bind "change:reload:sleep 0.1; $rg_cmd -- {q} 2>/dev/null || true" \
+        --bind 'alt-/:toggle-preview' \
+        --preview 'bat --color=always --style=numbers --highlight-line {2} {1} 2>/dev/null || cat {1}' \
+        --preview-window 'right,60%,border-left,+{2}+3/3,~3'
+  )
+
+  [[ -z "$selections" ]] && return 0
+
+  local -a args
+  local file line
+  while IFS=: read -r file line _; do
+    [[ -z "$file" ]] && continue
+    args+=("+${line}" "$file")
+  done <<< "$selections"
+
+  (( ${#args[@]} > 0 )) && ${EDITOR:-nvim} -p "${args[@]}"
+}
+
+# Alt+R: launch rgn from anywhere on the command line
+_rgn_widget() {
+  BUFFER='rgn'
+  zle accept-line
+}
+zle -N _rgn_widget
+bindkey '^[r' _rgn_widget
 
 # =============================================================================
 # Devbox wrapper - auto re-add to chezmoi after global changes


### PR DESCRIPTION
## 概要

- `rgn` コマンドを追加: ripgrep → fzf（ライブリロード）→ nvim パイプライン
- `Alt+R` zle widget で任意のコマンドライン位置から即起動
- ghostty に `macos-option-as-alt = left` を追加し、左 Option キーを Alt として有効化

## 変更内容

### `dot_config/zsh/split/functions.zsh`
- `rgn` 関数: タイプごとに rg を再実行（`--disabled` + `change:reload`）、Tab でマルチセレクト → `nvim -p` で各マッチ行を開く
- `_rgn_widget` / `bindkey '^[r'`: `Alt+R` で即起動
- `dots` ヘルプに `Alt+r` / `rgn` エントリを追記

### `dot_config/ghostty/config`
- `macos-option-as-alt = left`: 左 Option → Alt（`Alt+R`, `Alt+C` などが有効に）
- 右 Option は引き続き macOS 特殊文字入力（`®`, `™` など）に使用可能

## 使い方

| 操作 | 挙動 |
|---|---|
| `rgn` | 空で起動、タイプするたびに live rg |
| `rgn foo` | `foo` を初期クエリに |
| `Alt+R` | 任意コマンドライン位置から起動 |
| `Tab` | マッチを複数選択 |
| `Enter` | `nvim -p` で各マッチ行を開く |
| `Alt+/` | プレビュー ON/OFF |

## 反映手順

```sh
chezmoi apply
# ghostty を完全再起動 (Cmd+Q)
exec zsh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)