### PR TITLE
feat(claude): situational rule loading + mermaid rule

### DIFF
--- a/dot_claude/hooks/executable_chezmoi-inject.sh
+++ b/dot_claude/hooks/executable_chezmoi-inject.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# PreToolUse(Write|Edit) hook: inject ~/.claude/rules/chezmoi.md as
+# additionalContext when file_path is under ~/.local/share/chezmoi/.
+# Reads Claude Code hook JSON from stdin; emits JSON on stdout.
+set -euo pipefail
+
+rule="$HOME/.claude/rules/chezmoi.md"
+
+path=$(jq -r '.tool_input.file_path // ""')
+
+case "$path" in
+  */.local/share/chezmoi/*) ;;
+  *) exit 0 ;;
+esac
+
+[[ -f $rule ]] || exit 0
+
+jq -n --rawfile body "$rule" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    additionalContext: $body
+  }
+}'

--- a/dot_claude/hooks/executable_gh-pr-inject.sh
+++ b/dot_claude/hooks/executable_gh-pr-inject.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook: inject ~/.claude/rules/gh-pr-body.md as
+# additionalContext when the command contains `gh pr create` or `gh pr edit`.
+# Reads Claude Code hook JSON from stdin; emits JSON on stdout.
+set -euo pipefail
+
+rule="$HOME/.claude/rules/gh-pr-body.md"
+
+cmd=$(jq -r '.tool_input.command // ""')
+
+if ! printf '%s' "$cmd" | grep -qE '\bgh pr (create|edit)\b'; then
+  exit 0
+fi
+
+[[ -f $rule ]] || exit 0
+
+jq -n --rawfile body "$rule" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    additionalContext: $body
+  }
+}'

--- a/dot_claude/rules/chezmoi.md
+++ b/dot_claude/rules/chezmoi.md
@@ -1,5 +1,5 @@
 ---
-alwaysApply: true
+alwaysApply: false
 ---
 
 # chezmoi

--- a/dot_claude/rules/gh-pr-body.md
+++ b/dot_claude/rules/gh-pr-body.md
@@ -1,5 +1,5 @@
 ---
-alwaysApply: true
+alwaysApply: false
 ---
 
 # `gh pr` body: never backslash-escape backticks
@@ -23,9 +23,13 @@ gh pr view <N> --repo <owner>/<repo> --json body -q '.body' \
 
 `<<'EOF'` is intentionally non-interpolating. Escaping backticks "to be safe" is the exact failure mode: the shell leaves the backslash in place, and GitHub then renders `backslash-backslash-backslash-mermaid` as literal text instead of opening a code fence. This has broken mermaid diagrams in real PRs (paveg/gontainer #2) more than once. The reactive fix is always the same strip-and-re-push, so the preventive discipline is to stop emitting the backslashes in the first place.
 
+## When to include mermaid
+
+For PRs touching architecture, flows, state, or cross-system interactions: embed a mermaid diagram in the body. A diagram up front makes review faster than bulleted prose. Structural refactors should show before/after side-by-side. Diagram type by use case: see `mermaid-diagrams.md`.
+
 ## How to apply
 
-Whenever constructing a PR body with non-trivial Markdown:
+Whenever constructing a PR body with non-trivial Markdown (mermaid, code fences, nested backticks):
 
 1. Default path — `Write` the body to a scratch file (e.g. `/tmp/pr_body.md`), then `gh pr edit N --body-file /tmp/pr_body.md`.
 2. Only use inline heredoc bodies for plain prose with no code fences at all.

--- a/dot_claude/rules/mermaid-diagrams.md
+++ b/dot_claude/rules/mermaid-diagrams.md
@@ -1,0 +1,32 @@
+---
+alwaysApply: true
+---
+
+# Mermaid Diagrams
+
+Actively use mermaid when explaining architecture, flow, sequences, or state. A small diagram beats a paragraph of prose.
+
+## Reach for mermaid in
+
+- Design / brainstorming responses — align on shape before implementation
+- PR bodies describing structural or cross-system changes
+- ADRs and technical docs
+
+## Type by use case
+
+| Use case | Syntax |
+|----------|--------|
+| Architecture / dependency | `graph TD` |
+| API / cross-system calls | `sequenceDiagram` |
+| State machines, lifecycles | `stateDiagram-v2` |
+| Data flow / pipeline | `flowchart LR` |
+| Schemas / relations | `erDiagram` |
+
+## Rules
+
+- ≤ ~10 nodes per diagram; split larger into multiple
+- Concrete node labels (`UserService`, not `ServiceA`)
+- Show before/after side-by-side for structural refactors
+- Prefer `LR` for pipelines, `TD` for hierarchies
+
+For embedding in PR bodies safely (backslash-escape pitfall), see `gh-pr-body.md`.

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "c=$(jq -r '.tool_input.command // \"\"'); echo \"$c\" | grep -qE '\\bgh pr (create|edit)\\b' && jq -n --rawfile a \"$HOME/.claude/rules/gh-pr-body.md\" '{hookSpecificOutput:({hookEventName:\"PreToolUse\",additionalContext:$a})}' 2>/dev/null || true"
+            "command": "$HOME/.claude/hooks/gh-pr-inject.sh"
           }
         ]
       },
@@ -109,7 +109,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "p=$(jq -r '.tool_input.file_path // \"\"'); echo \"$p\" | grep -q '/\\.local/share/chezmoi/' && jq -n --rawfile a \"$HOME/.claude/rules/chezmoi.md\" '{hookSpecificOutput:({hookEventName:\"PreToolUse\",additionalContext:$a})}' 2>/dev/null || true"
+            "command": "$HOME/.claude/hooks/chezmoi-inject.sh"
           }
         ]
       }

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -72,7 +72,8 @@
     "code-simplifier@claude-plugins-official": true,
     "ralph-loop@claude-plugins-official": true,
     "swift-lsp@claude-plugins-official": false,
-    "superpowers@claude-plugins-official": true
+    "superpowers@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": true
 {{- end }}
   },
 {{- if not .business_use }}
@@ -87,5 +88,31 @@
   "skipDangerousModePermissionPrompt": true,
 {{- end }}
   "alwaysThinkingEnabled": true,
-  "language": "Follow the user's input language. Prioritize accuracy. Think step-by-step. Do not guess—ask or investigate when uncertain."
+  "language": "Follow the user's input language. Prioritize accuracy. Think step-by-step. Do not guess—ask or investigate when uncertain.",
+  "claudeMdExcludes": [
+    "**/.claude/rules/gh-pr-body.md",
+    "**/.claude/rules/chezmoi.md"
+  ],
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "c=$(jq -r '.tool_input.command // \"\"'); echo \"$c\" | grep -qE '\\bgh pr (create|edit)\\b' && jq -n --rawfile a \"$HOME/.claude/rules/gh-pr-body.md\" '{hookSpecificOutput:({hookEventName:\"PreToolUse\",additionalContext:$a})}' 2>/dev/null || true"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "p=$(jq -r '.tool_input.file_path // \"\"'); echo \"$p\" | grep -q '/\\.local/share/chezmoi/' && jq -n --rawfile a \"$HOME/.claude/rules/chezmoi.md\" '{hookSpecificOutput:({hookEventName:\"PreToolUse\",additionalContext:$a})}' 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #123. Introduces:

1. **Situational rule loading** — `gh-pr-body.md` and `chezmoi.md` leave always-loaded context and inject only when their trigger fires
2. **`rules/mermaid-diagrams.md`** (new) — actively use mermaid for architecture / flow / sequence / state diagrams in design and PR bodies
3. Cross-link from `rules/gh-pr-body.md` via a new "When to include mermaid" section

### Infrastructure

- **`settings.json.tmpl: claudeMdExcludes`** — exclude `gh-pr-body.md` and `chezmoi.md` from always-loaded context
- **`settings.json.tmpl: hooks.PreToolUse`** — inject those rules only on their trigger:
  - Bash matching `gh pr (create|edit)` → inject `gh-pr-body.md`
  - Write/Edit on path under `~/.local/share/chezmoi/` → inject `chezmoi.md`
- **`dot_claude/hooks/*.sh`** — hook logic in standalone bash scripts (shebang, `set -euo pipefail`, comments) instead of JSON-embedded shell. `settings.json` just references the script paths

### Template cleanup

- `settings.json.tmpl` — add `gopls-lsp` to `enabledPlugins` (drifted into applied config but missing from template)

### Rule frontmatter

- `rules/chezmoi.md`, `rules/gh-pr-body.md` — `alwaysApply: false` reflecting their excluded status

## Architecture

```mermaid
flowchart LR
  Session[Claude Code session]
  Settings[~/.claude/settings.json]
  GhPrHook[gh-pr-inject.sh]
  ChezmoiHook[chezmoi-inject.sh]
  GhPrRule[rules/gh-pr-body.md]
  ChezmoiRule[rules/chezmoi.md]

  Session -->|PreToolUse Bash| GhPrHook
  Session -->|PreToolUse Write/Edit| ChezmoiHook
  Settings -. configures .-> GhPrHook
  Settings -. configures .-> ChezmoiHook
  GhPrHook -->|matches gh pr create/edit| GhPrRule
  ChezmoiHook -->|path under ~/.local/share/chezmoi/| ChezmoiRule
```

## Verification

- Both hook scripts pipe-tested standalone (match / no-match / chained-command cases)
- Hooks fired live during authoring: chezmoi rule injection on Write/Edit of chezmoi files, gh-pr-body injection on Bash containing `gh pr create`
- `jq -e` validated final `settings.json` shape

## Test plan

- [ ] CI passes (fmt, lint, chezmoi dry-run on darwin + linux, personal + business modes)
- [ ] After merge + session restart: `gh-pr-body.md` and `chezmoi.md` absent from always-loaded context
- [ ] `gh pr create` in a new session triggers the Bash hook and injects `gh-pr-body.md`
- [ ] Editing a file under `~/.local/share/chezmoi/` triggers the Write/Edit hook and injects `chezmoi.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
