### PR TITLE
feat(atcoder): add Go language template and macOS config symlink

### DIFF
--- a/Library/Preferences/symlink_atcoder-cli-nodejs
+++ b/Library/Preferences/symlink_atcoder-cli-nodejs
@@ -1,0 +1,1 @@
+../../.config/atcoder-cli-nodejs

--- a/dot_config/atcoder-cli-nodejs/go/main.go
+++ b/dot_config/atcoder-cli-nodejs/go/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+var (
+	sc = bufio.NewScanner(os.Stdin)
+	wr = bufio.NewWriter(os.Stdout)
+)
+
+func init() {
+	sc.Buffer(make([]byte, 1024*1024), 1024*1024*1024)
+	sc.Split(bufio.ScanWords)
+}
+
+func nextStr() string { sc.Scan(); return sc.Text() }
+func nextInt() int    { n, _ := strconv.Atoi(nextStr()); return n }
+
+func main() {
+	defer func() {
+		_ = wr.Flush()
+	}()
+
+	n := nextInt()
+	_, _ = fmt.Fprintln(wr, n)
+}

--- a/dot_config/atcoder-cli-nodejs/go/template.json
+++ b/dot_config/atcoder-cli-nodejs/go/template.json
@@ -1,0 +1,6 @@
+{
+  "task": {
+    "program": ["main.go"],
+    "submit": "main.go"
+  }
+}


### PR DESCRIPTION
## Summary
- Add Go template for `acc` (atcoder-cli-nodejs) under `dot_config/atcoder-cli-nodejs/go/` with a competitive-programming I/O skeleton (bufio scanner + writer, `nextStr` / `nextInt` helpers, 1 GiB buffer to avoid scanner overflow on large inputs).
- Add chezmoi `symlink_` entry at `Library/Preferences/symlink_atcoder-cli-nodejs` pointing to `../../.config/atcoder-cli-nodejs`, unifying the macOS (`~/Library/Preferences/`) and Linux (`~/.config/`) config locations used by the `conf` package.
- Register `main.go` as both the program and submit file via `template.json`.

## Test plan
- [ ] `just apply` on macOS creates the symlink at `~/Library/Preferences/atcoder-cli-nodejs` and the config files at `~/.config/atcoder-cli-nodejs/go/`.
- [ ] `acc new <contest> --template go` scaffolds a task directory containing `main.go`.
- [ ] `acc submit` uses `main.go` as the submit target.
- [ ] `go run main.go` compiles cleanly against a sample input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)