### PR TITLE
feat(claude): update settings permissions allow/deny list

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -1,7 +1,10 @@
 {
   "permissions": {
     "allow": [
-      "Bash(gog gmail settings filters:*)"
+      "Bash(mysql:*)",
+      "Bash(gh*)",
+      "Bash(go*)",
+      "Bash(git worktree*)"
     ],
     "deny": [
       "Bash(sudo:*)",
@@ -23,11 +26,12 @@
       "Bash(wget:*)",
       "Bash(nc:*)",
       "Bash(psql:*)",
-      "Bash(mysql:*)",
       "Bash(mongod:*)",
       "Read(**/.env)",
       "Read(**/.env.*)",
       "Read(**/.dev.vars)",
+      "Read(**/.envrc)",
+      "Read(**/.envrc.*)",
       "Read(id_rsa)",
       "Read(id_ed25519)",
       "Read(**/*token*)",


### PR DESCRIPTION
## 変更内容

`dot_claude/settings.json.tmpl` の permissions を更新。

### allow に追加
- `Bash(mysql:*)` — DB 操作
- `Bash(gh*)` — GitHub CLI
- `Bash(go*)` — Go ツールチェーン
- `Bash(git worktree*)` — worktree 操作（subagent ワークフロー用）

### deny に追加
- `Read(**/.envrc)` / `Read(**/.envrc.*)` — direnv 設定ファイルの読み取り制限

### 削除
- `Bash(gog gmail settings filters:*)` — allow から削除
- `Bash(mysql:*)` — deny から削除（allow へ移動）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)