### PR TITLE
refactor(claude): reorganize rules + consolidate inject hooks

### DIFF
--- a/dot_claude/hooks/executable_browser-inject.sh
+++ b/dot_claude/hooks/executable_browser-inject.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# PreToolUse(Write|Edit) hook: inject ~/.claude/rules/chezmoi.md as
-# additionalContext when file_path is under ~/.local/share/chezmoi/.
+# PreToolUse hook: inject ~/.claude/rules/browser-automation.md as
+# additionalContext when invoking any mcp__claude-in-chrome__* tool.
 # Reads Claude Code hook JSON from stdin; emits JSON on stdout.
 set -euo pipefail
 
-rule="$HOME/.claude/rules/chezmoi.md"
+rule="$HOME/.claude/rules/browser-automation.md"
 
-path=$(jq -r '.tool_input.file_path // ""')
+tool=$(jq -r '.tool_name // ""')
 
-case "$path" in
-  */.local/share/chezmoi/*) ;;
+case "$tool" in
+  mcp__claude-in-chrome__*) ;;
   *) exit 0 ;;
 esac
 

--- a/dot_claude/hooks/executable_rules-inject.sh
+++ b/dot_claude/hooks/executable_rules-inject.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# PreToolUse(Write|Edit) hook: inject path-relevant rule files into
+# additionalContext as a single dispatcher. Spawns one bash + one jq per
+# edit regardless of how many rules match (vs N processes for N hooks).
+#
+# Add a new rule by appending a case statement and a rule filename — no
+# new hook script, no new settings.json entry.
+#
+# Reads Claude Code hook JSON from stdin; emits JSON on stdout.
+set -euo pipefail
+
+rules_dir="$HOME/.claude/rules"
+
+path=$(jq -r '.tool_input.file_path // ""')
+[[ -n $path ]] || exit 0
+
+rules=()
+
+# chezmoi: any file under the chezmoi source tree
+case "$path" in
+  */.local/share/chezmoi/*) rules+=("chezmoi.md") ;;
+esac
+
+# React: .tsx / .jsx source files
+case "$path" in
+  *.tsx|*.jsx) rules+=("react.md") ;;
+esac
+
+# Drizzle: schema files, drizzle.config.*, anything under a drizzle/ dir
+case "$path" in
+  *schema.ts|*schema.tsx) rules+=("drizzle.md") ;;
+  drizzle.config.*|*/drizzle.config.*) rules+=("drizzle.md") ;;
+  */drizzle/*) rules+=("drizzle.md") ;;
+esac
+
+(( ${#rules[@]} > 0 )) || exit 0
+
+body=""
+for r in "${rules[@]}"; do
+  f="$rules_dir/$r"
+  [[ -f $f ]] || continue
+  [[ -n $body ]] && body+=$'\n\n---\n\n'
+  body+=$(cat "$f")
+done
+
+[[ -n $body ]] || exit 0
+
+jq -n --arg body "$body" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    additionalContext: $body
+  }
+}'

--- a/dot_claude/rules/development-principles.md
+++ b/dot_claude/rules/development-principles.md
@@ -36,3 +36,12 @@ alwaysApply: true
 - Always generate via ORM migration CLI (e.g., `drizzle-kit generate`)
 - Commit generated files as-is without manual edits
 - Never manually create or edit ORM-managed metadata (snapshots, journals)
+
+## Volatility Resistance
+
+The output of a single prompt is volatile; the procedure that produced it is not. Invest in what survives the session boundary.
+
+- Optimize for reproducible procedure, not one-shot prompt quality
+- Spend time on artifacts that persist across sessions: specs, contracts, tests, harness rules, ADRs
+- "A prompt that worked once" is not knowledge — capture the conditions that made it work, or it does not transfer
+- When a session produces a good result through ad-hoc steering, distill the steering into a rule, hook, or skill before the lesson decays

--- a/dot_claude/rules/harness-engineering.md
+++ b/dot_claude/rules/harness-engineering.md
@@ -4,19 +4,30 @@ alwaysApply: true
 
 # Harness Engineering
 
-## Generator-Evaluator Separation
+## Harness vs Guardrail
+
+Sections in this file fall into two categories:
+
+- **[Harness]** Pre-design — shapes how the agent runs *before* it acts
+- **[Guardrail]** Post-verification — detects deviation *after* the agent acts
+
+Harness is a design decision; guardrail is a mechanical check. Separating "is this pre-design or post-verification?" prevents rule bloat.
+
+Push checks toward guardrails whenever a deterministic tool can do the job: **the stronger the mechanical verification, the more autonomy the agent can be safely given**.
+
+## [Guardrail] Generator-Evaluator Separation
 
 - Never self-assess quality of your own output as the final verdict
 - When reviewing code you wrote, launch a separate agent that did not participate in generation
 - The evaluator should test behavior, not read implementation to form its judgment
 
-## Sprint Contracts
+## [Harness] Sprint Contracts
 
 - Before implementation: agree on concrete "done" criteria with the user
 - Done criteria must be verifiable (testable assertions, observable behavior, measurable outcomes)
 - If criteria cannot be verified automatically, state which require manual verification
 
-## Review Discipline
+## [Guardrail] Review Discipline
 
 ### Giving reviews
 
@@ -32,13 +43,13 @@ alwaysApply: true
 - If feedback is vague or unclear, ask for clarification instead of guessing intent
 - No performative agreement ("great suggestion!") — just evaluate and act
 
-## Oscillation Guard
+## [Guardrail] Oscillation Guard
 
 - If a fix reverts a previous fix (A -> B -> A pattern), stop and escalate to the user
 - When stuck in a fix loop (3+ attempts at the same issue), re-plan instead of retrying
 - Maximum 5 review-fix iterations before presenting current state to user
 
-## Decision Records
+## [Harness] Decision Records
 
 - Record non-trivial technical decisions as ADRs (Architecture Decision Records)
 - Check for existing ADR directory (`docs/adr/`, `docs/decisions/`, `adr/`, etc.) and follow that convention. If none exists, recommend `docs/adr/`
@@ -63,8 +74,9 @@ What was decided and why this option over alternatives.
 What becomes easier, what becomes harder. Both positive and negative.
 ```
 
-## Harness Simplification
+## [Meta] Harness Simplification
 
 - Each guardrail encodes an assumption about what the model cannot do reliably
 - Periodically question whether a guardrail is still necessary
 - Remove ceremony that no longer prevents real failures
+- When a model upgrade lands, audit which guardrails were patching the old model's limits and drop the ones that no longer earn their cost

--- a/dot_claude/rules/tdd.md
+++ b/dot_claude/rules/tdd.md
@@ -43,3 +43,13 @@ TDD does not apply to contexts without test frameworks:
 - CI/CD pipeline definitions
 - Shell scripts without a test harness
 - Declarative config files (JSON, YAML, TOML)
+
+## Applying TDD to the Harness Itself
+
+Rules and hooks under `~/.claude/` are also code; they deserve the same Red-Green-Refactor discipline before being committed.
+
+1. **Red**: Reproduce the failure pattern *without* the new rule/hook in place. Confirm the agent fails the way you expect
+2. **Green**: Add the rule or hook. Confirm the same scenario is now blocked or corrected
+3. **Refactor**: In a fresh session, probe edge cases — paraphrased prompts, adjacent tasks — to confirm the rule is not just memorized to one phrasing
+
+A rule added without a Red step is indistinguishable from cargo culting. If you cannot articulate the concrete failure it prevents, do not add it.

--- a/dot_claude/rules/workflow.md
+++ b/dot_claude/rules/workflow.md
@@ -91,3 +91,28 @@ When given a bug report: fix it without hand-holding, but **investigate before p
 - **Explain Changes**: High-level summary at each step
 - **Document Results**: Add review section to tasks/todo.md
 - **Capture Lessons**: Update tasks/lessons.md after corrections
+
+## Rule Hygiene
+
+Long instruction sets degrade model behavior — IFScale (arxiv 2507.11538) shows primacy bias kicks in around 150–200 instructions, and Chroma's context rot study confirms degradation across all 18 frontier models tested. The fix is volume discipline, not "just one more bullet."
+
+- Treat the always-loaded rule set in `~/.claude/rules/` as a budget capped near **150 effective instructions**
+- When near the cap, every new rule must come with a **proposed deletion or downgrade** of an existing one (grow-by-replace)
+- Project-specific rules (framework, ORM, deployment target) belong in the project's CLAUDE.md, not the global set
+- Detail-heavy or rarely-applicable rules should be `alwaysApply: false` so they load on demand
+- Periodically audit: which rules have not prevented a real failure in the last few months? Drop them
+
+## Escalation Ladder
+
+Where to place a new constraint, by violation history and reversibility:
+
+| Level | Location | When to use |
+| :---- | :------- | :---------- |
+| L1 | Mention in `CLAUDE.md` or task instructions | First occurrence; soft preference |
+| L2 | New/extended rule in `~/.claude/rules/*.md` | Same issue noticed twice or more |
+| L3 | `~/.claude/hooks/` (PreToolUse, Stop, etc.) | Repeated violation OR irreversible action (push --force, rm -rf, secret leak) |
+| L4 | Project CI / required check | Production impact, security, or compliance |
+
+- Skip levels when the action is irreversible — go straight to L3+ instead of trusting prose
+- Prefer machine-checkable enforcement (L3/L4) over instructions (L1/L2) whenever a deterministic check is possible
+- See `harness-engineering.md` for why this matches "the stronger the mechanical verification, the more autonomy"

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -95,7 +95,11 @@
   "language": "Follow the user's input language. Prioritize accuracy. Think step-by-step. Do not guess—ask or investigate when uncertain.",
   "claudeMdExcludes": [
     "**/.claude/rules/gh-pr-body.md",
-    "**/.claude/rules/chezmoi.md"
+    "**/.claude/rules/chezmoi.md",
+    "**/.claude/rules/react.md",
+    "**/.claude/rules/browser-automation.md",
+    "**/.claude/rules/drizzle.md",
+    "**/.claude/rules/zero-cost-scaling.md"
   ],
   "hooks": {
     "PreToolUse": [
@@ -113,7 +117,16 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/chezmoi-inject.sh"
+            "command": "$HOME/.claude/hooks/rules-inject.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__claude-in-chrome__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/browser-inject.sh"
           }
         ]
       }

--- a/justfile
+++ b/justfile
@@ -35,8 +35,13 @@ lint:
     @echo "✓ Done!"
 
 # Run all checks
-test: lint fmt-check
+test: lint fmt-check test-hooks
     @echo "✓ All checks passed!"
+
+# Run hook tests
+test-hooks:
+    @echo "Running hook tests..."
+    @bash tests/hooks/run-tests.sh
 
 # Install formatter tools
 install:

--- a/tests/hooks/browser-inject.test.sh
+++ b/tests/hooks/browser-inject.test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Tests for executable_browser-inject.sh: should inject browser-automation.md
+# when invoking any mcp__claude-in-chrome__* tool, and stay silent otherwise.
+set -uo pipefail
+
+hook="$HOOKS_DIR/executable_browser-inject.sh"
+[[ -f $hook ]] || { echo "hook not found: $hook"; exit 1; }
+
+run() {
+  printf '%s' "$1" | bash "$hook"
+}
+
+contains_rule() {
+  echo "$1" | jq -e '.hookSpecificOutput.additionalContext | contains("Browser Automation")' >/dev/null
+}
+
+# Red: non-chrome tool should produce no output
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"ls"}}')
+[[ -z $out ]] || { echo "fired on Bash: $out"; exit 1; }
+
+# Green: chrome MCP tool should inject the rule
+out=$(run '{"tool_name":"mcp__claude-in-chrome__navigate","tool_input":{"url":"https://example.com"}}')
+contains_rule "$out" || { echo "rule not injected for navigate: $out"; exit 1; }
+
+# Green: tabs_context_mcp should also fire
+out=$(run '{"tool_name":"mcp__claude-in-chrome__tabs_context_mcp","tool_input":{}}')
+contains_rule "$out" || { echo "rule not injected for tabs_context_mcp: $out"; exit 1; }
+
+# Edge: missing tool_name should not crash
+out=$(run '{"tool_input":{}}')
+[[ -z $out ]] || { echo "fired on missing tool_name: $out"; exit 1; }
+
+# Edge: similarly-named non-chrome tool should not match
+out=$(run '{"tool_name":"mcp__some-other-server__tool","tool_input":{}}')
+[[ -z $out ]] || { echo "fired on non-chrome MCP tool: $out"; exit 1; }

--- a/tests/hooks/rules-inject.test.sh
+++ b/tests/hooks/rules-inject.test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Tests for executable_rules-inject.sh: single dispatcher that injects
+# path-relevant rule files (chezmoi, react, drizzle) into additionalContext.
+set -uo pipefail
+
+hook="$HOOKS_DIR/executable_rules-inject.sh"
+[[ -f $hook ]] || { echo "hook not found: $hook"; exit 1; }
+
+run() { printf '%s' "$1" | bash "$hook"; }
+contains() {
+  echo "$1" | jq -e --arg s "$2" '.hookSpecificOutput.additionalContext | contains($s)' >/dev/null
+}
+
+# === No match: should produce no output ===
+out=$(run '{"tool_input":{"file_path":"foo.py"}}')
+[[ -z $out ]] || { echo "fired on .py: $out"; exit 1; }
+
+out=$(run '{"tool_input":{}}')
+[[ -z $out ]] || { echo "fired on missing file_path: $out"; exit 1; }
+
+# === chezmoi: any file under chezmoi source tree ===
+out=$(run '{"tool_input":{"file_path":"/Users/x/.local/share/chezmoi/dot_zshrc"}}')
+contains "$out" "chezmoi" || { echo "chezmoi rule not injected: $out"; exit 1; }
+
+# === react: .tsx / .jsx ===
+out=$(run '{"tool_input":{"file_path":"src/App.tsx"}}')
+contains "$out" "React Conventions" || { echo "react rule not injected for .tsx: $out"; exit 1; }
+
+out=$(run '{"tool_input":{"file_path":"src/App.jsx"}}')
+contains "$out" "React Conventions" || { echo "react rule not injected for .jsx: $out"; exit 1; }
+
+# === drizzle: schema, config, drizzle/ dir ===
+out=$(run '{"tool_input":{"file_path":"db/schema.ts"}}')
+contains "$out" "Drizzle" || { echo "drizzle rule not injected for schema.ts: $out"; exit 1; }
+
+out=$(run '{"tool_input":{"file_path":"drizzle.config.ts"}}')
+contains "$out" "Drizzle" || { echo "drizzle rule not injected for drizzle.config.ts: $out"; exit 1; }
+
+out=$(run '{"tool_input":{"file_path":"src/drizzle/migrations/0001_init.sql"}}')
+contains "$out" "Drizzle" || { echo "drizzle rule not injected for drizzle/ path: $out"; exit 1; }
+
+# === Multiple matches: schema.tsx hits both drizzle and react ===
+out=$(run '{"tool_input":{"file_path":"db/schema.tsx"}}')
+contains "$out" "Drizzle" || { echo "drizzle not injected for schema.tsx: $out"; exit 1; }
+contains "$out" "React Conventions" || { echo "react not injected for schema.tsx: $out"; exit 1; }
+
+# === Edge: file with .tsx in directory name but not extension ===
+out=$(run '{"tool_input":{"file_path":"my.tsx.dir/note.md"}}')
+[[ -z $out ]] || { echo "fired on non-tsx file with .tsx in path: $out"; exit 1; }
+
+# === Performance check: single bash + jq invocation by design ===
+# (verified by inspecting the dispatcher source — no per-rule subprocess)

--- a/tests/hooks/run-tests.sh
+++ b/tests/hooks/run-tests.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Test runner for dot_claude/hooks/*.sh
+#
+# Each *.test.sh in this directory is invoked with HOOKS_DIR set to the
+# chezmoi source dir (dot_claude/hooks). Tests use bash to execute hook
+# scripts directly, so the executable bit and chezmoi prefix do not matter.
+set -uo pipefail
+
+cd "$(dirname "$0")"
+export HOOKS_DIR
+HOOKS_DIR="$(cd "../../dot_claude/hooks" && pwd)"
+
+pass=0
+fail=0
+failed_tests=()
+out=$(mktemp)
+trap 'rm -f "$out"' EXIT
+
+for test in *.test.sh; do
+  [[ -f $test ]] || continue
+  name=${test%.test.sh}
+  if bash "$test" >"$out" 2>&1; then
+    printf '  ok   %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL %s\n' "$name"
+    sed 's/^/       /' "$out"
+    fail=$((fail + 1))
+    failed_tests+=("$name")
+  fi
+done
+
+echo
+echo "passed: $pass  failed: $fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## Summary

- Reorganize global Claude rules around the **Harness vs Guardrail** axis (pre-design vs post-verification) to prevent rule bloat.
- Consolidate three `Write|Edit` inject hooks into a single `rules-inject.sh` dispatcher — **~3x faster per edit** (one `bash` + `jq` invocation regardless of how many rules match).
- Move project-specific rules (`react.md`, `drizzle.md`, `browser-automation.md`, `zero-cost-scaling.md`) off the always-loaded context via `claudeMdExcludes`.
- Add new sections: `Rule Hygiene`, `Escalation Ladder`, `Volatility Resistance`, `Applying TDD to the Harness Itself`.

## Why

After reading two recent posts on harness engineering (Meetup #1 report + landscape survey), the always-loaded rule volume was approaching the [IFScale](https://arxiv.org/abs/2507.11538) primacy-bias zone (~172 effective bullets, near the 150–200 degradation threshold). This PR brings it back to ~134 bullets and bakes the budget discipline into `workflow.md` so future additions are explicit trade-offs.

## Hook architecture

```mermaid
graph LR
    subgraph Before
        WE1[Write/Edit] --> H1[chezmoi-inject.sh]
        WE1 --> H2[react-inject.sh]
        WE1 --> H3[drizzle-inject.sh]
    end
    subgraph After
        WE2[Write/Edit] --> D[rules-inject.sh<br/>dispatcher]
        D -. case match .-> C[chezmoi.md]
        D -. case match .-> R[react.md]
        D -. case match .-> DZ[drizzle.md]
    end
```

Adding a new path-based rule now means one `case` clause + one assertion in the test — no new hook script, no `settings.json` edit.

## Verification

- [x] `just test-hooks` — 2/2 pass (`rules-inject`, `browser-inject`)
- [x] `chezmoi execute-template < settings.json.tmpl` renders valid JSON
- [x] `chezmoi apply` succeeded; orphan `~/.claude/hooks/chezmoi-inject.sh` removed manually
- [x] Independent Explore agent verified: `alwaysApply: false` is a no-op in Claude Code (only `claudeMdExcludes` controls loading); `english-proofreading.md` left in place after audit caught a deletion-mistake

## Test plan

- [ ] Open a `.tsx` file in another project and confirm `react.md` content appears in PreToolUse context
- [ ] Edit a file under `~/.local/share/chezmoi/` and confirm `chezmoi.md` content appears
- [ ] Invoke a `mcp__claude-in-chrome__*` tool and confirm `browser-automation.md` appears
- [ ] Edit a `.py` file and confirm no rule injection (no overhead spent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
