### PR TITLE
feat(workmux): integrate parallel agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@ dot_local/share/devbox/global/default/devbox.lock
 .claude/
 .firecrawl/
 
+# workmux Copilot CLI hooks (unused; auto-created by `workmux setup` if it detects Copilot CLI)
+.github/hooks/
+
 # Business-only configs (contain company infrastructure details)
 dot_config/colima/

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -131,12 +131,51 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status working"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status working"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt|elicitation_dialog",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status waiting"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
           {
             "type": "command",
             "command": "$HOME/.claude/hooks/mermaid-render.sh"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status done"
           }
         ]
       }

--- a/dot_config/workmux/config.yaml
+++ b/dot_config/workmux/config.yaml
@@ -1,0 +1,4 @@
+# Worktrees live at <project-root>/.claude/worktrees/<slug>
+# (overrides workmux default of <project>__worktrees/ sibling)
+worktree_dir: .claude/worktrees
+nerdfont: true

--- a/dot_local/share/devbox/global/default/devbox.json.tmpl
+++ b/dot_local/share/devbox/global/default/devbox.json.tmpl
@@ -48,7 +48,8 @@
     "uv@latest",
     "deno@latest",
     "rustup@latest",
-    "mergiraf@latest"
+    "mergiraf@latest",
+    "github:raine/workmux"
   ],
   "shell": {
     "init_hook": []

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -140,6 +140,14 @@ bind S set -g status
 bind y setw synchronize-panes \; display "Sync panes: #{?pane_synchronized,ON,OFF}"
 
 # -----------------------------------------------------------------------------
+# workmux integration
+# -----------------------------------------------------------------------------
+# Toggle live agent status sidebar across all tmux sessions
+bind g run-shell "workmux sidebar"
+# Same, but scoped to the current session only
+bind G run-shell "workmux sidebar -s"
+
+# -----------------------------------------------------------------------------
 # Status bar - Tokyo Night theme
 # -----------------------------------------------------------------------------
 set -g status-position bottom


### PR DESCRIPTION
## Summary

Adopts [raine/workmux](https://github.com/raine/workmux) for orchestrating git worktrees + tmux windows + Claude Code agents in parallel, declaratively integrated with chezmoi and existing tooling.

- **devbox**: workmux installed via upstream flake reference (`github:raine/workmux`) — not in nixpkgs, but ships its own flake; works in `devbox global`
- **workmux config** (`~/.config/workmux/config.yaml`): `worktree_dir: .claude/worktrees` honors the `<project-root>/.claude/worktrees/<slug>` rule from `~/.claude/rules/workflow.md`. Nerdfont preserved.
- **Claude Code hooks**: 4 status-tracking hooks (`UserPromptSubmit` / `PostToolUse` / `Notification` / `Stop`) added directly to `settings.json.tmpl`. Pure config — no `claude plugin install` required, so business and personal both work without external state.
- **tmux**: `prefix+g` toggles workmux sidebar (live agent status across sessions); `prefix+G` is session-scoped. Avoided `prefix+w` to preserve tmux default `choose-tree -Zw`.
- **gitignore**: `.github/hooks/` excluded — `workmux setup` auto-creates Copilot CLI hooks there if it detects Copilot, but we don't use Copilot CLI.

## Test plan

- [x] `just test` passes (lint + format + hook tests)
- [x] Both personal and business chezmoi modes render `settings.json.tmpl` to valid JSON (`jq -e`)
- [x] `chezmoi apply --force` succeeds; `chezmoi status` clean afterward
- [x] `workmux 0.1.187` resolves via `which workmux` (devbox flake working)
- [x] `tmux list-keys -T prefix | grep -E '^bind-key.*\b(g|G)\b'` shows new bindings
- [x] `prefix+w` remains tmux default (`choose-tree -Zw`) — no clobber
- [ ] Manual: run `workmux add test-branch` in any repo and verify worktree lands at `<repo>/.claude/worktrees/test-branch`
- [ ] Manual: trigger `prefix+g` and observe sidebar with Claude Code agent status icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)