### PR TITLE
feat(tmux): add synchronize-panes toggle with visual indicator

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -141,6 +141,10 @@ if-shell '[ -n "$SSH_TTY" ]' 'set -g status off'
 # Toggle status bar on/off
 bind S set -g status
 
+# Toggle synchronize-panes (send same input to all panes in window)
+# Visual indicator appears in status bar and window list when ON
+bind y setw synchronize-panes \; display "Sync panes: #{?pane_synchronized,ON,OFF}"
+
 # -----------------------------------------------------------------------------
 # Status bar - Tokyo Night theme
 # -----------------------------------------------------------------------------
@@ -150,12 +154,12 @@ set -g status-style "bg=#1a1b26,fg=#c0caf5"
 set -g status-left-length 40
 set -g status-left "#[bg=#7aa2f7,fg=#1a1b26,bold] #S #[bg=#1a1b26] "
 
-set -g status-right-length 60
-set -g status-right "#[fg=#565f89]%Y-%m-%d #[fg=#c0caf5]%H:%M #[bg=#9ece6a,fg=#1a1b26,bold] #h "
+set -g status-right-length 80
+set -g status-right "#{?pane_synchronized,#[bg=#f7768e#,fg=#1a1b26#,bold] ⚠ SYNC ⚠ #[default] ,}#[fg=#565f89]%Y-%m-%d #[fg=#c0caf5]%H:%M #[bg=#9ece6a,fg=#1a1b26,bold] #h "
 
-# Window status
-setw -g window-status-format "#[fg=#565f89] #I:#W "
-setw -g window-status-current-format "#[bg=#33467c,fg=#c0caf5,bold] #I:#W "
+# Window status (append [SYNC] when synchronize-panes is on for that window)
+setw -g window-status-format "#[fg=#565f89] #I:#W#{?pane_synchronized,#[fg=#f7768e#,bold] [SYNC],} "
+setw -g window-status-current-format "#[bg=#33467c,fg=#c0caf5,bold] #I:#W#{?pane_synchronized,#[fg=#f7768e] [SYNC],} "
 
 # Pane borders
 set -g pane-border-style "fg=#33467c"


### PR DESCRIPTION
## Summary
- Bind `prefix + y` to toggle `synchronize-panes` (sYnc mnemonic, no conflict with existing bindings or terminal XOFF)
- Append `[SYNC]` marker to window list entries whose window has synchronize-panes on (uses `pane_synchronized` format variable)
- Show prominent `⚠ SYNC ⚠` block in status-right (Tokyo Night red `#f7768e`, matching the existing passthrough-mode warning style)

## Test plan
- [ ] `tmux source-file ~/.tmux.conf` reloads without errors
- [ ] `prefix + y` toggles sync; status bar shows "Sync panes: ON/OFF" message
- [ ] When ON: window list shows `[SYNC]`, status-right shows `⚠ SYNC ⚠`
- [ ] When OFF: indicators disappear
- [ ] Per-window scope verified: enabling sync in window A does not mark window B

🤖 Generated with [Claude Code](https://claude.com/claude-code)