### PR TITLE
docs(claude): add worktree location rule and gh-pr-body rule

### DIFF
--- a/dot_claude/rules/gh-pr-body.md
+++ b/dot_claude/rules/gh-pr-body.md
@@ -1,0 +1,32 @@
+---
+alwaysApply: true
+---
+
+# `gh pr` body: never backslash-escape backticks
+
+## Rule
+
+- Single-quoted heredocs (`<<'EOF' ... EOF`) perform **no** interpolation. Backslashes are literal. Never "protect" a backtick by writing it as backslash-backtick inside one — the backslash persists into the saved Markdown.
+- For any PR body containing code fences, mermaid blocks, or otherwise backtick-heavy Markdown: write the body to a file with the `Write` tool, then pass it as `gh pr edit --body-file <path>` (or `gh pr create --body-file`). `Write` bypasses shell quoting entirely, which removes the entire failure mode.
+- After any `gh pr create` / `gh pr edit`, verify the result by fetching the body back and inspecting code-fence lines. Any fence line with a leading backslash means the body is broken — strip the backslashes from the local file and re-push with `--body-file`.
+
+Verification snippet:
+
+```sh
+gh pr view <N> --repo <owner>/<repo> --json body -q '.body' \
+  | awk '/^\\`/ {print NR": "$0}'
+```
+
+(A fence line starting with a literal backslash is the bug signature.)
+
+## Why
+
+`<<'EOF'` is intentionally non-interpolating. Escaping backticks "to be safe" is the exact failure mode: the shell leaves the backslash in place, and GitHub then renders `backslash-backslash-backslash-mermaid` as literal text instead of opening a code fence. This has broken mermaid diagrams in real PRs (paveg/gontainer #2) more than once. The reactive fix is always the same strip-and-re-push, so the preventive discipline is to stop emitting the backslashes in the first place.
+
+## How to apply
+
+Whenever constructing a PR body with non-trivial Markdown:
+
+1. Default path — `Write` the body to a scratch file (e.g. `/tmp/pr_body.md`), then `gh pr edit N --body-file /tmp/pr_body.md`.
+2. Only use inline heredoc bodies for plain prose with no code fences at all.
+3. Always re-fetch the body and eyeball the first code-fence line after editing.

--- a/dot_claude/rules/workflow.md
+++ b/dot_claude/rules/workflow.md
@@ -29,6 +29,17 @@ alwaysApply: true
 - After implementation, dispatch separate review subagents: spec compliance, then code quality
 - **Push and PR creation require explicit user confirmation**
 
+### Worktree Location
+
+- When creating worktrees manually (sequential subagent dispatch in a shared worktree),
+  always use **`<project-root>/.claude/worktrees/<branch-name>`**
+- NOT `~/.claude/worktrees/` (user-global) and NOT sibling-of-repo paths (`../foo-branch`)
+- Add `.claude/worktrees/` to the project's `.gitignore` if not already excluded
+- Rationale: keeps worktrees scoped to the project, avoids cross-project name collisions,
+  and makes cleanup obvious (delete with the project, not orphaned in a global cache)
+- The Agent tool's `isolation: "worktree"` parameter handles its own worktree placement
+  automatically — this rule applies to manually-created worktrees only
+
 ### Stay in main process for
 
 - Brainstorming, spec clarification, architecture decisions


### PR DESCRIPTION
## Summary
- Add `Worktree Location` guidance in `dot_claude/rules/workflow.md` — require `<project-root>/.claude/worktrees/<branch>` for manually created worktrees, with an explicit note that the `Agent` tool's `isolation: "worktree"` parameter is unaffected
- Add new `dot_claude/rules/gh-pr-body.md` rule for GitHub PR body conventions

## Test plan
- [ ] CI passes (fmt, lint, chezmoi dry-run on macOS + Linux, Neovim startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)