### PR TITLE
docs(claude): clarify PR routing applies to post-phase follow-ups

### DIFF
--- a/dot_claude/rules/workflow.md
+++ b/dot_claude/rules/workflow.md
@@ -27,7 +27,7 @@ alwaysApply: true
 - Main process stays as the evaluator (see `harness-engineering.md` generator-evaluator separation)
 - Brief subagents with relevant rules inline — they have no conversation history
 - After implementation, dispatch separate review subagents: spec compliance, then code quality
-- **Push and PR creation require explicit user confirmation**
+- **Push and PR creation require explicit user confirmation** — including post-phase follow-ups (docs, cleanup, completion records). Prefer branch-protection enforcement over discipline.
 
 ### Worktree Location
 


### PR DESCRIPTION
## Summary
- Extend the existing **Push and PR creation require explicit user confirmation** bullet so it explicitly covers post-phase follow-ups (docs, cleanup, completion records)
- Add a one-line preference for branch-protection enforcement over discipline
- Reconciles a source/target drift in `~/.claude/rules/workflow.md` without expanding the always-loaded rule budget (bullet count unchanged)

## Test plan
- [ ] CI passes (format check, lint, chezmoi dry-run)
- [ ] After merge, `chezmoi apply` reflects the updated rule in `~/.claude/rules/workflow.md` with no remaining diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)