### PR TITLE
feat(zsh): add atc-* helpers for AtCoder workflow

### DIFF
--- a/.chezmoiscripts/run_once_after_configure-atcoder-cli.sh
+++ b/.chezmoiscripts/run_once_after_configure-atcoder-cli.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Configure atcoder-cli (acc) defaults after install.
+# Template files live in ~/.config/atcoder-cli-nodejs/go/ (chezmoi-managed).
+# Runs once per machine.
+
+set -euo pipefail
+
+if ! command -v acc >/dev/null 2>&1; then
+  echo "acc not found — skipping acc config" >&2
+  exit 0
+fi
+
+acc config default-template go
+acc config default-task-choice all

--- a/.chezmoiscripts/run_once_after_create-atcoder-workspace.sh
+++ b/.chezmoiscripts/run_once_after_create-atcoder-workspace.sh
@@ -14,7 +14,7 @@ mkdir -p "$dir"
 cd "$dir"
 git init -q -b main
 
-cat > .gitignore <<'EOF'
+cat >.gitignore <<'EOF'
 # Build artifacts
 *.out
 *.exe

--- a/.chezmoiscripts/run_once_after_create-atcoder-workspace.sh
+++ b/.chezmoiscripts/run_once_after_create-atcoder-workspace.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Bootstrap ~/repos/paveg/atcoder as an empty git repo for AtCoder solutions.
+# Runs once per machine.
+
+set -euo pipefail
+
+dir="$HOME/repos/paveg/atcoder"
+
+if [[ -d "$dir/.git" ]]; then
+  exit 0
+fi
+
+mkdir -p "$dir"
+cd "$dir"
+git init -q -b main
+
+cat > .gitignore <<'EOF'
+# Build artifacts
+*.out
+*.exe
+
+# Editor
+.vscode/
+.idea/
+
+# acc test cases (problem statements are copyrighted by AtCoder)
+**/tests/
+EOF
+
+echo "Initialized empty AtCoder workspace at $dir"

--- a/.chezmoiscripts/run_once_after_create-atcoder-workspace.sh
+++ b/.chezmoiscripts/run_once_after_create-atcoder-workspace.sh
@@ -7,15 +7,12 @@ set -euo pipefail
 
 dir="$HOME/repos/github.com/paveg/atcoder"
 
-if [[ -d "$dir/.git" ]]; then
-  exit 0
-fi
-
 mkdir -p "$dir"
 cd "$dir"
-git init -q -b main
 
-cat >.gitignore <<'EOF'
+if [[ ! -d ".git" ]]; then
+  git init -q -b main
+  cat >.gitignore <<'EOF'
 # Build artifacts
 *.out
 *.exe
@@ -27,5 +24,10 @@ cat >.gitignore <<'EOF'
 # acc test cases (problem statements are copyrighted by AtCoder)
 **/tests/
 EOF
+fi
 
-echo "Initialized empty AtCoder workspace at $dir"
+if [[ ! -f "go.mod" ]] && command -v go >/dev/null 2>&1; then
+  go mod init github.com/paveg/atcoder >/dev/null
+fi
+
+echo "AtCoder workspace ready at $dir"

--- a/.chezmoiscripts/run_once_after_create-atcoder-workspace.sh
+++ b/.chezmoiscripts/run_once_after_create-atcoder-workspace.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-# Bootstrap ~/repos/paveg/atcoder as an empty git repo for AtCoder solutions.
-# Runs once per machine.
+# Bootstrap ~/repos/github.com/paveg/atcoder as an empty git repo for AtCoder
+# solutions. Uses the <host>/<owner>/<repo> layout shared by other repos in
+# ~/repos/. Runs once per machine.
 
 set -euo pipefail
 
-dir="$HOME/repos/paveg/atcoder"
+dir="$HOME/repos/github.com/paveg/atcoder"
 
 if [[ -d "$dir/.git" ]]; then
   exit 0

--- a/.chezmoiscripts/run_onchange_after_install-atcoder-tools.sh
+++ b/.chezmoiscripts/run_onchange_after_install-atcoder-tools.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Install AtCoder CLI tooling:
+#   - atcoder-cli (acc): npm pkg, installed via pnpm (no nix equivalent)
+#   - online-judge-tools (oj): installed via uv with Selenium in the same
+#     isolated env. AtCoder's login page has JS/captcha checks that oj's CUI
+#     login cannot pass, so Selenium (browser-driven) is required. The nix
+#     version cannot be augmented with Selenium, hence uv.
+#
+# Triggered on chezmoi apply when this script changes.
+
+set -euo pipefail
+
+# atcoder-cli via pnpm
+if command -v acc >/dev/null 2>&1; then
+  :
+elif command -v pnpm >/dev/null 2>&1; then
+  echo "Installing atcoder-cli via pnpm..."
+  pnpm add -g atcoder-cli
+else
+  echo "pnpm not found — skipping acc install" >&2
+fi
+
+# online-judge-tools + selenium via uv
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv not found — skipping oj install" >&2
+  exit 0
+fi
+
+if uv tool list 2>/dev/null | grep -qE '^online-judge-tools\b'; then
+  # Already installed; ensure selenium is present in its env
+  uv tool install --with selenium --with setuptools --force online-judge-tools >/dev/null
+else
+  echo "Installing online-judge-tools with selenium via uv..."
+  uv tool install --with selenium --with setuptools online-judge-tools
+fi

--- a/.chezmoiscripts/run_onchange_after_install-mermaid-ascii.sh
+++ b/.chezmoiscripts/run_onchange_after_install-mermaid-ascii.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Install mermaid-ascii for Claude Code Stop hook rendering.
+# Binary lands in $GOPATH/bin (default $HOME/go/bin), used by
+# ~/.claude/hooks/mermaid-render.sh to turn fenced ```mermaid blocks
+# into ASCII art after each assistant response.
+#
+# Triggered on chezmoi apply when this script changes.
+
+set -euo pipefail
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "go not found — skipping mermaid-ascii install" >&2
+  exit 0
+fi
+
+echo "Installing mermaid-ascii via go install..."
+go install github.com/AlexanderGrooff/mermaid-ascii@latest

--- a/dot_claude/hooks/executable_mermaid-render.sh
+++ b/dot_claude/hooks/executable_mermaid-render.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Stop hook: render mermaid code blocks from the last assistant message as
+# ASCII art via mermaid-ascii. Only supported diagram types (graph/flowchart/
+# sequenceDiagram) are rendered; unsupported types are silently skipped so
+# the assistant response is never disrupted.
+#
+# Input: Claude Code hook JSON on stdin (uses .transcript_path).
+# Output: ASCII-rendered diagrams to stdout, shown after the response.
+set -euo pipefail
+
+# Skip interactive invocation (no piped stdin).
+[[ -t 0 ]] && exit 0
+
+# Locate mermaid-ascii. Hook PATH may not include $GOPATH/bin.
+if command -v mermaid-ascii >/dev/null 2>&1; then
+  mmd_bin="mermaid-ascii"
+elif [[ -x "$HOME/go/bin/mermaid-ascii" ]]; then
+  mmd_bin="$HOME/go/bin/mermaid-ascii"
+else
+  exit 0
+fi
+
+input=$(cat)
+transcript=$(printf '%s' "$input" | jq -r '.transcript_path // empty' 2>/dev/null || true)
+[[ -n $transcript && -f $transcript ]] || exit 0
+
+# Extract the last assistant message's concatenated text content.
+last_text=$(jq -rs '
+  [.[] | select(.type == "assistant" and (.message.content | type) == "array")]
+  | last
+  | (.message.content // [])
+  | map(select(.type == "text") | .text)
+  | join("\n")
+' "$transcript" 2>/dev/null || true)
+
+[[ -n $last_text ]] || exit 0
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Split mermaid fenced blocks into individual files.
+printf '%s\n' "$last_text" | awk -v d="$tmpdir" '
+  /^```mermaid[[:space:]]*$/ { n++; in_block=1; path=d "/block-" n ".mmd"; next }
+  /^```[[:space:]]*$/ && in_block { in_block=0; close(path); next }
+  in_block { print > path }
+'
+
+shopt -s nullglob
+blocks=("$tmpdir"/block-*.mmd)
+(( ${#blocks[@]} > 0 )) || exit 0
+
+# Allowlist: mermaid-ascii supports only these diagram headers.
+supported=()
+for b in "${blocks[@]}"; do
+  first=$(awk 'NF { print; exit }' "$b")
+  case "$first" in
+    graph\ *|flowchart\ *|sequenceDiagram*) supported+=("$b") ;;
+  esac
+done
+
+(( ${#supported[@]} > 0 )) || exit 0
+
+total=${#supported[@]}
+for ((i=0; i<total; i++)); do
+  printf '\n─── mermaid (%d/%d) ───\n' "$((i+1))" "$total"
+  "$mmd_bin" -f "${supported[$i]}" 2>/dev/null || printf '(render failed)\n'
+done

--- a/dot_claude/rules/mermaid-diagrams.md
+++ b/dot_claude/rules/mermaid-diagrams.md
@@ -29,4 +29,12 @@ Actively use mermaid when explaining architecture, flow, sequences, or state. A 
 - Show before/after side-by-side for structural refactors
 - Prefer `LR` for pipelines, `TD` for hierarchies
 
+## Terminal rendering constraints (mermaid-ascii)
+
+A Stop hook auto-renders ```` ```mermaid ```` blocks as ASCII in my terminal via [mermaid-ascii](https://github.com/AlexanderGrooff/mermaid-ascii). To keep renders clean, author diagrams within its limits:
+
+- **Decision nodes:** use `[label]` not `{label}` — curly-brace diamonds break silently (label appears as a separate node)
+- **Supported types:** `graph TD/TB/LR`, `flowchart TD/TB/LR`, `sequenceDiagram` — rendered inline
+- **Unsupported types:** `stateDiagram-v2`, `erDiagram`, and others — the raw mermaid source is still shown; switch to `graph TD` if visualization matters, otherwise accept the raw text
+
 For embedding in PR bodies safely (backslash-escape pitfall), see `gh-pr-body.md`.

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -117,6 +117,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/mermaid-render.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/dot_config/zsh/split/functions.zsh
+++ b/dot_config/zsh/split/functions.zsh
@@ -665,3 +665,35 @@ wt() {
     *)    _wt_cd "$@" ;;
   esac
 }
+
+# =============================================================================
+# AtCoder login via 1Password
+# =============================================================================
+# Fetches credentials from the AtCoder item in Personal vault and runs oj login.
+# Uses field id (not label) to disambiguate duplicate-labeled fields created by
+# 1Password's web form autofill. Session cookie is stored under
+# ~/Library/Application Support/online-judge-tools/, so re-login is only needed
+# after cookie expiry.
+atcoder-login() {
+  if ! command -v op >/dev/null 2>&1; then
+    echo "Error: op (1Password CLI) not found" >&2
+    return 1
+  fi
+  if ! command -v oj >/dev/null 2>&1; then
+    echo "Error: oj (online-judge-tools) not found — run 'devbox install'" >&2
+    return 1
+  fi
+
+  local item='tcrb5hlxmncj3d45ttchkx6y5y'
+  local json user pass
+  json=$(op item get "$item" --format json --reveal) || return 1
+  user=$(echo "$json" | jq -r '.fields[] | select(.id == "username") | .value')
+  pass=$(echo "$json" | jq -r '.fields[] | select(.id == "password") | .value')
+
+  if [[ -z "$user" || -z "$pass" ]]; then
+    echo "Error: failed to extract credentials (id='username'/'password' not found)" >&2
+    return 1
+  fi
+
+  oj login https://atcoder.jp/ -u "$user" -p "$pass"
+}

--- a/dot_config/zsh/split/functions.zsh
+++ b/dot_config/zsh/split/functions.zsh
@@ -669,11 +669,19 @@ wt() {
 # =============================================================================
 # AtCoder login via 1Password
 # =============================================================================
-# Fetches credentials from the AtCoder item in Personal vault and runs oj login.
+# Fetches credentials from the AtCoder item in Personal vault and runs oj login,
+# then propagates the REVEL_SESSION cookie to acc (atcoder-cli) so both tools
+# share authentication. oj and acc authenticate against the same AtCoder domain
+# but use different session stores, and acc's `login` command requires an
+# interactive inquirer prompt, so sharing oj's freshly-minted cookie is the
+# cleanest automation path.
+#
 # Uses field id (not label) to disambiguate duplicate-labeled fields created by
-# 1Password's web form autofill. Session cookie is stored under
-# ~/Library/Application Support/online-judge-tools/, so re-login is only needed
-# after cookie expiry.
+# 1Password's web form autofill. Session cookies are written under:
+#   oj:  ~/Library/Application Support/online-judge-tools/cookie.jar  (macOS)
+#        $XDG_CONFIG_HOME/online-judge-tools/cookie.jar               (Linux)
+#   acc: ~/Library/Preferences/atcoder-cli-nodejs/session.json        (macOS)
+#        $XDG_CONFIG_HOME/atcoder-cli-nodejs/session.json             (Linux)
 atcoder-login() {
   if ! command -v op >/dev/null 2>&1; then
     echo "Error: op (1Password CLI) not found" >&2
@@ -695,5 +703,29 @@ atcoder-login() {
     return 1
   fi
 
-  oj login https://atcoder.jp/ -u "$user" -p "$pass"
+  oj login https://atcoder.jp/ -u "$user" -p "$pass" || return 1
+
+  # Sync REVEL_SESSION to acc so `acc session` reports logged-in.
+  if command -v acc >/dev/null 2>&1; then
+    local oj_jar acc_conf_dir session
+    if [[ "$OSTYPE" == linux* ]]; then
+      oj_jar="${XDG_CONFIG_HOME:-$HOME/.config}/online-judge-tools/cookie.jar"
+      acc_conf_dir="${XDG_CONFIG_HOME:-$HOME/.config}/atcoder-cli-nodejs"
+    else
+      oj_jar="$HOME/Library/Application Support/online-judge-tools/cookie.jar"
+      acc_conf_dir="$HOME/Library/Preferences/atcoder-cli-nodejs"
+    fi
+
+    if [[ -f "$oj_jar" ]]; then
+      session=$(sed -nE 's/^Set-Cookie3: REVEL_SESSION="([^"]+)".*$/\1/p' "$oj_jar" | head -1)
+      if [[ -n "$session" ]]; then
+        mkdir -p "$acc_conf_dir"
+        jq -n --arg s "$session" '{cookies: ["REVEL_FLASH=", "REVEL_SESSION=" + $s]}' \
+          >"$acc_conf_dir/session.json"
+        echo "Synced REVEL_SESSION to acc"
+      else
+        echo "Warning: REVEL_SESSION not found in $oj_jar — acc session not updated" >&2
+      fi
+    fi
+  fi
 }

--- a/dot_config/zsh/split/functions.zsh
+++ b/dot_config/zsh/split/functions.zsh
@@ -729,3 +729,50 @@ atcoder-login() {
     fi
   fi
 }
+
+# Open the current AtCoder task's problem page in the browser.
+# Run from a task directory (e.g., ~/repos/github.com/paveg/atcoder/abc321/a).
+# Derives URL from the directory hierarchy: <contest>/<task>.
+atc-open() {
+  local task contest
+  task=$(basename "$PWD")
+  contest=$(basename "$(dirname "$PWD")")
+  open "https://atcoder.jp/contests/${contest}/tasks/${contest}_${task}"
+}
+
+# Open the contest's task list page in the browser.
+# If run from a task directory, uses the parent (contest) name.
+# If run from a contest directory, uses the cwd name.
+atc-top() {
+  local contest
+  # Heuristic: if cwd contains tests/ or main.go, treat as task dir → use parent
+  if [[ -d tests || -f main.go ]]; then
+    contest=$(basename "$(dirname "$PWD")")
+  else
+    contest=$(basename "$PWD")
+  fi
+  open "https://atcoder.jp/contests/${contest}/tasks"
+}
+
+# Build main.go and run sample tests.
+# acc writes samples to tests/ (plural), oj defaults to test/ (singular) — both
+# are supported. Additional args pass through to oj t (e.g., --print-input).
+atc-test() {
+  go build -o a.out main.go || return 1
+  local dir
+  if [[ -d tests ]]; then
+    dir=tests
+  elif [[ -d test ]]; then
+    dir=test
+  else
+    echo "No tests/ or test/ directory found" >&2
+    return 1
+  fi
+  oj t -d "$dir" "$@"
+}
+
+# Submit the current task's main.go to AtCoder via acc.
+# Interactive confirmation by default; pass --force-submit to skip.
+atc-submit() {
+  acc submit -- "$@"
+}


### PR DESCRIPTION
## Summary
- Add `atc-open` / `atc-top` to open the current task or contest page in the browser, derived from the cwd hierarchy
- Add `atc-test` to build `main.go` and run samples, auto-detecting `tests/` (acc) or `test/` (oj)
- Add `atc-submit` as a thin wrapper around `acc submit --`

## Test plan
- [ ] `source ~/.config/zsh/split/functions.zsh` and confirm the new functions are defined
- [ ] From a task directory (`.../<contest>/<task>`), run `atc-open` and verify the correct URL opens
- [ ] From a task directory, run `atc-top` and verify it opens the parent contest's task list
- [ ] From a contest directory, run `atc-top` and verify it uses the cwd name
- [ ] With samples under `tests/`, run `atc-test` and verify `oj t -d tests` executes
- [ ] With samples under `test/`, run `atc-test` and verify `oj t -d test` executes
- [ ] Run `atc-submit` and confirm `acc submit --` is invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)