### PR TITLE
feat(claude): block code comments that rot via PreToolUse hook

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -19,6 +19,9 @@ devbox.lock
 # Repo-local docs (specs, plans, ADRs — not for home dir)
 docs/
 
+# Repo-local tests for dot_claude/hooks (run via `just test`)
+tests/
+
 # macOS specific
 {{ if ne .chezmoi.os "darwin" }}
 .config/karabiner/

--- a/dot_claude/hooks/executable_block-rot-comments.py
+++ b/dot_claude/hooks/executable_block-rot-comments.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# PreToolUse(Write|Edit|MultiEdit) hook: block code comments that contain
+# patterns known to rot quickly. The existing rules in
+# ~/.claude/rules/development-principles.md already forbid these, but
+# instructions alone have not held — this turns the policy into a
+# deterministic check so it survives context-window pressure.
+#
+# What counts as a rot-prone comment:
+#   1. Issue / PR / ticket references ("// added for #123", "# fixes PR-456").
+#      Context belongs in commit messages, not comments.
+#   2. Caller / usage references ("// used by handleSubmit", "called from
+#      the auth handler"). These break the moment callers move.
+#   3. Temporal phrasing ("previously", "now does X", "deprecated as of",
+#      "as of 2024"). Code evolves; this dates itself.
+#   4. Bare TODO / FIXME without an owner (@name) or date (YYYY-MM-DD).
+#      Unactionable reminders accumulate forever.
+#
+# Skipped:
+#   - Prose extensions (.md, .mdx, .txt, .rst, .adoc) — issue refs and
+#     temporal language are legitimate there.
+#   - For Edit / MultiEdit, only lines present in new_string but not in
+#     old_string are scanned, so touching code near an existing rot
+#     comment does not retroactively block the edit.
+#
+# Reads Claude Code hook JSON from stdin; emits a deny JSON on stdout
+# when blocking, otherwise exits silently.
+
+import json
+import re
+import sys
+
+PROSE_EXTENSIONS = (".md", ".mdx", ".txt", ".rst", ".adoc")
+
+ROT_PATTERNS = [
+    (
+        re.compile(r"\b(issue|pr|ticket)\s*[#-]?\s*\d+\b", re.I),
+        "issue / PR / ticket reference",
+    ),
+    (
+        re.compile(r"(?:^|\s)#\d{2,}\b"),
+        "issue number (#NNN)",
+    ),
+    (
+        re.compile(
+            r"\b(?:used\s+by|called\s+(?:from|by)|"
+            r"added\s+(?:for|in|to\s+(?:support|handle))|"
+            r"needed\s+for(?:\s+the)?|"
+            r"for\s+the\s+\S.*?\s+(?:flow|handler|component|page))\b",
+            re.I,
+        ),
+        "caller / usage reference",
+    ),
+    (
+        re.compile(
+            r"\b(?:previously|used\s+to|was\s+changed|"
+            r"now\s+(?:does|returns|handles)|"
+            r"deprecated\s+as\s+of|legacy\s+code|"
+            r"since\s+v\d|as\s+of\s+\d{4})\b",
+            re.I,
+        ),
+        "temporal phrasing",
+    ),
+    (
+        re.compile(r"\b(TEMP(?:ORARY)?|HACK|XXX)\s*:", re.I),
+        "TEMP/HACK/XXX marker",
+    ),
+]
+
+TODO_PATTERN = re.compile(r"\b(TODO|FIXME)\b", re.I)
+TODO_OWNER_OR_DATE = re.compile(r"\(@[\w-]+\)|\d{4}-\d{2}-\d{2}")
+
+# Comment-marker extraction. Order matters — try HTML/SQL/block before
+# line-style. Each pattern uses lookarounds so URLs (http://), CSS hex
+# colors (#ff0099), Python floor division (x // 2 — value caught, but
+# safe since no rot terms hit numeric content), and shebangs (#!) are
+# not mistaken for comments.
+COMMENT_REGEXES = (
+    re.compile(r"<!--(.*?)(?:-->|$)"),
+    re.compile(r"(?<![:/])//(.*)"),
+    re.compile(r"/\*(.*?)(?:\*/|$)"),
+    re.compile(r"(?:^|\s)--(.*)"),
+    re.compile(r"(?:(?<=^)|(?<=\s))#(?!!)(.*)"),
+)
+
+
+def extract_comment_text(line: str) -> str | None:
+    if line.lstrip().startswith("#!"):
+        return None
+    for pattern in COMMENT_REGEXES:
+        match = pattern.search(line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def added_lines(tool_name: str, tool_input: dict) -> list[str]:
+    if tool_name == "Write":
+        return (tool_input.get("content") or "").splitlines()
+    if tool_name == "Edit":
+        old = set((tool_input.get("old_string") or "").splitlines())
+        new = (tool_input.get("new_string") or "").splitlines()
+        return [line for line in new if line not in old]
+    if tool_name == "MultiEdit":
+        result: list[str] = []
+        for edit in tool_input.get("edits") or []:
+            old = set((edit.get("old_string") or "").splitlines())
+            new = (edit.get("new_string") or "").splitlines()
+            result.extend(line for line in new if line not in old)
+        return result
+    return []
+
+
+def find_violations(lines: list[str]) -> list[tuple[str, str]]:
+    hits: list[tuple[str, str]] = []
+    for line in lines:
+        comment = extract_comment_text(line)
+        if comment is None:
+            continue
+        matched_label: str | None = None
+        for pattern, label in ROT_PATTERNS:
+            if pattern.search(comment):
+                matched_label = label
+                break
+        if matched_label is None and TODO_PATTERN.search(comment):
+            if not TODO_OWNER_OR_DATE.search(comment):
+                matched_label = "TODO/FIXME without owner (@name) or date (YYYY-MM-DD)"
+        if matched_label:
+            hits.append((line.strip(), matched_label))
+    return hits
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    tool_name = payload.get("tool_name") or ""
+    tool_input = payload.get("tool_input") or {}
+    file_path = tool_input.get("file_path") or ""
+
+    if file_path.lower().endswith(PROSE_EXTENSIONS):
+        return 0
+    if tool_name not in ("Write", "Edit", "MultiEdit"):
+        return 0
+
+    violations = find_violations(added_lines(tool_name, tool_input))
+    if not violations:
+        return 0
+
+    sample = "\n".join(
+        f"  {idx}. {line}\n     → {label}"
+        for idx, (line, label) in enumerate(violations[:5], 1)
+    )
+    overflow = f"\n  …and {len(violations) - 5} more." if len(violations) > 5 else ""
+    reason = (
+        "Comment(s) that tend to rot blocked.\n\n"
+        f"{sample}{overflow}\n\n"
+        "Why these rot:\n"
+        "  - Issue / PR / ticket numbers belong in the commit message or PR body,\n"
+        "    not in code that will outlive them.\n"
+        "  - Caller / usage references break the moment callers are renamed or moved.\n"
+        "  - Temporal phrasing (\"previously\", \"now does\", \"as of v2\") goes stale\n"
+        "    the next time the code is rewritten.\n"
+        "  - Bare TODO / FIXME without an owner or target date is an unactionable\n"
+        "    reminder that accumulates forever.\n\n"
+        "How to fix:\n"
+        "  - Delete the comment if the code is self-explanatory.\n"
+        "  - Rewrite it to describe the WHY (a constraint, invariant, surprise).\n"
+        "  - Move task context to the commit message / PR description.\n"
+        "  - For TODOs: add an owner — TODO(@username) — or a target date —\n"
+        "    TODO 2026-12-31."
+    )
+
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        },
+        sys.stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -49,7 +49,8 @@
       "Write(**/.ssh/*)",
       "Write(**/authorized_keys)",
       "mcp__supabase__execute_sql"
-    ]
+    ],
+    "defaultMode": "auto"
   },
 {{- if .business_use }}
   "env": {
@@ -131,6 +132,10 @@
           {
             "type": "command",
             "command": "$HOME/.claude/hooks/rules-inject.sh"
+          },
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/block-rot-comments.py"
           }
         ]
       },

--- a/tests/hooks/block-rot-comments.test.sh
+++ b/tests/hooks/block-rot-comments.test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Tests for executable_block-rot-comments.py: PreToolUse(Write|Edit) guard
+# that blocks code comments containing patterns known to rot — references
+# to current task/PR/issue numbers, caller names, temporal phrasing
+# ("previously", "now does"), and TODO/FIXME without owner or date.
+set -uo pipefail
+
+hook="$HOOKS_DIR/executable_block-rot-comments.py"
+[[ -f $hook ]] || { echo "hook not found: $hook"; exit 1; }
+
+# run "<json>" — pipe JSON to the hook, capture stdout. Hook is expected
+# to either exit silently (allow) or emit a deny JSON (block).
+run() { printf '%s' "$1" | python3 "$hook"; }
+is_block() {
+  echo "$1" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null
+}
+reason_has() {
+  echo "$1" | jq -e --arg s "$2" '.hookSpecificOutput.permissionDecisionReason | contains($s)' >/dev/null
+}
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# === ALLOW: no input, missing fields ===
+out=$(run '{"tool_input":{}}')
+[[ -z $out ]] || fail "fired with empty tool_input: $out"
+
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"foo.ts"}}')
+[[ -z $out ]] || fail "fired with missing content: $out"
+
+# === ALLOW: prose / docs files ===
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"README.md","content":"# Project\n\nSee issue #123 for context."}}')
+[[ -z $out ]] || fail "fired on .md file: $out"
+
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"docs/spec.mdx","content":"used by the auth flow"}}')
+[[ -z $out ]] || fail "fired on .mdx file: $out"
+
+# === ALLOW: shebangs ===
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"script.sh","content":"#!/usr/bin/env bash\necho hi\n"}}')
+[[ -z $out ]] || fail "shebang flagged as rot comment: $out"
+
+# === ALLOW: URL fragments and CSS hex colors are not comments ===
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":"const url = \"http://example.com#section42\";\nconst color = \"#ff0099\";\n"}}')
+[[ -z $out ]] || fail "URL fragment / hex color mistaken for comment: $out"
+
+# === ALLOW: legitimate code comments without rot patterns ===
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":"// Retries are required because the upstream API drops connections silently.\nfunction f() {}\n"}}')
+[[ -z $out ]] || fail "blocked legit explanatory comment: $out"
+
+# === BLOCK: issue / PR reference in comment ===
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":"// added for #123\nfunction f() {}\n"}}')
+is_block "$out" || fail "did not block '#123' issue reference: $out"
+reason_has "$out" "rot" || fail "deny reason missing 'rot' keyword: $out"
+
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.py","content":"# fixes PR-456\ndef f(): pass\n"}}')
+is_block "$out" || fail "did not block 'PR-456' reference: $out"
+
+# === BLOCK: caller / usage reference ===
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":"// used by handleSubmit\nfunction f() {}\n"}}')
+is_block "$out" || fail "did not block 'used by' caller reference: $out"
+
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.go","content":"// called from the auth handler\nfunc f() {}\n"}}')
+is_block "$out" || fail "did not block 'called from' caller reference: $out"
+
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.rb","content":"# added for the signup flow\ndef f; end\n"}}')
+is_block "$out" || fail "did not block 'added for the X flow': $out"
+
+# === BLOCK: temporal phrasing ===
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":"// previously returned null, now returns []\nfunction f() {}\n"}}')
+is_block "$out" || fail "did not block 'previously ... now': $out"
+
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":"// deprecated as of v2.3\nfunction f() {}\n"}}')
+is_block "$out" || fail "did not block 'deprecated as of': $out"
+
+# === BLOCK: bare TODO / FIXME without owner or date ===
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":"// TODO: fix this\nfunction f() {}\n"}}')
+is_block "$out" || fail "did not block bare TODO: $out"
+
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.py","content":"# FIXME: broken\ndef f(): pass\n"}}')
+is_block "$out" || fail "did not block bare FIXME: $out"
+
+# === ALLOW: TODO with owner ===
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":"// TODO(@alice): rewrite this once the v2 API is ready\nfunction f() {}\n"}}')
+[[ -z $out ]] || fail "blocked TODO with owner: $out"
+
+# === ALLOW: TODO with date ===
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":"// TODO 2026-12-31: revisit after migration\nfunction f() {}\n"}}')
+[[ -z $out ]] || fail "blocked TODO with date: $out"
+
+# === BLOCK: inline trailing comment with rot pattern ===
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":"const x = 42; // used by computeTotal\n"}}')
+is_block "$out" || fail "did not block inline trailing rot comment: $out"
+
+# === Edit: only NEW comment lines are checked ===
+# Old already had a rot comment; new_string keeps it but does not introduce
+# anything new. Should ALLOW because we did not author the rot comment.
+old='// used by handleSubmit\nfunction f() { return 1; }\n'
+new='// used by handleSubmit\nfunction f() { return 2; }\n'
+out=$(run "{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"a.ts\",\"old_string\":\"$old\",\"new_string\":\"$new\"}}")
+[[ -z $out ]] || fail "blocked edit that did not add the rot comment: $out"
+
+# Edit ADDS a new rot comment → BLOCK.
+old='function f() { return 1; }\n'
+new='// added for #999\nfunction f() { return 1; }\n'
+out=$(run "{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"a.ts\",\"old_string\":\"$old\",\"new_string\":\"$new\"}}")
+is_block "$out" || fail "did not block edit adding rot comment: $out"
+
+# === ALLOW: Edit that REMOVES a rot comment ===
+old='// added for #999\nfunction f() {}\n'
+new='function f() {}\n'
+out=$(run "{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"a.ts\",\"old_string\":\"$old\",\"new_string\":\"$new\"}}")
+[[ -z $out ]] || fail "blocked edit that removed a rot comment: $out"
+
+echo "all assertions passed"


### PR DESCRIPTION
## Summary
- Add `block-rot-comments.py` PreToolUse(Write|Edit|MultiEdit) hook that denies code comments containing rot-prone patterns: issue/PR/ticket refs, caller / usage references, temporal phrasing (`previously`, `now does`, `deprecated as of`), and bare `TODO`/`FIXME` without an owner (`@name`) or date (`YYYY-MM-DD`)
- Ignore `tests/` in `.chezmoiignore` — it was being deployed to `~/tests/` because the directory has no `dot_` prefix and no ignore entry
- Pin `defaultMode: "auto"` in `dot_claude/settings.json.tmpl` so `chezmoi apply` no longer drops the existing live value

## Why
The rule in `~/.claude/rules/development-principles.md` already forbids these comment patterns, and the system prompt repeats the prohibition. Instruction-only enforcement has not held under context pressure — this is the L3 (mechanical hook) step per `workflow.md`'s Escalation Ladder.

## How it filters
- Skips prose extensions (`.md`, `.mdx`, `.txt`, `.rst`, `.adoc`) so headings, issue refs in docs, and temporal language in changelogs are unaffected
- Skips shebangs (`#!/...`), URL fragments (`http://...#section`), and CSS hex colors via comment-marker lookarounds
- For `Edit`/`MultiEdit`, only lines that appear in `new_string` but not in `old_string` are scanned, so touching code near an existing rot comment does not retroactively block the edit

## Test plan
- [x] `just test` passes (3/3 — `block-rot-comments`, `browser-inject`, `rules-inject`)
- [x] `chezmoi apply --force` succeeded; `chezmoi diff` empty afterwards
- [x] `~/.claude/hooks/block-rot-comments.py` deployed `0755`
- [ ] Confirm hook blocks `// TODO: fix this` in a fresh session
- [ ] Confirm hook allows `// TODO(@owner): note` and `// TODO 2026-12-31: note`
- [ ] Verify no false-positive on `.md` writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)