### PR TITLE
feat(claude): add db-safety guard for destructive DB operations

### DIFF
--- a/dot_claude/hooks/executable_block-destructive-db.sh
+++ b/dot_claude/hooks/executable_block-destructive-db.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook: deny destructive database operations by default.
+#
+# Why: a tool-invoked `db:reset` (or equivalent across stacks) wipes data
+# unconditionally. The same command targets development by default in most
+# ORMs, so a wrong run during automated work destroys the developer's local
+# DB. Recovery is hours; pausing is zero.
+#
+# Behavior:
+#   - Deny if the command matches a destructive DB pattern AND no explicit
+#     test-environment marker is present (RAILS_ENV=test, NODE_ENV=test,
+#     MIX_ENV=test).
+#   - The deny is advisory: the user can override per-project via
+#     `.claude/settings.json` permissions.allow, or run the command in
+#     their own shell (the hook only sees tool-invoked Bash).
+#
+# Reads Claude Code hook JSON from stdin; emits JSON on stdout when blocking.
+
+set -euo pipefail
+
+cmd=$(jq -r '.tool_input.command // ""')
+[[ -n $cmd ]] || exit 0
+
+# Allowlist: if the command explicitly opts into a test environment, let it
+# through. Inheriting RAILS_ENV from the shell does not count — the marker
+# must be in the command itself.
+if echo "$cmd" | grep -qiE '\b(RAILS_ENV|NODE_ENV|MIX_ENV|RACK_ENV)=test\b'; then
+  exit 0
+fi
+if echo "$cmd" | grep -qiE '\bDJANGO_SETTINGS_MODULE=[^[:space:]]*test'; then
+  exit 0
+fi
+
+# Destructive patterns across common stacks. Keep generic — no
+# project-specific naming. `\b` boundaries to avoid matching inside paths.
+patterns=(
+  # Rails / Rake / bin/rails (db:reset, db:drop, db:setup, db:schema:load)
+  '(rails|rake|bin/rails)[[:space:]]+db:(reset|drop|setup|schema:load|nuke)\b'
+  # Django
+  'manage\.py[[:space:]]+(flush|reset_db|sqlflush)\b'
+  # Prisma
+  'prisma[[:space:]]+migrate[[:space:]]+reset\b'
+  'prisma[[:space:]]+db[[:space:]]+push[^&|;]*--force-reset\b'
+  'prisma[[:space:]]+db[[:space:]]+seed[^&|;]*--reset\b'
+  # Sequelize CLI
+  'sequelize[[:space:]]+db:drop\b'
+  'sequelize[[:space:]]+db:migrate:undo:all\b'
+  # TypeORM
+  'typeorm[[:space:]]+schema:drop\b'
+  # Knex
+  'knex[[:space:]]+migrate:rollback[[:space:]]+--all\b'
+  # PostgreSQL
+  '\bdropdb\b'
+  # MySQL admin
+  'mysqladmin[[:space:]]+([^&|;]*[[:space:]])?drop\b'
+  # Raw SQL escaping into shell context
+  'DROP[[:space:]]+(DATABASE|SCHEMA)\b'
+  'TRUNCATE([[:space:]]+TABLE)?\b'
+)
+
+for p in "${patterns[@]}"; do
+  if echo "$cmd" | grep -qiE "$p"; then
+    matched="$p"
+    reason="Destructive database operation blocked by the db-safety guard.
+
+Matched pattern: $matched
+Command: $cmd
+
+This pattern wipes data unconditionally and is rarely the right move during
+automated work. Transient DDL/schema errors (e.g. \"Table definition has
+changed\") are environment noise, not code bugs — do not \"recover\" from
+them with a destructive reset.
+
+If a reset is genuinely needed:
+  1. Run the command yourself in your shell (this guard only blocks
+     tool-invoked Bash), or
+  2. Run with an explicit test-environment marker:
+       RAILS_ENV=test <command>     # or NODE_ENV=test / MIX_ENV=test
+  3. Add a per-project allow rule in .claude/settings.json:
+       permissions.allow: [\"Bash(<the specific command>:*)\"]
+
+For sub-agents: do NOT escalate to a destructive command to clear a flaky
+test. Stop and report the failing command + error to the parent."
+
+    jq -n --arg reason "$reason" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: $reason
+      }
+    }'
+    exit 0
+  fi
+done
+
+exit 0

--- a/dot_claude/rules/db-safety.md
+++ b/dot_claude/rules/db-safety.md
@@ -1,0 +1,42 @@
+# Database Safety
+
+## Never wipe a database to recover from a transient error
+
+Commands like `db:reset`, `db:drop`, `db:setup`, `db:schema:load`, `prisma migrate reset`, `manage.py flush`, `TRUNCATE`, and `DROP DATABASE` wipe data unconditionally. They are virtually never the right response to:
+
+- Concurrent-test schema noise (e.g. "Table definition has changed, please retry transaction")
+- Flaky migrations that succeed on retry
+- Stale fixtures, snapshot mismatches, or seed-cache drift
+
+These look like "DB is broken, reset it" but are environment problems. Reset destroys whatever development data the human was relying on for manual testing, and that data is often not in any seed or snapshot.
+
+## Stop, do not "recover"
+
+When you see schema/DDL errors during tests or runtime:
+
+1. Stop the destructive plan
+2. Capture the exact error and the command that produced it
+3. Report to the parent / user with that evidence
+4. Wait for instruction
+
+The user can decide whether a reset is acceptable — they know what dev data they have. You do not.
+
+## Force the test environment explicitly
+
+If you are running tests, set the test environment in the same command, not as inherited state:
+
+- Rails / Rake: `RAILS_ENV=test bundle exec rails ...`
+- Node / Prisma: `NODE_ENV=test ...`
+- Elixir / Mix: `MIX_ENV=test ...`
+- Django: `DJANGO_SETTINGS_MODULE=...test ...`
+
+Inheriting environment from the parent shell is how "test cleanup" wipes development.
+
+## Mechanical guard
+
+A PreToolUse Bash hook denies destructive database operations by default unless the command explicitly opts into a test environment (`RAILS_ENV=test`, `NODE_ENV=test`, `MIX_ENV=test`). To run a destructive command deliberately:
+
+- Run it in your own shell (the guard only blocks tool-invoked commands), or
+- Add a per-project allow rule in `.claude/settings.json` for the specific pattern
+
+The guard is conservative on purpose. A false-positive (one extra prompt) is cheap; a false-negative (wiping a developer's local DB) is hours of recovery.

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -117,6 +117,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$HOME/.claude/hooks/block-destructive-db.sh"
+          },
+          {
+            "type": "command",
             "command": "$HOME/.claude/hooks/gh-pr-inject.sh"
           }
         ]


### PR DESCRIPTION
## Why

A tool-invoked `db:reset` / `prisma migrate reset` / `manage.py flush` wipes data unconditionally and usually targets development by default. When an agent runs one of these to "recover" from a transient schema error during automated work, the developer loses their local DB — and the data is rarely in any seed file. Recovery is hours; pausing is zero.

This PR adds a paired rule + hook so the same failure mode is blocked at two layers, matching the L2/L3 escalation ladder in `~/.claude/rules/workflow.md`.

## What changed

| Layer | File | Role |
|-------|------|------|
| L2 (rule) | `dot_claude/rules/db-safety.md` | Human-facing principles, escape hatches, how to force a test env |
| L3 (hook) | `dot_claude/hooks/executable_block-destructive-db.sh` | PreToolUse(Bash) deny for destructive patterns across Rails / Django / Prisma / Sequelize / TypeORM / Knex / dropdb / mysqladmin / raw SQL |
| Wiring | `dot_claude/settings.json.tmpl` | Register the hook in the PreToolUse(Bash) chain |

## Behavior

- Deny if the command matches a destructive DB pattern **and** no explicit test-env marker (`RAILS_ENV=test`, `NODE_ENV=test`, `MIX_ENV=test`, `DJANGO_SETTINGS_MODULE=*test`) is present in the command itself
- Inheriting `RAILS_ENV` from the parent shell does **not** count — the marker must be in the command, so background "test cleanup" can't silently wipe dev
- Deny is advisory: users can override per-project via `.claude/settings.json` `permissions.allow`, or run the command in their own shell (the hook only sees tool-invoked Bash)

## Design tradeoff

False-positive (one extra prompt) is cheap; false-negative (wiping a developer's local DB) is hours of recovery. The pattern list is conservative on purpose — generic markers like `TRUNCATE` and `DROP DATABASE` are blocked even outside a known ORM context.

## Verification

- `just test` passes (lint + format)
- Hook reads from stdin per Claude Code hook contract and emits the `hookSpecificOutput.permissionDecision: "deny"` JSON shape on match; falls through with exit 0 otherwise
- Pattern coverage was sanity-checked against representative commands for each stack listed in the patterns array

## Out of scope

- The hook is advisory only — production database safety belongs to CI/migrations, not a local agent hook
- No project-specific allowlist baked in; per-project overrides go in `.claude/settings.json`
