### PR TITLE
feat(git): rewrite GitHub HTTPS URLs to SSH in work config

### DIFF
--- a/dot_config/git/work.tmpl
+++ b/dot_config/git/work.tmpl
@@ -4,4 +4,6 @@
   useConfigOnly = true
 [core]
   hooksPath = {{ .chezmoi.homeDir }}/.fdev-git-hooks
+[url "git@github.com:"]
+  insteadOf = https://github.com/
 {{- end }}


### PR DESCRIPTION
## 変更内容

会社環境では SSL Inspection プロキシが HTTPS 通信を復号・検査するため、
GitHub への HTTPS 接続で証明書検証エラーが発生する。

 を設定することで、`https://github.com/` を自動的に
`git@github.com:` へ書き換え、SSH プロトコルで接続するようにした。

## 影響範囲

- `business_use=true` の環境のみ適用（個人マシンには影響なし）
- 既存のリポジトリの remote URL を変更せずとも自動的に SSH が使われる