### PR TITLE
chore: refine Claude harness and trim redundant SSL exports

### DIFF
--- a/dot_claude/rules/harness-engineering.md
+++ b/dot_claude/rules/harness-engineering.md
@@ -26,6 +26,7 @@ Push checks toward guardrails whenever a deterministic tool can do the job: **th
 - Before implementation: agree on concrete "done" criteria with the user
 - Done criteria must be verifiable (testable assertions, observable behavior, measurable outcomes)
 - If criteria cannot be verified automatically, state which require manual verification
+- For multi-turn implementation tasks, encode the contract via `/goal <criteria>` so the harness tracks completion across turns (shows live elapsed/turns/tokens overlay)
 
 ## [Guardrail] Review Discipline
 

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -98,6 +98,9 @@
   },
 {{- end }}
   "alwaysThinkingEnabled": true,
+  "worktree": {
+    "baseRef": "head"
+  },
   "language": "Follow the user's input language. Prioritize accuracy. Think step-by-step. Do not guess—ask or investigate when uncertain.",
   "claudeMdExcludes": [
     "**/.claude/rules/gh-pr-body.md",

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -83,9 +83,7 @@ _brew_ca_dir="{{ .homebrew_prefix }}/etc/openssl@3/certs"
 _brew_palo_ca="$_brew_ca_dir/palo-root.pem"
 
 if [[ -f "$_brew_palo_ca" ]]; then
-  export SSL_CERT_DIR="$_brew_ca_dir"
   export CAPATH="$_brew_ca_dir"
-  export SSL_CERT_FILE="$_brew_palo_ca"
   export NODE_EXTRA_CA_CERTS="$_brew_palo_ca"
   export CURL_CA_BUNDLE="$_brew_palo_ca"
   export NIX_SSL_CERT_FILE="$_brew_palo_ca"


### PR DESCRIPTION
## Summary
- `harness-engineering.md`: document `/goal <criteria>` as the Sprint Contracts tool for multi-turn tasks (added in Claude Code v2.1.139). One bullet under the existing rule — no net increase in the always-loaded rule budget.
- `settings.json.tmpl`: set `worktree.baseRef` to `"head"` so manually-created worktrees branch from local HEAD and preserve unpushed commits (useful for TDD-in-progress subagent dispatch).
- `dot_zshenv.tmpl`: drop redundant `SSL_CERT_DIR` and `SSL_CERT_FILE` exports. `NODE_EXTRA_CA_CERTS`, `CURL_CA_BUNDLE`, `NIX_SSL_CERT_FILE` and `CAPATH` already cover the runtimes that consult corporate CA trust.

## Why
Walked through the recent Claude Code changelog (v2.1.94 → v2.1.139) and selected two low-risk harness improvements that align with the existing rule set without expanding the instruction budget. Both features are already supported on the installed version (2.1.139). The zshenv cleanup is unrelated working-tree state, bundled here as a small follow-up.

## Test plan
- [x] `chezmoi execute-template` renders `settings.json.tmpl` as valid JSON in both personal and business modes
- [x] `just test` passes (zsh syntax + lua + format + hook tests)
- [x] `chezmoi diff` empty after apply
- [x] `jq '.worktree' ~/.claude/settings.json` returns `{ "baseRef": "head" }` post-apply
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)