### PR TITLE
feat(work): wire corporate CA trust and stabilize openssl@3 PATH

### DIFF
--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -70,4 +70,26 @@ export GITLEAKS_CONFIG="$XDG_CONFIG_HOME/gitleaks/config.toml"
 # =============================================================================
 export BUSINESS_USE=1
 export COLIMA_HOME="$XDG_CONFIG_HOME/colima"
+
+# Corporate TLS inspection CA: wire palo-root.pem (in Homebrew's cert store)
+# into common SSL env vars so curl/Node/Python/Ruby-OpenSSL trust certificates
+# reissued by a corporate TLS-inspecting proxy.
+# PATH ordering for openssl@3 and general Homebrew bin is handled in .zshrc
+# (must run last to survive subsequent reordering by mise/devbox/pnpm/etc.).
+# NIX_SSL_CERT_FILE is read by nix-built tools (devbox, nix CLI, builders that
+# inherit env), which ignore the standard SSL_CERT_FILE and use their own
+# baked-in CA bundle path otherwise.
+_brew_ca_dir="{{ .homebrew_prefix }}/etc/openssl@3/certs"
+_brew_palo_ca="$_brew_ca_dir/palo-root.pem"
+
+if [[ -f "$_brew_palo_ca" ]]; then
+  export SSL_CERT_DIR="$_brew_ca_dir"
+  export CAPATH="$_brew_ca_dir"
+  export SSL_CERT_FILE="$_brew_palo_ca"
+  export NODE_EXTRA_CA_CERTS="$_brew_palo_ca"
+  export CURL_CA_BUNDLE="$_brew_palo_ca"
+  export NIX_SSL_CERT_FILE="$_brew_palo_ca"
+fi
+
+unset _brew_ca_dir _brew_palo_ca
 {{- end }}

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -62,5 +62,17 @@
 # =============================================================================
 # Work Environment
 # =============================================================================
-# Add work-specific configurations here
+# mise activates earlier in zshrc and snapshots PATH; on every prompt its
+# precmd hook restores PATH from that snapshot, appending anything added
+# later (incl. keg-only openssl@3) to the back. Force openssl@3 to stay
+# at the front via our own precmd hook, registered AFTER mise's so it
+# runs later in the chain.
+_brew_force_openssl_path() {
+  local brew_openssl="{{ .homebrew_prefix }}/opt/openssl@3/bin"
+  [[ -d "$brew_openssl" ]] || return
+  [[ "${PATH%%:*}" == "$brew_openssl" ]] && return
+  export PATH="$brew_openssl:${PATH//:$brew_openssl/}"
+}
+typeset -ag precmd_functions
+precmd_functions+=(_brew_force_openssl_path)
 {{- end }}


### PR DESCRIPTION
## 概要

業務環境（`business_use=true`）向けに2点を追加する。

### 1. 企業CA証明書の設定（`dot_zshenv.tmpl`）

PaloAlto TLS検査プロキシが再発行する証明書を curl / Node.js / Python / Ruby-OpenSSL などが信頼できるよう、Homebrew の openssl@3 cert store にインストール済みの `palo-root.pem` を各SSL環境変数にセットする。

| 変数 | 対象ツール |
|---|---|
| `SSL_CERT_FILE` / `SSL_CERT_DIR` / `CAPATH` | 汎用 OpenSSL |
| `NODE_EXTRA_CA_CERTS` | Node.js |
| `CURL_CA_BUNDLE` | curl |
| `NIX_SSL_CERT_FILE` | devbox / nix CLI |

証明書ファイルが存在しない場合は何もしない（`[[ -f "$_brew_palo_ca" ]]" ガード`）。

### 2. keg-only openssl@3 の PATH 固定（`dot_zshrc.tmpl`）

Homebrew の openssl@3 は keg-only のため `/opt/homebrew/bin/` にリンクされない。  
単純に PATH 先頭へ追加するだけでは、mise の precmd フック（`_mise_hook_precmd`）が起動時スナップショットから PATH を復元するたびに末尾へ追いやられる。

**対策**: mise の後に登録した precmd フック `_brew_force_openssl_path` がプロンプト毎に openssl@3/bin を先頭に再配置する。二重追加しないよう冪等ガード付き。

## 変更ファイル

- `dot_zshenv.tmpl` — 企業CA環境変数ブロック追加（`business_use` only）
- `dot_zshrc.tmpl` — openssl@3 PATH 強制 precmd フック追加（`business_use` only）

## 未解決

`devbox global install` がビルダー内部で TLS エラーになる問題は **本PRの対象外**。  
nix-daemon が起動するビルダープロセスはシェル環境を継承しないため、別途 daemon レベルの設定が必要。