### PR TITLE
chore(git): drop docs/superpowers/ from global ignore

### DIFF
--- a/dot_config/git/ignore
+++ b/dot_config/git/ignore
@@ -39,5 +39,4 @@ devbox.lock
 
 sourcemaps
 
-docs/superpowers/
 .claude/worktrees/


### PR DESCRIPTION
## Summary
- Remove `docs/superpowers/` from the global `~/.config/git/ignore` so the exclusion is managed per repository instead of silently for every repo on this machine.
- Keep `.claude/worktrees/` in the global ignore — that one stays universal.

## Why
Global ignore hides the rule from collaborators: anyone cloning a personal repo without the same global config could accidentally commit `docs/superpowers/`. Moving the rule to each repo's own `.gitignore` makes the contract explicit and lets corporate repos (which never produce that directory) opt out cleanly.

## Test plan
- [ ] `just fmt-check` passes
- [ ] `just lint` passes
- [ ] `just diff` shows only the expected single-line removal in `~/.config/git/ignore`
- [ ] After `just apply`, `git check-ignore -v docs/superpowers/foo` in a personal repo no longer matches the global rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)
