### PR TITLE
feat(skills): equity-decision — 1-page purchase memo for US/JP individual stocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ dot_local/share/devbox/global/default/devbox.lock
 .claude/
 .firecrawl/
 
+# Python tooling caches (pytest harness under tests/skills/)
+__pycache__/
+.pytest_cache/
+
 # workmux Copilot CLI hooks (unused; auto-created by `workmux setup` if it detects Copilot CLI)
 .github/hooks/
 

--- a/docs/superpowers/plans/2026-05-29-equity-decision-skill.md
+++ b/docs/superpowers/plans/2026-05-29-equity-decision-skill.md
@@ -1,0 +1,1506 @@
+# `equity-decision` Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Claude Code skill `equity-decision` that produces a 1-page purchase memo for a US or JP stock when invoked with a ticker, walking 5 phases (business → fundamentals → valuation → risks → verdict) and ending with deep-dive options.
+
+**Architecture:**
+- chezmoi-managed source at `dot_claude/skills/equity-decision/`, deploys to `~/.claude/skills/equity-decision/`
+- SKILL.md as entry; phase templates and rubrics in `references/`; data fetchers as PEP 723 standalone Python scripts in `scripts/`
+- Adapted from anthropics/financial-services (Apache 2.0) but using only free data (SEC EDGAR, EDINET, Yahoo Finance, NYU Damodaran)
+- v1 covers Phase A (skeleton, hand-fill) + Phase B (fetchers, automated). ETF (Phase C) and polish (Phase D) deferred
+
+**Tech Stack:**
+- Markdown for skill content (SKILL.md, references)
+- Python 3.11+ via `uv run` (PEP 723 inline metadata) — no `devbox add`, no global pip
+- Fetcher deps: `yfinance`, `requests`, `beautifulsoup4`
+- Test deps: `pytest`, `requests-mock`
+- chezmoi for deployment, justfile/devbox for repo lint
+
+---
+
+## Spec reference
+
+[docs/superpowers/specs/2026-05-29-equity-decision-skill-design.md](../specs/2026-05-29-equity-decision-skill-design.md)
+
+## File map
+
+### Created files
+
+```
+dot_claude/skills/equity-decision/
+├── SKILL.md                          # entry, frontmatter, routing summary
+├── README.md                         # user-facing usage examples
+├── references/
+│   ├── equity-workflow.md            # 5 phase template (individual stock)
+│   ├── dcf-rubric.md                 # WACC, growth, terminal value defaults
+│   ├── growth-stock-checks.md        # SBC, NRR, Rule-of-40
+│   ├── risk-taxonomy.md              # 5 axes Debt/Competition/Regulation/Accounting/Concentration
+│   └── data-sources.md               # EDGAR / EDINET / Yahoo / Damodaran queries
+└── scripts/
+    ├── fetch_yahoo.py                # price + summary metrics via yfinance
+    ├── fetch_edgar.py                # latest 10-K / 10-Q from SEC EDGAR
+    ├── fetch_edinet.py               # 直近の有価証券報告書 from EDINET
+    └── industry_medians.py           # Damodaran industry medians (cached CSV)
+
+tests/skills/equity-decision/
+├── conftest.py                       # pytest fixtures: ticker symbols, mock responses
+├── test_fetch_yahoo.py
+├── test_fetch_edgar.py
+├── test_fetch_edinet.py
+└── run-tests.sh                      # wrapper: uv run pytest in this dir
+
+docs/superpowers/specs/2026-05-29-equity-decision-skill-design.md  # already exists
+docs/superpowers/plans/2026-05-29-equity-decision-skill.md         # this file
+```
+
+### Modified files
+
+- `justfile` — add a `test-skills` recipe that runs the pytest harness
+- (optional, end) `.github/workflows/ci.yml` if Python lint is desired
+
+---
+
+## Phase A: Skeleton (hand-fill workflow)
+
+End-state: Claude can be invoked as `/equity-decision NVDA`, will hand-fill the 5-phase template using web knowledge + any URL/PDF the user provides, no Python fetchers yet.
+
+### Task 1: Create the SKILL.md entry
+
+**Files:**
+- Create: `dot_claude/skills/equity-decision/SKILL.md`
+
+- [ ] **Step 1: Write SKILL.md with frontmatter and routing**
+
+```markdown
+---
+name: equity-decision
+description: |
+  Generate a 1-page purchase memo for a US or JP individual stock (ETF support in v1.1).
+  Walks 5 phases — business, fundamentals, valuation, risks, verdict — and ends with deep-dive options.
+  Use when (1) the user asks "should I buy <TICKER>?", (2) the user wants a fundamental review of a specific company, (3) the user pastes a 10-K / 有報 / IR URL and asks for an analysis. Skip for ETF / index / dividend-focused questions in v1.
+argument-hint: <TICKER or URL> [extra context]
+---
+
+# `equity-decision` skill
+
+Produces a structured purchase memo for an individual stock (US or JP). Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache 2.0); modified for retail use without paid data sources.
+
+> ⚠️ **Not investment advice.** Outputs are research summaries based on public filings and market data. Verify numbers against primary sources; the final decision is the user's.
+
+## Inputs
+
+| Form | Example | Routing |
+|---|---|---|
+| US ticker | `NVDA`, `AAPL` | `^[A-Z]{1,5}$` → EDGAR + Yahoo Finance |
+| JP code | `7203`, `9984` | `^\d{4}$` → EDINET + Yahoo Finance (Japan) |
+| URL | `https://www.sec.gov/.../10-K.htm` | Read page; infer symbol; route per above |
+| Mixed | `NVDA "DC 売上の頭打ちが気になる"` | Use the extra string as a hypothesis to test in Phase 5 |
+| Flag | `--ja 9434` | Force JP routing for ambiguous 4-digit |
+| Flag | `--no-cache NVDA` | Skip 24h cache, refetch |
+
+## Output
+
+A single markdown memo of 100–200 lines, matching `references/equity-workflow.md` exactly. After the memo, always append:
+
+```
+深掘りする？
+  1. valuation を変数いじって再計算 (WACC / terminal / 売上 CAGR)
+  2. risks #N をフィリングから根拠引用つきで再構成
+  3. 競合 X 社との指標横並び比較
+  4. 直近 3 四半期の earnings call 言及トピック差分
+  5. KPI モニタを 5 つに絞り込む
+```
+
+## Workflow
+
+1. Detect market from ticker (see Inputs).
+2. Read `references/equity-workflow.md` to load the 5-phase template.
+3. Run the fetchers in `scripts/` (Phase B+ only). For Phase A: ask the user for numbers, or have them paste a 10-K URL.
+4. Fill the memo template phase-by-phase. **If a number cannot be fetched or sourced, write "数字取得失敗 — manual entry required" — never make up a number.**
+5. Apply rubrics from `references/dcf-rubric.md`, `references/growth-stock-checks.md`, `references/risk-taxonomy.md`.
+6. Emit the memo, then the deep-dive menu.
+
+## Fail-loud rules
+
+- No hallucinated revenue / margin / multiples. If you can't source it, write "数字取得失敗".
+- No "approximately" or "around" numbers without citing the source filing.
+- DCF inputs (WACC, terminal growth) must be inside `references/dcf-rubric.md` guardrails or explicitly flagged.
+
+## Disclaimer
+
+This skill produces research summaries, not investment advice. Verify all numbers against primary filings before acting.
+```
+
+- [ ] **Step 2: Smoke-check the frontmatter parses**
+
+Run:
+```bash
+python3 -c "
+import yaml, sys
+with open('/Users/ryota/.local/share/chezmoi/dot_claude/skills/equity-decision/SKILL.md') as f:
+    text = f.read()
+assert text.startswith('---'), 'missing frontmatter'
+fm = text.split('---', 2)[1]
+parsed = yaml.safe_load(fm)
+assert parsed['name'] == 'equity-decision', f'name mismatch: {parsed}'
+assert 'description' in parsed and len(parsed['description']) > 50, 'description too short'
+print('OK:', parsed['name'])
+"
+```
+
+Expected: `OK: equity-decision`
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/ryota/.local/share/chezmoi
+git add dot_claude/skills/equity-decision/SKILL.md
+git commit -m "feat(skills): scaffold equity-decision SKILL.md"
+```
+
+---
+
+### Task 2: Write the individual-stock 5-phase workflow reference
+
+**Files:**
+- Create: `dot_claude/skills/equity-decision/references/equity-workflow.md`
+
+- [ ] **Step 1: Write the template**
+
+```markdown
+> Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache License 2.0).
+> Modified for retail use without paid data sources.
+
+# Individual Stock Workflow — 5 Phase Template
+
+When the skill is invoked with an individual stock ticker (US or JP), fill this exact template. Keep total output to 100–200 lines.
+
+## Template
+
+```markdown
+# {Company Name} ({TICKER}) — Purchase Memo
+*Generated: {YYYY-MM-DD} | Last close: {currency}{price} ({30d %} ↑↓)*
+
+> Research summary only — not investment advice.
+
+## 1. What they do
+
+{Two- or three-sentence business description, ≤80 chars per sentence}
+
+| Segment | % of revenue (FY{N}) | YoY growth |
+|---|---|---|
+| {Seg 1} | {%} | {%} |
+| {Seg 2} | {%} | {%} |
+| {Seg 3} | {%} | {%} |
+
+Customer concentration: {one line — top customer %, top-5 %, or "not disclosed"}
+
+## 2. Fundamentals (3y trend)
+
+| Metric | FY-2 | FY-1 | FY (TTM) | Comment |
+|---|---|---|---|---|
+| Revenue ({currency}) | … | … | … | CAGR {%} |
+| Gross / Operating / Net margin | … | … | … | {trend} |
+| FCF margin | … | … | … | {SBC-adjusted? yes/no} |
+| ROIC | … | … | … | {vs WACC} |
+| Net debt / EBITDA | … | … | … | {trend} |
+| Diluted share count Δ | … | … | … | {SBC dilution rate %} |
+
+## 3. Valuation
+
+**Multiples (vs sector median)**:
+
+| | This | Sector median | Gap |
+|---|---|---|---|
+| PER (TTM) | … | … | +{%} |
+| PSR | … | … | +{%} |
+| EV / EBITDA | … | … | +{%} |
+| EV / FCF | … | … | +{%} |
+
+**DCF (5y + terminal)** — guardrails per `dcf-rubric.md`:
+
+| Scenario | 売上 CAGR | Terminal g | WACC | Fair value / share |
+|---|---|---|---|---|
+| Bear | … | … | … | {currency}{value} |
+| Base | … | … | … | {currency}{value} |
+| Bull | … | … | … | {currency}{value} |
+
+→ Current {currency}{price} is in the **{bear/base/bull}** range. Upside +{%}, downside −{%}.
+
+## 4. Risks
+
+- 💰 **Debt**: {one line — net debt / EBITDA, refinancing schedule, covenants}
+- ⚔️ **Competition**: {one line — main rival(s), structural moat trend}
+- ⚖️ **Regulation / litigation**: {one line — pending probes, ongoing litigation cited in 10-K Item 3 / 有報 訴訟}
+- 📚 **Accounting / disclosure**: {one line — auditor change, restatements, SBC magnitude, working-capital tricks}
+- 🎯 **Customer concentration**: {one line — top customer share, single-product dependency}
+
+## 5. Verdict
+
+**Thesis (why buy now)**:
+1. {claim grounded in Phase 2 or 3 data}
+2. {claim}
+3. {claim}
+
+**Invalidation (these would break the thesis)**:
+1. {testable KPI — e.g., "Q3 で Data Center YoY が +30% を下回る"}
+2. {testable KPI}
+3. {testable KPI}
+
+**Verdict**: {Buy / Watch / Pass}
+**Suggested sizing**: {Small <2% / Medium 2–5% / Large >5%} of portfolio
+**Time horizon**: {6mo / 1–3y / 5y+}
+
+---
+
+深掘りする？
+  1. valuation を変数いじって再計算 (WACC / terminal / 売上 CAGR)
+  2. risks #N をフィリングから根拠引用つきで再構成
+  3. 競合 X 社との指標横並び比較
+  4. 直近 3 四半期の earnings call 言及トピック差分
+  5. KPI モニタを 5 つに絞り込む
+```
+
+## Filling rules
+
+- **Numbers must be sourced.** If a metric can't be pulled from a filing or Yahoo Finance, write `n/a — 数字取得失敗`. Never invent a number.
+- **Invalidation KPIs must be testable.** A line like "Macro turns sour" is invalid. A line like "Q3 で Data Center YoY が +30% を下回る" is valid.
+- **Thesis claims must reference data in earlier phases.** No claim should rely on information not shown in Phases 1–4.
+- **Verdict mapping**:
+  - **Buy**: thesis grounded, current price in bear or base range, no Tier-1 risks active
+  - **Watch**: thesis interesting but waiting on a catalyst or price → "what specifically would trigger?"
+  - **Pass**: thesis weak, valuation in bull range, or ≥1 unmitigated Tier-1 risk
+```
+
+- [ ] **Step 2: Quick lint — check the file is valid markdown with 5 numbered sections**
+
+Run:
+```bash
+grep -E "^## [1-5]\." /Users/ryota/.local/share/chezmoi/dot_claude/skills/equity-decision/references/equity-workflow.md
+```
+
+Expected: 5 lines matching `## 1.` through `## 5.`
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/ryota/.local/share/chezmoi
+git add dot_claude/skills/equity-decision/references/equity-workflow.md
+git commit -m "feat(skills): equity-decision 5-phase workflow template"
+```
+
+---
+
+### Task 3: Write the DCF rubric
+
+**Files:**
+- Create: `dot_claude/skills/equity-decision/references/dcf-rubric.md`
+
+- [ ] **Step 1: Write the rubric**
+
+```markdown
+> Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache License 2.0).
+> Modified for retail use without paid data sources.
+
+# DCF Rubric — Defaults and Guardrails
+
+Used by Phase 3 of `equity-workflow.md`. The skill produces a 3-scenario DCF (Bear / Base / Bull); each scenario must respect these guardrails.
+
+## Inputs and defaults
+
+| Input | Default | Guardrail |
+|---|---|---|
+| Forecast horizon | 5 years | Fixed |
+| Revenue CAGR (Bear / Base / Bull) | sector median × {0.5 / 1.0 / 1.5} | ±50% around base; cap at 30% even for hyper-growth |
+| Operating margin (steady state) | average of last 3y | ±5pp from history unless step-change argued |
+| Tax rate | 25% (US) / 30% (JP) | Override only if disclosed effective rate ≠ statutory ≥ 5pp |
+| WACC | 8% (US large-cap) / 7% (US tech) / 6% (JP large-cap) | ±2pp; cite source in memo if outside |
+| Terminal growth | 2.5% | Hard cap 3.5%; never exceed long-term GDP+1 |
+| Net debt | from latest 10-Q / 短信 | Use book value; flag if off-balance-sheet ≥ 10% of market cap |
+
+## Method (skill internal)
+
+1. Build 5-year revenue projection per scenario.
+2. Apply operating margin to derive EBIT; subtract tax → NOPAT.
+3. Add back D&A, subtract capex and working-capital changes → FCF.
+4. Discount each year's FCF at WACC.
+5. Terminal value = year-5 FCF × (1+g) / (WACC − g). Discount to PV.
+6. Sum → enterprise value. Subtract net debt → equity value. Divide by diluted shares → fair value/share.
+
+## Sanity checks (apply before emitting numbers)
+
+- **Bull < Base × 2.0**: if Bull/Base > 2.0, the bull scenario is unrealistic — tighten growth or margin assumption.
+- **Bear > Base × 0.4**: if Bear/Base < 0.4, the base case is fragile — recheck steady-state margin.
+- **All scenarios > current price**: usually means consensus is too pessimistic OR assumptions are too aggressive. Flag in the memo.
+- **All scenarios < current price**: market is pricing growth/option value the model doesn't capture. Note in Phase 5 Invalidation.
+
+## When to skip DCF
+
+- Companies with negative FCF for ≥3 years and no path to profitability → use rNPV, PSR, or "not valued" with reason.
+- Financials (banks / insurers): DCF on FCF is misleading; use dividend discount model or P/TBV instead.
+- Holding companies / SOTP candidates: use sum-of-the-parts; DCF would mask segment economics.
+
+If skipping, state which alternative was used and why.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/ryota/.local/share/chezmoi
+git add dot_claude/skills/equity-decision/references/dcf-rubric.md
+git commit -m "feat(skills): equity-decision DCF rubric with guardrails"
+```
+
+---
+
+### Task 4: Write growth-stock checks
+
+**Files:**
+- Create: `dot_claude/skills/equity-decision/references/growth-stock-checks.md`
+
+- [ ] **Step 1: Write the checks file**
+
+```markdown
+> Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache License 2.0).
+> Modified for retail use without paid data sources.
+
+# Growth Stock Checks
+
+Extra checks to run during Phase 2 (Fundamentals) when the company is high-growth (revenue CAGR > 20%) or tech / SaaS. Surface findings in the **Comment** column of the Fundamentals table or in Phase 4 Risks.
+
+## SBC (Stock-Based Compensation)
+
+- Compute **SBC / Revenue** and **SBC / FCF** for each of the last 3 years.
+- **Yellow flag**: SBC > 10% of revenue OR SBC > 50% of GAAP net income.
+- **Red flag**: SBC > 20% of revenue OR FCF goes negative when SBC is subtracted.
+- Always show **FCF — SBC** (the "real" cash flow to shareholders) in the memo alongside reported FCF.
+
+## Dilution
+
+- Compute **YoY growth in diluted share count**.
+- **Yellow flag**: >3% per year.
+- **Red flag**: >5% per year, or buybacks barely offsetting SBC.
+
+## Rule of 40 (SaaS)
+
+For SaaS or recurring-revenue businesses: **Revenue growth % + FCF margin % ≥ 40**.
+- Above 40 → healthy. Above 60 → exceptional.
+- Below 40 → either growth or profitability needs to improve.
+
+## NRR (Net Revenue Retention)
+
+If disclosed (most SaaS companies report it):
+- **<100%**: churn problem.
+- **100–110%**: stable.
+- **110–130%**: healthy land-and-expand.
+- **>130%**: best in class.
+
+## TAM Reality Check
+
+When the company quotes a TAM:
+- Is the TAM defined per-product or per-market-vertical? (Per-product is more credible.)
+- What's the **current penetration** (revenue / TAM)? At <5%, runway is real. At >25%, growth is decelerating soon.
+- Cross-check TAM against an independent estimate (e.g., a sector analyst report).
+
+## Working Capital Tricks
+
+Watch for revenue growth that doesn't translate to FCF:
+- DSO (Days Sales Outstanding) climbing year over year → channel stuffing or quality of revenue declining.
+- Inventory turns falling → product not selling through.
+- Deferred revenue declining despite reported growth → real growth slowing.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/ryota/.local/share/chezmoi
+git add dot_claude/skills/equity-decision/references/growth-stock-checks.md
+git commit -m "feat(skills): equity-decision growth-stock checks reference"
+```
+
+---
+
+### Task 5: Write the risk taxonomy
+
+**Files:**
+- Create: `dot_claude/skills/equity-decision/references/risk-taxonomy.md`
+
+- [ ] **Step 1: Write the file**
+
+```markdown
+> Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache License 2.0).
+> Modified for retail use without paid data sources.
+
+# Risk Taxonomy — 5 Axes
+
+Phase 4 of `equity-workflow.md` lists 5 risks. For each axis, the memo line states **whether the risk is materially active for this name today**, not generic warnings.
+
+## 1. 💰 Debt
+
+- **Active**: Net debt / EBITDA > 3.0×, OR upcoming refinancing > 20% of debt within 18 months, OR covenant headroom < 20%.
+- **Latent**: ratio rising but still < 3.0×.
+- **Inactive**: net cash, OR ratio < 1.5× with no near-term refinancing.
+
+Source: 10-K Item 7 (Liquidity), 10-Q balance sheet, 有報「財政状態」.
+
+## 2. ⚔️ Competition
+
+- **Active**: market share losing > 2pp/year, OR a credible new entrant disclosed (e.g., 10-K Item 1A, S-1 of a competitor) in the last 2 years.
+- **Latent**: moat narrowing but still dominant (>30% share); pricing power weakening.
+- **Inactive**: structural moat, market share stable or growing.
+
+Source: 10-K Item 1 (Business), Item 1A (Risk Factors), industry reports.
+
+## 3. ⚖️ Regulation / Litigation
+
+- **Active**: pending probe by a major regulator (DOJ, FTC, EU, JFTC), OR class action with damages claim > 5% of market cap, OR new rule (announced) that hits ≥10% of revenue.
+- **Latent**: industry under increasing scrutiny but no specific action.
+- **Inactive**: no disclosed material proceedings; regulation stable.
+
+Source: 10-K Item 3 (Legal Proceedings), 8-K material disclosures, 有報「訴訟事件等の概要」.
+
+## 4. 📚 Accounting / Disclosure
+
+- **Active**: auditor changed in the last 2 years (especially mid-cycle), OR restatement filed (8-K Item 4.02), OR going-concern paragraph, OR repeated material weakness in ICFR.
+- **Latent**: SBC > 20% of revenue, OR aggressive revenue recognition (long contracts, capitalized commissions ballooning), OR off-balance-sheet items > 10% of market cap.
+- **Inactive**: clean opinion, stable auditor, no flags.
+
+Source: 10-K Item 9A (ICFR), auditor's report, 有報「監査の状況」.
+
+## 5. 🎯 Customer / Product / Geographic Concentration
+
+- **Active**: top customer > 20% of revenue, OR top 3 customers > 50%, OR single product > 60% of revenue, OR single country > 70% with that country under political stress.
+- **Latent**: top customer 10–20%, OR single product / country between 50–70%.
+- **Inactive**: diversified across all three dimensions.
+
+Source: 10-K Item 1 (Customers), segment notes, 有報「販売の状況」.
+
+## How to write the memo line
+
+For each axis in Phase 4, write a single line in this shape:
+
+```
+{emoji} **{Axis}**: {Active/Latent/Inactive} — {specific reason with number}.
+```
+
+Examples:
+- `💰 **Debt**: Inactive — net cash $24B, no maturities < 24mo.`
+- `⚔️ **Competition**: Latent — Nvidia share holding ~80% datacenter GPU, AMD MI300 ramp + Intel Gaudi3 watch.`
+- `⚖️ **Regulation**: Active — China export controls on H100/H200 cut DC revenue ~15% in FY24.`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/ryota/.local/share/chezmoi
+git add dot_claude/skills/equity-decision/references/risk-taxonomy.md
+git commit -m "feat(skills): equity-decision risk taxonomy reference"
+```
+
+---
+
+### Task 6: Write the data-sources reference
+
+**Files:**
+- Create: `dot_claude/skills/equity-decision/references/data-sources.md`
+
+- [ ] **Step 1: Write the file**
+
+```markdown
+> Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache License 2.0).
+> Modified for retail use without paid data sources.
+
+# Data Sources
+
+Free, retail-accessible sources used by the skill. Each source includes the URL pattern, what's available, and known limits.
+
+## US Equities
+
+### SEC EDGAR
+
+- **Company ticker → CIK map** (one-time fetch, cache yearly):
+  `GET https://www.sec.gov/files/company_tickers.json`
+- **Latest filings index**: `GET https://data.sec.gov/submissions/CIK{cik_10digit}.json`
+- **Filing body**: assembled from the recent filings index (returns `accessionNumber`, `primaryDocument`):
+  `GET https://www.sec.gov/Archives/edgar/data/{cik}/{accession_no_dashes}/{primary_document}`
+- **User-Agent required**: SEC blocks requests without a UA. Use `User-Agent: <name> <email>`.
+- **Rate limit**: 10 requests/second across all SEC endpoints.
+
+Key forms:
+- `10-K`: annual report → Phase 1 (Item 1, 1A), Phase 4 (Item 1A, 3, 9A)
+- `10-Q`: quarterly → updated balance sheet for Phase 2
+- `8-K`: material events → check for Item 4.02 (restatements), Item 5.02 (auditor change)
+- `DEF 14A`: proxy → SBC and dilution details
+
+### Yahoo Finance (via `yfinance`)
+
+- Quote, summary, key statistics (PE, PSR, market cap, beta).
+- Historical price (5-year daily for `30d %` and CAGR calculations).
+- Quarterly and annual income statement, balance sheet, cash flow.
+- **Rate limit**: undocumented; treat as soft. Add 1s sleep between calls.
+- **Reliability**: API breaks occasionally. Use Stooq as fallback (Phase D).
+
+## JP Equities
+
+### EDINET
+
+- **Document list** (per date): `GET https://disclosure.edinet-fsa.go.jp/api/v2/documents.json?date=YYYY-MM-DD&type=2`
+- **Document body** (PDF or XBRL): `GET https://disclosure.edinet-fsa.go.jp/api/v2/documents/{docID}?type=2`
+- **No auth key required** (as of 2026); rate limit is unstated but conservative — keep to ≤1 RPS.
+- Filter by `docTypeCode`:
+  - `120` — 有価証券報告書 (annual)
+  - `140` — 四半期報告書 (quarterly)
+  - `160` — 半期報告書
+
+To find a 4-digit securities code → EDINET CIK (`edinetCode`): use the document listing's `secCode` field.
+
+### TDnet (適時開示)
+
+- Per-day index HTML: `https://www.release.tdnet.info/inbs/I_list_001_{YYYYMMDD}.html`
+- Use for 8-K-equivalent events (短信 release, M&A announcement, guidance revisions).
+- **Scraping** — fragile. Treat as best-effort.
+
+### Yahoo Finance Japan (via `yfinance`)
+
+- Tickers as `{code}.T` (e.g., `7203.T` for Toyota).
+- Same surface as US; slightly fewer historical data points.
+
+## Industry medians
+
+### NYU Damodaran
+
+- Annual update; CSV download URLs (cache for one year):
+  - `https://pages.stern.nyu.edu/~adamodar/New_Home_Page/datafile/pedata.html` (PE by sector)
+  - `https://pages.stern.nyu.edu/~adamodar/New_Home_Page/datafile/wacc.html` (WACC by sector)
+  - `https://pages.stern.nyu.edu/~adamodar/New_Home_Page/datafile/Betas.html` (betas)
+- For JP equities, use US sector as proxy unless Damodaran's `globalEquity` table covers the sector explicitly.
+
+## Cache
+
+- All sources cached at `~/.cache/equity-decision/{source}-{ticker}-{YYYY-MM-DD}.json`
+- TTL 24h for prices and recent filings; 1 year for Damodaran tables.
+- `--no-cache` flag forces refetch.
+
+## Failure behaviour
+
+- Network error → 1 retry → write "数字取得失敗 — manual entry required" in the memo. Never hallucinate.
+- Symbol resolution fails → state which lookup failed (e.g., "EDGAR ticker→CIK miss for XYZ").
+- HTTP 429 → exponential backoff (2s, 4s, 8s) up to 3 attempts.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/ryota/.local/share/chezmoi
+git add dot_claude/skills/equity-decision/references/data-sources.md
+git commit -m "feat(skills): equity-decision data-sources reference"
+```
+
+---
+
+### Task 7: Write the user-facing README
+
+**Files:**
+- Create: `dot_claude/skills/equity-decision/README.md`
+
+- [ ] **Step 1: Write the README**
+
+```markdown
+# equity-decision
+
+A Claude Code skill that produces a structured purchase memo for an individual stock (US or JP). Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache 2.0); reworked for retail use against free public data.
+
+> Not investment advice. Outputs are research summaries.
+
+## Quick start
+
+```
+/equity-decision NVDA                                # US ticker
+/equity-decision 7203                                # JP code (Toyota)
+/equity-decision NVDA "DC growth slowing"            # ticker + hypothesis
+/equity-decision https://www.sec.gov/.../10-K.htm    # URL
+/equity-decision --ja 9434                           # Force JP routing
+/equity-decision --no-cache NVDA                     # Skip 24h cache
+```
+
+The skill emits a 100–200 line memo covering business, fundamentals (3-year trend), valuation (multiples + DCF), risks (5 axes), and a verdict (Buy/Watch/Pass + sizing + horizon). The memo ends with five deep-dive options you can pick from in the next turn.
+
+## What's in scope (v1)
+
+- US individual stocks (10-K / 10-Q / 8-K via SEC EDGAR + Yahoo Finance)
+- JP individual stocks (有価証券報告書 via EDINET + Yahoo Finance Japan)
+
+## What's not in scope (v1)
+
+- ETF / index funds → coming in v1.1
+- Dividend-focused screens (yield + payout ratio + coverage) — different rubric
+- Crypto, commodities, individual bonds
+- Hong Kong / Shanghai / European listings
+- Tax optimization (NISA balance, foreign tax credit) — needs personal account data
+
+## Files
+
+```
+SKILL.md                       # skill entry, routing, output rules
+references/equity-workflow.md  # the 5-phase template (this is what gets filled)
+references/dcf-rubric.md       # WACC / growth / terminal defaults & guardrails
+references/growth-stock-checks.md  # SBC, NRR, Rule of 40
+references/risk-taxonomy.md    # 5 axes Active/Latent/Inactive scoring
+references/data-sources.md     # EDGAR / EDINET / Yahoo / Damodaran query notes
+scripts/fetch_yahoo.py         # `uv run scripts/fetch_yahoo.py NVDA`
+scripts/fetch_edgar.py         # `uv run scripts/fetch_edgar.py NVDA`
+scripts/fetch_edinet.py        # `uv run scripts/fetch_edinet.py 7203`
+scripts/industry_medians.py    # `uv run scripts/industry_medians.py software`
+```
+
+## Smoke-test the fetchers
+
+After Phase B is in:
+
+```bash
+cd ~/.claude/skills/equity-decision
+uv run scripts/fetch_yahoo.py NVDA  | jq '.summary'
+uv run scripts/fetch_edgar.py NVDA  | jq '.filings[0]'
+uv run scripts/fetch_edinet.py 7203 | jq '.docs[0]'
+```
+
+Expected: each returns a JSON object with the documented shape (see each script's docstring).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/ryota/.local/share/chezmoi
+git add dot_claude/skills/equity-decision/README.md
+git commit -m "docs(skills): equity-decision user-facing README"
+```
+
+---
+
+### Task 8: Phase A end-to-end manual smoke test
+
+This is a manual step — no automated test, just a check that Claude can use the skill as-is to produce a usable memo.
+
+- [ ] **Step 1: chezmoi apply (with user confirmation)**
+
+Confirm with user first (per chezmoi rule). Then:
+```bash
+chezmoi diff | head -50
+# user reviews
+chezmoi apply --force
+ls ~/.claude/skills/equity-decision/   # expect: SKILL.md, README.md, references/
+```
+
+- [ ] **Step 2: Restart Claude Code or invoke skill detection**
+
+Open a new Claude Code session in any project. Confirm `/equity-decision` is listed.
+
+- [ ] **Step 3: Run the smoke test**
+
+In the new session:
+```
+/equity-decision NVDA
+```
+
+Expected:
+- Claude reads `references/equity-workflow.md`
+- Asks the user (or attempts to recall from training) for numbers since no fetchers yet
+- Emits a memo following the 5-phase structure
+- Ends with the "深掘りする？" menu
+
+If Claude invents numbers without flagging, the SKILL.md hallucination rule isn't strong enough — return to Task 1 and tighten the wording.
+
+- [ ] **Step 4: Tag the commit (optional but useful)**
+
+```bash
+cd /Users/ryota/.local/share/chezmoi
+git tag equity-decision-v1.0-phase-a -m "Phase A: skeleton, hand-fill workflow"
+```
+
+---
+
+## Phase B: Fetchers
+
+End-state: `/equity-decision NVDA` runs `scripts/fetch_yahoo.py NVDA` (and EDGAR / EDINET as appropriate), pulls live data, and fills the memo automatically.
+
+### Task 9: Add a pytest harness under tests/skills
+
+**Files:**
+- Create: `tests/skills/equity-decision/conftest.py`
+- Create: `tests/skills/equity-decision/run-tests.sh`
+- Modify: `justfile` (add `test-skills` recipe)
+
+- [ ] **Step 1: Create the conftest**
+
+`tests/skills/equity-decision/conftest.py`:
+```python
+"""Shared fixtures for equity-decision fetcher tests."""
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[3] / "dot_claude" / "skills" / "equity-decision" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+@pytest.fixture
+def us_tickers() -> list[str]:
+    return ["NVDA", "AAPL"]
+
+
+@pytest.fixture
+def jp_tickers() -> list[str]:
+    return ["7203", "9984"]
+```
+
+- [ ] **Step 2: Create the runner script**
+
+`tests/skills/equity-decision/run-tests.sh`:
+```bash
+#!/usr/bin/env bash
+# Test runner for dot_claude/skills/equity-decision/scripts/*.py
+# Runs all pytest tests in this directory using `uv run`.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+uv run --with pytest --with requests-mock --with yfinance --with beautifulsoup4 \
+  python -m pytest -v --tb=short
+```
+
+- [ ] **Step 3: Add `test-skills` recipe to justfile**
+
+In `justfile`, append:
+```makefile
+# Run skill fetcher tests
+test-skills:
+    bash tests/skills/equity-decision/run-tests.sh
+```
+
+- [ ] **Step 4: Verify the harness wires up (no tests yet, no assertions)**
+
+Create an empty `tests/skills/equity-decision/test_smoke.py`:
+```python
+def test_harness_loads():
+    """Trivial: confirms pytest can be invoked via the runner."""
+    assert True
+```
+
+Run:
+```bash
+cd /Users/ryota/.local/share/chezmoi
+just test-skills
+```
+
+Expected: `1 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/skills/equity-decision/conftest.py tests/skills/equity-decision/run-tests.sh tests/skills/equity-decision/test_smoke.py justfile
+git commit -m "test(skills): add pytest harness for equity-decision fetchers"
+```
+
+---
+
+### Task 10: `fetch_yahoo.py` — write the failing test
+
+**Files:**
+- Create: `tests/skills/equity-decision/test_fetch_yahoo.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Tests for scripts/fetch_yahoo.py.
+
+The script's contract:
+- argv[1] is the ticker (US: AAPL; JP: 7203 — auto-suffixed .T inside the script)
+- prints JSON to stdout with shape: {ticker, market, price, summary: {pe, psr, marketCap, ...}, financials: {...}}
+- exits 0 on success, 1 on hard failure (network, unknown ticker)
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / "dot_claude" / "skills" / "equity-decision" / "scripts" / "fetch_yahoo.py"
+
+
+def run_script(*args: str) -> dict:
+    """Run the script via uv run, return parsed JSON or raise."""
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"script exited {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}")
+    return json.loads(result.stdout)
+
+
+def test_us_ticker_returns_expected_shape():
+    data = run_script("AAPL")
+    assert data["ticker"] == "AAPL"
+    assert data["market"] == "US"
+    assert isinstance(data["price"], (int, float))
+    assert data["price"] > 0
+    assert "pe" in data["summary"]
+    assert "marketCap" in data["summary"]
+
+
+def test_jp_ticker_auto_suffix():
+    data = run_script("7203")
+    assert data["ticker"] == "7203"
+    assert data["market"] == "JP"
+    assert data["price"] > 0
+    assert "pe" in data["summary"]
+
+
+def test_unknown_ticker_exits_nonzero():
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), "ZZZNOTAREALTICKER"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "数字取得失敗" in result.stderr or "not found" in result.stderr.lower()
+```
+
+- [ ] **Step 2: Run the test, confirm it fails (Red)**
+
+```bash
+cd /Users/ryota/.local/share/chezmoi
+just test-skills
+```
+
+Expected: `3 failed` (script doesn't exist yet).
+
+---
+
+### Task 11: `fetch_yahoo.py` — implement and pass
+
+**Files:**
+- Create: `dot_claude/skills/equity-decision/scripts/fetch_yahoo.py`
+
+- [ ] **Step 1: Implement**
+
+```python
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "yfinance>=0.2.40",
+# ]
+# ///
+"""fetch_yahoo.py — Yahoo Finance quote + summary metrics for a ticker.
+
+Usage:
+    uv run fetch_yahoo.py <TICKER>
+
+Examples:
+    uv run fetch_yahoo.py NVDA   # US
+    uv run fetch_yahoo.py 7203   # JP (auto .T suffix)
+
+Output (stdout, JSON):
+    {
+      "ticker": "AAPL",
+      "market": "US",
+      "price": 192.34,
+      "summary": {
+        "pe": 31.2,
+        "psr": 8.1,
+        "marketCap": 3000000000000,
+        "beta": 1.25,
+        "dividendYield": 0.005
+      },
+      "financials": {
+        "revenue_ttm": 385000000000,
+        "operatingIncome_ttm": 120000000000,
+        "freeCashFlow_ttm": 100000000000
+      }
+    }
+
+Exits 1 with a message on stderr if the ticker is unknown or fetch fails.
+"""
+import json
+import re
+import sys
+
+import yfinance as yf
+
+
+def detect_market(raw_ticker: str) -> tuple[str, str]:
+    """Return (yahoo_symbol, market_label)."""
+    if re.fullmatch(r"\d{4}", raw_ticker):
+        return f"{raw_ticker}.T", "JP"
+    return raw_ticker.upper(), "US"
+
+
+def fetch_summary(raw_ticker: str) -> dict:
+    yahoo_symbol, market = detect_market(raw_ticker)
+    ticker = yf.Ticker(yahoo_symbol)
+    info = ticker.info or {}
+
+    if not info or not info.get("regularMarketPrice"):
+        raise ValueError(f"数字取得失敗: ticker {raw_ticker!r} not found on Yahoo Finance")
+
+    return {
+        "ticker": raw_ticker,
+        "market": market,
+        "price": info.get("regularMarketPrice"),
+        "summary": {
+            "pe": info.get("trailingPE"),
+            "psr": info.get("priceToSalesTrailing12Months"),
+            "marketCap": info.get("marketCap"),
+            "beta": info.get("beta"),
+            "dividendYield": info.get("dividendYield"),
+        },
+        "financials": {
+            "revenue_ttm": info.get("totalRevenue"),
+            "operatingIncome_ttm": info.get("ebitda"),  # closest proxy in info dict
+            "freeCashFlow_ttm": info.get("freeCashflow"),
+        },
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: fetch_yahoo.py <TICKER>", file=sys.stderr)
+        return 2
+    try:
+        data = fetch_summary(sys.argv[1])
+    except Exception as e:
+        print(f"数字取得失敗: {e}", file=sys.stderr)
+        return 1
+    json.dump(data, sys.stdout, ensure_ascii=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Run the test, confirm it passes (Green)**
+
+```bash
+cd /Users/ryota/.local/share/chezmoi
+just test-skills
+```
+
+Expected: `3 passed`. (Note: network-dependent; if Yahoo is throttled, the tests may flake. Re-run once.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dot_claude/skills/equity-decision/scripts/fetch_yahoo.py tests/skills/equity-decision/test_fetch_yahoo.py
+git commit -m "feat(skills): fetch_yahoo.py — Yahoo Finance quote/summary fetcher"
+```
+
+---
+
+### Task 12: `fetch_edgar.py` — write the failing test
+
+**Files:**
+- Create: `tests/skills/equity-decision/test_fetch_edgar.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Tests for scripts/fetch_edgar.py.
+
+Contract:
+- argv[1] is the US ticker
+- prints JSON with shape: {ticker, cik, filings: [{form, filedDate, accessionNumber, primaryDocument, url}]}
+- only the latest 10-K, 10-Q, and most recent 8-Ks (top 5) need be returned
+- exits 1 on unknown ticker
+"""
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / "dot_claude" / "skills" / "equity-decision" / "scripts" / "fetch_edgar.py"
+
+
+def run_script(*args: str) -> dict:
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"script exited {result.returncode}\nstderr: {result.stderr}")
+    return json.loads(result.stdout)
+
+
+def test_known_us_ticker_returns_filings():
+    data = run_script("AAPL")
+    assert data["ticker"] == "AAPL"
+    assert data["cik"].isdigit() and len(data["cik"]) <= 10
+    assert isinstance(data["filings"], list) and len(data["filings"]) > 0
+    forms = {f["form"] for f in data["filings"]}
+    assert "10-K" in forms, f"no 10-K in filings: {forms}"
+
+
+def test_unknown_ticker_exits_nonzero():
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), "ZZZNOTAREALTICKER"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "数字取得失敗" in result.stderr or "not found" in result.stderr.lower()
+```
+
+- [ ] **Step 2: Run, confirm fail (Red)**
+
+```bash
+just test-skills
+```
+
+Expected: `2 failed`.
+
+---
+
+### Task 13: `fetch_edgar.py` — implement and pass
+
+**Files:**
+- Create: `dot_claude/skills/equity-decision/scripts/fetch_edgar.py`
+
+- [ ] **Step 1: Implement**
+
+```python
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "requests>=2.31",
+# ]
+# ///
+"""fetch_edgar.py — SEC EDGAR filings for a US ticker.
+
+Usage:
+    uv run fetch_edgar.py <TICKER>
+
+Output (stdout, JSON):
+    {
+      "ticker": "AAPL",
+      "cik": "320193",
+      "filings": [
+        {"form": "10-K", "filedDate": "2024-11-01", "accessionNumber": "...", "primaryDocument": "aapl-20240928.htm", "url": "https://www.sec.gov/..."},
+        {"form": "10-Q", ...},
+        {"form": "8-K", ...},
+        ...
+      ]
+    }
+
+Returns the most recent 10-K, most recent 10-Q, and top-5 most recent 8-Ks.
+Exits 1 if ticker → CIK lookup fails or network errors.
+"""
+import json
+import sys
+
+import requests
+
+UA = "equity-decision-skill (pavegy@gmail.com)"
+TICKER_MAP_URL = "https://www.sec.gov/files/company_tickers.json"
+
+
+def lookup_cik(ticker: str) -> str:
+    """Return zero-padded 10-digit CIK for a US ticker."""
+    r = requests.get(TICKER_MAP_URL, headers={"User-Agent": UA}, timeout=10)
+    r.raise_for_status()
+    rows = r.json().values()
+    upper = ticker.upper()
+    for row in rows:
+        if row["ticker"].upper() == upper:
+            return str(row["cik_str"]).zfill(10)
+    raise ValueError(f"数字取得失敗: EDGAR ticker→CIK miss for {ticker!r}")
+
+
+def fetch_filings(ticker: str) -> dict:
+    cik_padded = lookup_cik(ticker)
+    cik = cik_padded.lstrip("0") or "0"
+    submissions_url = f"https://data.sec.gov/submissions/CIK{cik_padded}.json"
+    r = requests.get(submissions_url, headers={"User-Agent": UA}, timeout=15)
+    r.raise_for_status()
+    payload = r.json()
+
+    recent = payload["filings"]["recent"]
+    rows = list(zip(
+        recent["form"],
+        recent["filingDate"],
+        recent["accessionNumber"],
+        recent["primaryDocument"],
+    ))
+
+    selected = []
+    forms_seen = {"10-K": 0, "10-Q": 0, "8-K": 0}
+    for form, filed, accession, prim in rows:
+        if form == "10-K" and forms_seen["10-K"] == 0:
+            forms_seen["10-K"] += 1
+        elif form == "10-Q" and forms_seen["10-Q"] == 0:
+            forms_seen["10-Q"] += 1
+        elif form == "8-K" and forms_seen["8-K"] < 5:
+            forms_seen["8-K"] += 1
+        else:
+            continue
+        acc_clean = accession.replace("-", "")
+        selected.append({
+            "form": form,
+            "filedDate": filed,
+            "accessionNumber": accession,
+            "primaryDocument": prim,
+            "url": f"https://www.sec.gov/Archives/edgar/data/{cik}/{acc_clean}/{prim}",
+        })
+        if all(v >= (1 if k != "8-K" else 5) for k, v in forms_seen.items()):
+            break
+
+    return {"ticker": ticker.upper(), "cik": cik, "filings": selected}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: fetch_edgar.py <TICKER>", file=sys.stderr)
+        return 2
+    try:
+        data = fetch_filings(sys.argv[1])
+    except Exception as e:
+        print(f"数字取得失敗: {e}", file=sys.stderr)
+        return 1
+    json.dump(data, sys.stdout, ensure_ascii=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Run, confirm pass (Green)**
+
+```bash
+just test-skills
+```
+
+Expected: `5 passed` (3 yahoo + 2 edgar).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dot_claude/skills/equity-decision/scripts/fetch_edgar.py tests/skills/equity-decision/test_fetch_edgar.py
+git commit -m "feat(skills): fetch_edgar.py — SEC EDGAR filings fetcher"
+```
+
+---
+
+### Task 14: `fetch_edinet.py` — write the failing test
+
+**Files:**
+- Create: `tests/skills/equity-decision/test_fetch_edinet.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Tests for scripts/fetch_edinet.py.
+
+Contract:
+- argv[1] is a 4-digit JP securities code (e.g., 7203)
+- prints JSON with shape: {ticker, edinetCode, docs: [{docTypeCode, docDescription, submitDateTime, docID, url}]}
+- returns the most recent 有価証券報告書 (docTypeCode "120") and most recent 四半期報告書 (docTypeCode "140")
+- exits 1 on unknown code or network failure
+"""
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / "dot_claude" / "skills" / "equity-decision" / "scripts" / "fetch_edinet.py"
+
+
+def run_script(*args: str) -> dict:
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"script exited {result.returncode}\nstderr: {result.stderr}")
+    return json.loads(result.stdout)
+
+
+def test_toyota_returns_yuho():
+    data = run_script("7203")
+    assert data["ticker"] == "7203"
+    assert data["edinetCode"].startswith("E"), f"edinetCode shape: {data['edinetCode']}"
+    docs = data["docs"]
+    type_codes = {d["docTypeCode"] for d in docs}
+    assert "120" in type_codes, f"no 有報 returned: {type_codes}"
+
+
+def test_unknown_code_exits_nonzero():
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), "0000"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode != 0
+    assert "数字取得失敗" in result.stderr
+```
+
+- [ ] **Step 2: Run, confirm fail (Red)**
+
+```bash
+just test-skills
+```
+
+Expected: `2 failed`.
+
+---
+
+### Task 15: `fetch_edinet.py` — implement and pass
+
+**Files:**
+- Create: `dot_claude/skills/equity-decision/scripts/fetch_edinet.py`
+
+- [ ] **Step 1: Implement**
+
+```python
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "requests>=2.31",
+# ]
+# ///
+"""fetch_edinet.py — EDINET filings for a 4-digit JP securities code.
+
+Usage:
+    uv run fetch_edinet.py <CODE>
+
+Output (stdout, JSON):
+    {
+      "ticker": "7203",
+      "edinetCode": "E02144",
+      "docs": [
+        {"docTypeCode": "120", "docDescription": "有価証券報告書", "submitDateTime": "...", "docID": "S100...", "url": "https://disclosure..."},
+        {"docTypeCode": "140", ...}
+      ]
+    }
+
+Walks back up to 400 calendar days to find the most recent 有報 (docTypeCode 120)
+and 四半期報告書 (140) matching the secCode.
+Exits 1 on unknown code or network failure.
+"""
+import datetime as dt
+import json
+import sys
+import time
+from typing import Iterator
+
+import requests
+
+API = "https://disclosure.edinet-fsa.go.jp/api/v2/documents.json"
+TARGET_TYPES = ("120", "140")  # 有報, 四半期報告書
+MAX_DAYS_BACK = 400
+
+
+def iter_days(start: dt.date, days: int) -> Iterator[dt.date]:
+    for i in range(days):
+        yield start - dt.timedelta(days=i)
+
+
+def fetch_docs(sec_code: str) -> dict:
+    code_padded = sec_code.zfill(4) + "0"  # EDINET secCode is 5-digit (4-digit + trailing 0)
+    today = dt.date.today()
+    found: dict[str, dict] = {}
+    edinet_code = None
+
+    for day in iter_days(today, MAX_DAYS_BACK):
+        if all(t in found for t in TARGET_TYPES):
+            break
+        params = {"date": day.isoformat(), "type": "2"}
+        r = requests.get(API, params=params, timeout=15)
+        if r.status_code != 200:
+            time.sleep(1.0)
+            continue
+        for item in r.json().get("results", []):
+            if item.get("secCode") != code_padded:
+                continue
+            edinet_code = edinet_code or item.get("edinetCode")
+            t = item.get("docTypeCode")
+            if t in TARGET_TYPES and t not in found:
+                found[t] = {
+                    "docTypeCode": t,
+                    "docDescription": item.get("docDescription"),
+                    "submitDateTime": item.get("submitDateTime"),
+                    "docID": item.get("docID"),
+                    "url": f"https://disclosure.edinet-fsa.go.jp/api/v2/documents/{item['docID']}?type=2",
+                }
+        time.sleep(0.3)
+
+    if not edinet_code:
+        raise ValueError(f"数字取得失敗: EDINET secCode→edinetCode miss for {sec_code!r}")
+
+    return {
+        "ticker": sec_code,
+        "edinetCode": edinet_code,
+        "docs": [found[t] for t in TARGET_TYPES if t in found],
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: fetch_edinet.py <4-digit-secCode>", file=sys.stderr)
+        return 2
+    try:
+        data = fetch_docs(sys.argv[1])
+    except Exception as e:
+        print(f"数字取得失敗: {e}", file=sys.stderr)
+        return 1
+    json.dump(data, sys.stdout, ensure_ascii=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Run, confirm pass (Green)**
+
+```bash
+just test-skills
+```
+
+Expected: `7 passed`. Note: EDINET tests are slow (walking days backward); test_toyota may take 30-60s.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dot_claude/skills/equity-decision/scripts/fetch_edinet.py tests/skills/equity-decision/test_fetch_edinet.py
+git commit -m "feat(skills): fetch_edinet.py — EDINET 有報/短信 fetcher"
+```
+
+---
+
+### Task 16: Update SKILL.md to reference the fetchers
+
+**Files:**
+- Modify: `dot_claude/skills/equity-decision/SKILL.md`
+
+- [ ] **Step 1: Add a "Data fetchers" section after "## Workflow"**
+
+Find:
+```markdown
+## Fail-loud rules
+```
+
+Insert before it:
+```markdown
+## Data fetchers
+
+Run these from `~/.claude/skills/equity-decision/scripts/` via `uv run`:
+
+| When | Command | Returns |
+|---|---|---|
+| US ticker → price + multiples | `uv run scripts/fetch_yahoo.py NVDA` | quote, PE/PSR, market cap, TTM revenue/FCF |
+| US ticker → recent filings | `uv run scripts/fetch_edgar.py NVDA` | latest 10-K, 10-Q, 5 × 8-K (with URLs) |
+| JP ticker → price + multiples | `uv run scripts/fetch_yahoo.py 7203` | same shape, auto `.T` suffix |
+| JP code → EDINET filings | `uv run scripts/fetch_edinet.py 7203` | latest 有報 + 四半期報告書 (with URLs) |
+
+Each script outputs JSON to stdout. On failure, exit code is non-zero and stderr contains "数字取得失敗: ..." — propagate that text into the memo, do not invent numbers.
+
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add dot_claude/skills/equity-decision/SKILL.md
+git commit -m "feat(skills): SKILL.md links to data fetchers"
+```
+
+---
+
+### Task 17: End-to-end smoke test with real data
+
+- [ ] **Step 1: chezmoi apply (with user confirmation)**
+
+```bash
+cd /Users/ryota/.local/share/chezmoi
+chezmoi diff | head -50      # user reviews
+chezmoi apply --force
+```
+
+- [ ] **Step 2: Smoke test each fetcher from the deployed location**
+
+```bash
+cd ~/.claude/skills/equity-decision
+uv run scripts/fetch_yahoo.py NVDA  | jq '.ticker, .price, .summary.pe'
+uv run scripts/fetch_yahoo.py 7203  | jq '.ticker, .price, .summary.pe'
+uv run scripts/fetch_edgar.py NVDA  | jq '.filings | map(.form)'
+uv run scripts/fetch_edinet.py 7203 | jq '.docs | map(.docTypeCode)'
+```
+
+Expected:
+- Yahoo: a valid price and PE for both tickers
+- EDGAR: a list including at least "10-K" and "10-Q"
+- EDINET: a list including "120" (有報)
+
+If any returns "数字取得失敗", debug that fetcher before moving on.
+
+- [ ] **Step 3: End-to-end skill invocation**
+
+In a new Claude Code session:
+```
+/equity-decision NVDA
+```
+
+Expected: Claude runs the fetchers via Bash, fills the 5-phase memo with real numbers, ends with the 深掘りする？ menu.
+
+If Claude doesn't use the fetchers automatically, tighten the workflow in SKILL.md (Task 1 / Task 16) to instruct fetcher invocation explicitly.
+
+- [ ] **Step 4: Tag**
+
+```bash
+cd /Users/ryota/.local/share/chezmoi
+git tag equity-decision-v1.0 -m "v1: Phase A + Phase B, US + JP individual stocks"
+```
+
+---
+
+## Self-review checklist (done while writing this plan)
+
+- [x] **Spec coverage**: every requirement in the spec is mapped to a task above.
+  - Skill structure (Section 1) → Task 1 (SKILL.md), Task 7 (README), Phase A workflow tasks
+  - Individual stock 5-phase workflow (Section 2) → Task 2 (equity-workflow.md), Tasks 3–5 (rubrics)
+  - ETF 4-phase workflow (Section 3) → out of scope for v1, noted in plan header
+  - Output format (Section 4) → Task 2 (template) and Task 16 (fetcher hook)
+  - Data sources (Section 5) → Task 6 (reference) + Tasks 11/13/15 (fetchers)
+  - Phasing (Section 6) → Phase A = Tasks 1–8, Phase B = Tasks 9–17
+  - Done criteria #1–8 → satisfied by Tasks 8 (Phase A smoke) + 17 (Phase B smoke)
+- [x] **Placeholder scan**: no TBD / TODO / "add error handling" / "similar to" left in the plan.
+- [x] **Type consistency**: fetcher JSON shapes are documented in each test file's docstring and matched in each implementation's docstring. `数字取得失敗` is the consistent failure marker across fetchers, tests, and SKILL.md.
+
+---
+
+## Execution
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-29-equity-decision-skill.md`.
+
+Two execution options:
+
+1. **Subagent-Driven (recommended)** — one fresh subagent per task, two-stage review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-29-equity-decision-skill-design.md
+++ b/docs/superpowers/specs/2026-05-29-equity-decision-skill-design.md
@@ -1,0 +1,197 @@
+# Spec: `equity-decision` skill
+
+**Status**: Approved (brainstorming complete)
+**Date**: 2026-05-29
+**Author**: Ryota (with Claude)
+**Skill location**: `~/.local/share/chezmoi/dot_claude/skills/equity-decision/`
+**Origin**: Adapted from [`anthropics/financial-services`](https://github.com/anthropics/financial-services) (Apache 2.0)
+
+## Problem
+
+個人投資 (主に米株 + 日本株 + ETF / インデックス) の購入判断で時間を食う 4 ステップ — ファンダ読解 / バリュエーション妥当性 / リスク洗い出し / 論点整理 — を 1 コマンドで一気通貫させたい。長期保有・成長株・イベントドリブンの 3 スタイルをまたぐ。配当 / インカム重視は対象外。
+
+## Non-goals
+
+- 法的・税務的な投資助言ではない。出力にディスクレーマー記載必須
+- 香港・上海・欧州・暗号通貨・商品・個別債券は対象外
+- 自動ウォッチリスト / アラート / cron は別 skill / 別 issue
+- 既存ポートフォリオ管理ツールとの統合
+- ガイダンス / コンセンサス予想の取得 (paid data の世界)
+
+## Approach
+
+**Approach C (一発 + 深掘りポート)** を採用。
+初手レポートで全 phase の要点を 1 画面サマリで出す。末尾に「深掘りする？」5 件を提示し、必要なものだけ追加ターンで掘る。
+
+理由: A (対話的 walkthrough) は判断スピード優先に逆行、B (一発レポート) は何が決定打だったか見えにくく token も食う。C は速度と詳細掘りの折衷で最も「判断を簡単にする」要件にフィット。
+
+## Architecture
+
+### 呼び出しインタフェース
+
+```
+/equity-decision NVDA
+/equity-decision 7203                                # JP 4-digit
+/equity-decision VTI                                  # ETF
+/equity-decision NVDA "DC 売上の頭打ちが気になる"      # ticker + 仮説
+/equity-decision https://www.sec.gov/.../10-K.htm     # URL 直渡し
+/equity-decision --ja 9434                            # 強制 JP 指定
+/equity-decision --no-cache NVDA                      # 強制再フェッチ
+```
+
+### ルーティング
+
+- `^\d{4}$` → JP (EDINET + 決算短信)
+- `^[A-Z]{1,5}$` → US (EDGAR + Yahoo Finance)
+- URL → ページ内容からシンボル類推
+- ETF / 個別株: `yfinance` の `quoteType` で判定 (ETF / MUTUALFUND vs EQUITY)
+
+### ディレクトリ構成
+
+```
+dot_claude/skills/equity-decision/
+├── SKILL.md                    # エントリ、ルーティング、出力テンプレ参照
+├── README.md                   # ユーザ向け使用例
+├── references/
+│   ├── equity-workflow.md      # 個別株 5 phase 詳細
+│   ├── etf-workflow.md         # ETF 4 phase 詳細
+│   ├── dcf-rubric.md           # WACC・成長率・terminal value の既定値 / ガード
+│   ├── growth-stock-checks.md  # SBC, NRR, Rule-of-40 等
+│   ├── risk-taxonomy.md        # 5 軸 (Debt / Competition / Regulation / Accounting / Concentration)
+│   └── data-sources.md         # EDGAR / EDINET / Yahoo / Damodaran クエリ集
+└── scripts/
+    ├── fetch_yahoo.py          # yfinance ラッパー: stdout に JSON
+    ├── fetch_edgar.py          # SEC EDGAR submissions API
+    ├── fetch_edinet.py         # EDINET 書類取得 API
+    ├── fetch_holdings.py       # ETF holdings CSV (運用会社別 URL 解決)
+    └── industry_medians.py     # Damodaran 公開データ
+```
+
+## 個別株 workflow (5 phase)
+
+`/equity-decision NVDA` を叩いた初手レポートが必ず含む 5 phase + 上限。
+
+| Phase | 中身 | 上限 | データ源 |
+|---|---|---|---|
+| 1. Business snapshot | 事業 3 行 + セグメント売上比率 + 主要顧客集中度 | 80 字 + 表 | 10-K Item 1 / 有報 / 短信 |
+| 2. Fundamentals (3y) | 売上成長率, GP/OP/NP, FCF margin, ROIC, ND/EBITDA, 希薄化 | 表 1 個 | Yahoo + 直近 10-K/10-Q |
+| 3. Valuation triangulation | (a) Multiples (PER/PSR/EV-EBITDA/EV-FCF) vs 業種中央値, (b) DCF 簡易版 3 シナリオ | レンジ + 一言 | Yahoo + Damodaran |
+| 4. Risks (5 軸スキャン) | Debt / Competition / Regulation / Accounting / Concentration を各 1 行 | 5 行 | 10-K Item 1A / 有報 |
+| 5. Verdict | Thesis 3 行 + Invalidation KPI 3 件 + Verdict (Buy/Watch/Pass) + Sizing + Horizon | 150 字 | 上記合成 |
+
+末尾固定:
+```
+深掘りする？
+  1. valuation を変数いじって再計算 (WACC / terminal / 売上 CAGR)
+  2. risks #N をフィリングから根拠引用つきで再構成
+  3. 競合 X 社との指標横並び比較
+  4. 直近 3 四半期の earnings call 言及トピック差分
+  5. KPI モニタを 5 つに絞り込む
+```
+
+### Phase 5 — Invalidation の縛り
+
+崩壊条件は **検証可能な数字 KPI** に縛る。「市場が悪くなったら」のような曖昧な記述は不可。
+例: ✓ "Q3 で Data Center YoY が +30% を下回る" / ✗ "AI ブームが終わる"
+
+## ETF / Index workflow (4 phase)
+
+| Phase | 中身 | 上限 | データ源 |
+|---|---|---|---|
+| 1. 商品スナップショット | ベンチマーク, 運用会社, 設定日, AUM, 運用方式 (フルレプリ / サンプリング) | 表 1 個 | Yahoo + 運用会社 product page |
+| 2. コスト構造 | TER + 同等 ETF 3-5 本比較, bid-ask spread, 1y tracking error | 比較表 | Yahoo / Stooq + fact sheet |
+| 3. Holdings | 上位 10 銘柄, セクター, 地域, 集中度 (HHI or top10 比率) | 表 + 1 行 | 運用会社 CSV / Yahoo Holdings |
+| 4. Fit | ポートフォリオ重複 (optional), 3y/5y/10y total return, NISA 扱い, FX リスク | 4 行 | 上記 + ユーザ memo |
+
+Verdict ラベル: **Core / Satellite / Pass** (個別株とは別)
+
+末尾固定:
+```
+深掘りする？
+  1. 類似 ETF 3-5 本の横並び比較
+  2. tracking error 推移
+  3. NISA 成長投資枠 / つみたて枠での扱い
+  4. 既存保有との重複計算 (要 portfolio JSON)
+```
+
+## 出力フォーマット
+
+詳細テンプレは `references/equity-workflow.md` と `references/etf-workflow.md` に格納。テンプレ要件:
+
+- 100-200 行が上限 (ターミナル 1 画面)
+- Verdict 行は最後に固定書式 → `grep` 履歴比較できる
+- 末尾の「深掘りする？」5 (個別株) / 4 (ETF) 件を必ず提示
+- ディスクレーマー (投資助言ではない / データ取得失敗時は明示) を冒頭または末尾に 1 行
+
+## データ取得戦略
+
+### ソース
+
+| 用途 | US | JP | ETF |
+|---|---|---|---|
+| 株価・主要指標 | Yahoo Finance | Yahoo Finance Japan | Yahoo Finance |
+| 通期 (10-K / 有報) | SEC EDGAR submissions API | EDINET 書類取得 API | — |
+| 四半期 (10-Q / 短信) | EDGAR | TDnet 短信 HTML / EDINET | — |
+| 重要事実 (8-K / 適時開示) | EDGAR | TDnet | — |
+| 業種中央値 | NYU Damodaran | Damodaran (US proxy) | Morningstar category |
+| ETF holdings | — | — | 運用会社公式 CSV |
+
+### スクリプト規約
+
+- 全スクリプトは `uv run` で動く単体 Python (PEP 723 inline metadata)
+- 入力: argv (ticker / URL)、出力: JSON to stdout
+- 依存: yfinance, requests, beautifulsoup4 のみ。devbox / 環境変数不要
+- Claude は `Bash` でスクリプトを呼んで結果を受け取る (subagent 風)
+
+### キャッシュ
+
+- `~/.cache/equity-decision/{source}-{ticker}-{YYYY-MM-DD}.json`
+- TTL 24h
+- `--no-cache` で強制再取得
+
+### 失敗時挙動
+
+- yfinance rate limit → 1 回 retry → ダメなら memo に「価格データ取得失敗」を明示
+- EDGAR / EDINET シンボル解決失敗 → Phase 1 で明示
+- ETF holdings CSV フォーマット変化 → "holdings not available, manual entry required" + 続行
+- **Claude による hallucinate 補完は禁止**: SKILL.md に明示
+
+## Phasing
+
+| Phase | 内容 | リリース |
+|---|---|---|
+| A — Skeleton | SKILL.md + references/ ドキュメント一式。fetcher 無し、Claude が手で数字埋め。これだけで「ユーザが手で数字を渡す」フローは動く | v1 内 |
+| B — Fetchers | scripts/ に Yahoo / EDGAR / EDINET の最小フェッチャ。`uv run` で動く単体スクリプト | v1 内 |
+| C — ETF | ETF テンプレ + holdings フェッチャ + Core/Satellite/Pass verdict | v1.1 (別 PR) |
+| D — Polish | 24h cache, `--no-cache`, 失敗時メッセージ整備, Stooq フォールバック, README 使用例 | v1.2 (別 PR) |
+
+## Done criteria (v1 = Phase A + B + 個別株のみ)
+
+1. `~/.claude/skills/equity-decision/SKILL.md` deploy 済み
+2. `/equity-decision NVDA` で個別株 5 phase memo が出る (fetcher で数字埋め)
+3. `/equity-decision 7203` でトヨタの memo が EDINET + Yahoo 経由で出る
+4. データ取得失敗時、hallucination ではなく明示的に "数字取得失敗" を memo に書く
+5. 末尾の「深掘りする？」5 件が表示される
+6. SKILL.md 内に anthropics/financial-services への帰属表記
+7. `dot_claude/skills/equity-decision/scripts/*.py` が `uv run` で単体実行できる
+8. 簡易テスト: 既知 ticker 数件 (NVDA, AAPL, 7203, 9984) でフェッチャが JSON を返す
+
+ETF (Phase C) は v1.1、polish (cache / エラー文言整備) は v1.2 で別 PR。
+
+## ライセンスとリスク
+
+- 元 repo (Apache 2.0) の DCF / comps / 3-statement / thesis-tracker / earnings-analysis のフレーム参照あり
+- 各 `references/*.md` 冒頭で帰属表記:
+  ```
+  > Adapted from anthropics/financial-services (Apache License 2.0).
+  > Modified for retail use without paid data sources.
+  ```
+- 個人利用かつ chezmoi 管理内のため `LICENSE` / `NOTICE` ファイル設置までは過剰、ヘッダー帰属で済ます
+- 出力 memo は **投資助言ではない** ことを冒頭 1 行で明示
+- 取得データを盲信せず、最終判断はユーザ自身
+
+## Open questions (実装段階で判断)
+
+- yfinance の API は時々壊れる → 代替に Stooq の CSV をフォールバックに入れるか (Phase D で検討)
+- EDINET API は accessKey 不要だがレート制限あり → 同 API 1 ticker で複数取得時の throttle 設計
+- Damodaran データは年次更新 → 何時の snapshot をデフォルトにするか (最新を毎年 1 回手動更新 or skill が自動 fetch)

--- a/dot_claude/skills/equity-decision/README.md
+++ b/dot_claude/skills/equity-decision/README.md
@@ -1,0 +1,58 @@
+# equity-decision
+
+A Claude Code skill that produces a structured purchase memo for an individual stock (US or JP). Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache 2.0); reworked for retail use against free public data.
+
+> Not investment advice. Outputs are research summaries.
+
+## Quick start
+
+```
+/equity-decision NVDA                                # US ticker
+/equity-decision 7203                                # JP code (Toyota)
+/equity-decision NVDA "DC growth slowing"            # ticker + hypothesis
+/equity-decision https://www.sec.gov/.../10-K.htm    # URL
+/equity-decision --ja 9434                           # Force JP routing
+/equity-decision --no-cache NVDA                     # Skip 24h cache
+```
+
+The skill emits a 100–200 line memo covering business, fundamentals (3-year trend), valuation (multiples + DCF), risks (5 axes), and a verdict (Buy/Watch/Pass + sizing + horizon). The memo ends with five deep-dive options you can pick from in the next turn.
+
+## What's in scope (v1)
+
+- US individual stocks (10-K / 10-Q / 8-K via SEC EDGAR + Yahoo Finance)
+- JP individual stocks (有価証券報告書 via EDINET + Yahoo Finance Japan)
+
+## What's not in scope (v1)
+
+- ETF / index funds → coming in v1.1
+- Dividend-focused screens (yield + payout ratio + coverage) — different rubric
+- Crypto, commodities, individual bonds
+- Hong Kong / Shanghai / European listings
+- Tax optimization (NISA balance, foreign tax credit) — needs personal account data
+
+## Files
+
+```
+SKILL.md                       # skill entry, routing, output rules
+references/equity-workflow.md  # the 5-phase template (this is what gets filled)
+references/dcf-rubric.md       # WACC / growth / terminal defaults & guardrails
+references/growth-stock-checks.md  # SBC, NRR, Rule of 40
+references/risk-taxonomy.md    # 5 axes Active/Latent/Inactive scoring
+references/data-sources.md     # EDGAR / EDINET / Yahoo / Damodaran query notes
+scripts/fetch_yahoo.py         # `uv run scripts/fetch_yahoo.py NVDA`     (Phase B)
+scripts/fetch_edgar.py         # `uv run scripts/fetch_edgar.py NVDA`     (Phase B)
+scripts/fetch_edinet.py        # `uv run scripts/fetch_edinet.py 7203`    (Phase B)
+```
+
+## Smoke-test the fetchers
+
+After Phase B is in:
+
+```bash
+cd ~/.claude/skills/equity-decision
+uv run scripts/fetch_yahoo.py NVDA  | jq '.summary'
+uv run scripts/fetch_edgar.py NVDA  | jq '.filings[0]'
+uv run scripts/fetch_edinet.py 7203 | jq '.docs[0]'
+```
+
+Expected: each returns a JSON object with the documented shape (see each script's docstring).

--- a/dot_claude/skills/equity-decision/README.md
+++ b/dot_claude/skills/equity-decision/README.md
@@ -20,12 +20,11 @@ The skill emits a 100–200 line memo covering business, fundamentals (3-year tr
 ## What's in scope (v1)
 
 - US individual stocks (10-K / 10-Q / 8-K via SEC EDGAR + Yahoo Finance)
-- JP individual stocks via Yahoo Finance Japan (price + multiples). 有報 / 決算短信 are read via manual URL/PDF paste — EDINET API auto-fetch is v1.1.
+- JP individual stocks via Yahoo Finance Japan (price + multiples) + EDINET (有価証券報告書 / 四半期報告書 auto-fetch)
 
 ## What's not in scope (v1)
 
 - ETF / index funds → v1.1
-- EDINET API auto-fetch (requires free subscription key from disclosure2.edinet-fsa.go.jp) → v1.1
 - Dividend-focused screens (yield + payout ratio + coverage) — different rubric
 - Crypto, commodities, individual bonds
 - Hong Kong / Shanghai / European listings
@@ -42,6 +41,7 @@ references/risk-taxonomy.md    # 5 axes Active/Latent/Inactive scoring
 references/data-sources.md     # EDGAR / EDINET / Yahoo / Damodaran query notes
 scripts/fetch_yahoo.py         # `uv run scripts/fetch_yahoo.py NVDA`     (US + JP via .T)
 scripts/fetch_edgar.py         # `uv run scripts/fetch_edgar.py NVDA`     (US filings)
+scripts/fetch_edinet.py        # `uv run scripts/fetch_edinet.py 7203`    (JP 有報 + 四半期報告書)
 ```
 
 ## Smoke-test the fetchers
@@ -53,6 +53,9 @@ cd ~/.claude/skills/equity-decision
 uv run scripts/fetch_yahoo.py NVDA  | jq '.summary'
 uv run scripts/fetch_yahoo.py 7203  | jq '.summary'   # JP auto-suffix .T
 uv run scripts/fetch_edgar.py NVDA  | jq '.filings[0]'
+uv run scripts/fetch_edinet.py 7203 | jq '.docs[0]'
 ```
 
 Expected: each returns a JSON object with the documented shape (see each script's docstring).
+
+`fetch_edinet.py` needs a Subscription-Key. Set `EDINET_SUBSCRIPTION_KEY` env var or store it in 1Password at `op://Personal/EDINET/credential` (override path via `EDINET_OP_REF`).

--- a/dot_claude/skills/equity-decision/README.md
+++ b/dot_claude/skills/equity-decision/README.md
@@ -20,11 +20,12 @@ The skill emits a 100–200 line memo covering business, fundamentals (3-year tr
 ## What's in scope (v1)
 
 - US individual stocks (10-K / 10-Q / 8-K via SEC EDGAR + Yahoo Finance)
-- JP individual stocks (有価証券報告書 via EDINET + Yahoo Finance Japan)
+- JP individual stocks via Yahoo Finance Japan (price + multiples). 有報 / 決算短信 are read via manual URL/PDF paste — EDINET API auto-fetch is v1.1.
 
 ## What's not in scope (v1)
 
-- ETF / index funds → coming in v1.1
+- ETF / index funds → v1.1
+- EDINET API auto-fetch (requires free subscription key from disclosure2.edinet-fsa.go.jp) → v1.1
 - Dividend-focused screens (yield + payout ratio + coverage) — different rubric
 - Crypto, commodities, individual bonds
 - Hong Kong / Shanghai / European listings
@@ -39,9 +40,8 @@ references/dcf-rubric.md       # WACC / growth / terminal defaults & guardrails
 references/growth-stock-checks.md  # SBC, NRR, Rule of 40
 references/risk-taxonomy.md    # 5 axes Active/Latent/Inactive scoring
 references/data-sources.md     # EDGAR / EDINET / Yahoo / Damodaran query notes
-scripts/fetch_yahoo.py         # `uv run scripts/fetch_yahoo.py NVDA`     (Phase B)
-scripts/fetch_edgar.py         # `uv run scripts/fetch_edgar.py NVDA`     (Phase B)
-scripts/fetch_edinet.py        # `uv run scripts/fetch_edinet.py 7203`    (Phase B)
+scripts/fetch_yahoo.py         # `uv run scripts/fetch_yahoo.py NVDA`     (US + JP via .T)
+scripts/fetch_edgar.py         # `uv run scripts/fetch_edgar.py NVDA`     (US filings)
 ```
 
 ## Smoke-test the fetchers
@@ -51,8 +51,8 @@ After Phase B is in:
 ```bash
 cd ~/.claude/skills/equity-decision
 uv run scripts/fetch_yahoo.py NVDA  | jq '.summary'
+uv run scripts/fetch_yahoo.py 7203  | jq '.summary'   # JP auto-suffix .T
 uv run scripts/fetch_edgar.py NVDA  | jq '.filings[0]'
-uv run scripts/fetch_edinet.py 7203 | jq '.docs[0]'
 ```
 
 Expected: each returns a JSON object with the documented shape (see each script's docstring).

--- a/dot_claude/skills/equity-decision/SKILL.md
+++ b/dot_claude/skills/equity-decision/SKILL.md
@@ -61,6 +61,17 @@ Each script outputs JSON to stdout. On failure, exit code is non-zero and stderr
 
 `fetch_edinet.py` needs a Subscription-Key. Set `EDINET_SUBSCRIPTION_KEY`, or store it in 1Password at `op://Personal/EDINET/credential` (override path via `EDINET_OP_REF`).
 
+## JP fallback when EDINET is unavailable
+
+EDINET API is occasionally down, key activation can be delayed, and the portal has had outages. When `fetch_edinet.py` exits non-zero for a JP ticker:
+
+1. **Do NOT abort the memo.** Continue with Phase 2/3/5 using `fetch_yahoo.py {code}` only (it auto-suffixes `.T` and covers price + PE/PSR + market cap + TTM revenue / operating income / FCF).
+2. In Phase 1 (segment breakdown) and Phase 4 (filings-sourced risks), write `数字取得失敗 — EDINET unavailable. Paste 有報 / 短信 URL to enable.` Then ask the user: *「有報か短信の URL があれば貼ってください。なければこのまま Yahoo の数字で進めます」*
+3. If the user pastes a URL or PDF, fetch / read it and fill in Phase 1 + 4 from there.
+4. The Verdict (Phase 5) can still ground itself on Phase 2 / 3 alone; flag the missing filings context in the Invalidation list.
+
+This keeps JP coverage usable even when EDINET is offline.
+
 ## Fail-loud rules
 
 - No hallucinated revenue / margin / multiples. If you can't source it, write "数字取得失敗".

--- a/dot_claude/skills/equity-decision/SKILL.md
+++ b/dot_claude/skills/equity-decision/SKILL.md
@@ -18,11 +18,13 @@ Produces a structured purchase memo for an individual stock (US or JP). Adapted 
 | Form | Example | Routing |
 |---|---|---|
 | US ticker | `NVDA`, `AAPL` | `^[A-Z]{1,5}$` → EDGAR + Yahoo Finance |
-| JP code | `7203`, `9984` | `^\d{4}$` → EDINET + Yahoo Finance (Japan) |
+| JP code | `7203`, `9984` | `^\d{4}$` → Yahoo Finance Japan (有報 manual URL paste — see below) |
 | URL | `https://www.sec.gov/.../10-K.htm` | Read page; infer symbol; route per above |
 | Mixed | `NVDA "DC growth slowing"` | Use the extra string as a hypothesis to test in Phase 5 |
 | Flag | `--ja 9434` | Force JP routing for ambiguous 4-digit |
 | Flag | `--no-cache NVDA` | Skip 24h cache, refetch |
+
+**Note on JP filings**: EDINET API requires a free subscription key (deferred to v1.1). For now, paste the 有価証券報告書 / 決算短信 URL or PDF text alongside the ticker, e.g. `/equity-decision 7203 https://www.toyota.co.jp/.../yuho.pdf`.
 
 ## Output
 
@@ -45,6 +47,20 @@ A single markdown memo of 100–200 lines, matching `references/equity-workflow.
 4. Fill the memo template phase-by-phase. **If a number cannot be fetched or sourced, write "数字取得失敗 — manual entry required" — never make up a number.**
 5. Apply rubrics from `references/dcf-rubric.md`, `references/growth-stock-checks.md`, `references/risk-taxonomy.md`.
 6. Emit the memo, then the deep-dive menu.
+
+## Data fetchers
+
+Run these from `~/.claude/skills/equity-decision/scripts/` via `uv run`:
+
+| When | Command | Returns |
+|---|---|---|
+| US ticker → price + multiples | `uv run scripts/fetch_yahoo.py NVDA` | quote, PE/PSR, market cap, TTM revenue/FCF |
+| US ticker → recent filings | `uv run scripts/fetch_edgar.py NVDA` | latest 10-K, 10-Q, 5 × 8-K (with URLs) |
+| JP ticker → price + multiples | `uv run scripts/fetch_yahoo.py 7203` | same shape, auto `.T` suffix |
+
+Each script outputs JSON to stdout. On failure, exit code is non-zero and stderr contains `数字取得失敗: ...` — propagate that text into the memo, do not invent numbers.
+
+JP filings (有報 / 短信) have no fetcher in v1 — paste the URL/PDF alongside the ticker.
 
 ## Fail-loud rules
 

--- a/dot_claude/skills/equity-decision/SKILL.md
+++ b/dot_claude/skills/equity-decision/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: equity-decision
+description: |
+  Generate a 1-page purchase memo for a US or JP individual stock (ETF support in v1.1).
+  Walks 5 phases — business, fundamentals, valuation, risks, verdict — and ends with deep-dive options.
+  Use when (1) the user asks "should I buy <TICKER>?", (2) the user wants a fundamental review of a specific company, (3) the user pastes a 10-K / 有報 / IR URL and asks for an analysis. Skip for ETF / index / dividend-focused questions in v1.
+argument-hint: <TICKER or URL> [extra context]
+---
+
+# `equity-decision` skill
+
+Produces a structured purchase memo for an individual stock (US or JP). Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache 2.0); modified for retail use without paid data sources.
+
+> ⚠️ **Not investment advice.** Outputs are research summaries based on public filings and market data. Verify numbers against primary sources; the final decision is the user's.
+
+## Inputs
+
+| Form | Example | Routing |
+|---|---|---|
+| US ticker | `NVDA`, `AAPL` | `^[A-Z]{1,5}$` → EDGAR + Yahoo Finance |
+| JP code | `7203`, `9984` | `^\d{4}$` → EDINET + Yahoo Finance (Japan) |
+| URL | `https://www.sec.gov/.../10-K.htm` | Read page; infer symbol; route per above |
+| Mixed | `NVDA "DC growth slowing"` | Use the extra string as a hypothesis to test in Phase 5 |
+| Flag | `--ja 9434` | Force JP routing for ambiguous 4-digit |
+| Flag | `--no-cache NVDA` | Skip 24h cache, refetch |
+
+## Output
+
+A single markdown memo of 100–200 lines, matching `references/equity-workflow.md` exactly. After the memo, always append:
+
+```
+深掘りする？
+  1. valuation を変数いじって再計算 (WACC / terminal / 売上 CAGR)
+  2. risks #N をフィリングから根拠引用つきで再構成
+  3. 競合 X 社との指標横並び比較
+  4. 直近 3 四半期の earnings call 言及トピック差分
+  5. KPI モニタを 5 つに絞り込む
+```
+
+## Workflow
+
+1. Detect market from ticker (see Inputs).
+2. Read `references/equity-workflow.md` to load the 5-phase template.
+3. Run the fetchers in `scripts/` (Phase B+ only). For Phase A: ask the user for numbers, or have them paste a 10-K URL.
+4. Fill the memo template phase-by-phase. **If a number cannot be fetched or sourced, write "数字取得失敗 — manual entry required" — never make up a number.**
+5. Apply rubrics from `references/dcf-rubric.md`, `references/growth-stock-checks.md`, `references/risk-taxonomy.md`.
+6. Emit the memo, then the deep-dive menu.
+
+## Fail-loud rules
+
+- No hallucinated revenue / margin / multiples. If you can't source it, write "数字取得失敗".
+- No "approximately" or "around" numbers without citing the source filing.
+- DCF inputs (WACC, terminal growth) must be inside `references/dcf-rubric.md` guardrails or explicitly flagged.
+
+## Disclaimer
+
+This skill produces research summaries, not investment advice. Verify all numbers against primary filings before acting.

--- a/dot_claude/skills/equity-decision/SKILL.md
+++ b/dot_claude/skills/equity-decision/SKILL.md
@@ -18,13 +18,11 @@ Produces a structured purchase memo for an individual stock (US or JP). Adapted 
 | Form | Example | Routing |
 |---|---|---|
 | US ticker | `NVDA`, `AAPL` | `^[A-Z]{1,5}$` → EDGAR + Yahoo Finance |
-| JP code | `7203`, `9984` | `^\d{4}$` → Yahoo Finance Japan (有報 manual URL paste — see below) |
+| JP code | `7203`, `9984` | `^\d{4}$` → EDINET + Yahoo Finance (Japan) |
 | URL | `https://www.sec.gov/.../10-K.htm` | Read page; infer symbol; route per above |
 | Mixed | `NVDA "DC growth slowing"` | Use the extra string as a hypothesis to test in Phase 5 |
 | Flag | `--ja 9434` | Force JP routing for ambiguous 4-digit |
 | Flag | `--no-cache NVDA` | Skip 24h cache, refetch |
-
-**Note on JP filings**: EDINET API requires a free subscription key (deferred to v1.1). For now, paste the 有価証券報告書 / 決算短信 URL or PDF text alongside the ticker, e.g. `/equity-decision 7203 https://www.toyota.co.jp/.../yuho.pdf`.
 
 ## Output
 
@@ -57,10 +55,11 @@ Run these from `~/.claude/skills/equity-decision/scripts/` via `uv run`:
 | US ticker → price + multiples | `uv run scripts/fetch_yahoo.py NVDA` | quote, PE/PSR, market cap, TTM revenue/FCF |
 | US ticker → recent filings | `uv run scripts/fetch_edgar.py NVDA` | latest 10-K, 10-Q, 5 × 8-K (with URLs) |
 | JP ticker → price + multiples | `uv run scripts/fetch_yahoo.py 7203` | same shape, auto `.T` suffix |
+| JP code → EDINET filings | `uv run scripts/fetch_edinet.py 7203` | latest 有報 + 四半期報告書 (with URLs) |
 
 Each script outputs JSON to stdout. On failure, exit code is non-zero and stderr contains `数字取得失敗: ...` — propagate that text into the memo, do not invent numbers.
 
-JP filings (有報 / 短信) have no fetcher in v1 — paste the URL/PDF alongside the ticker.
+`fetch_edinet.py` needs a Subscription-Key. Set `EDINET_SUBSCRIPTION_KEY`, or store it in 1Password at `op://Personal/EDINET/credential` (override path via `EDINET_OP_REF`).
 
 ## Fail-loud rules
 

--- a/dot_claude/skills/equity-decision/references/data-sources.md
+++ b/dot_claude/skills/equity-decision/references/data-sources.md
@@ -34,17 +34,15 @@ Key forms:
 
 ## JP Equities
 
-### EDINET
+### EDINET — deferred to v1.1
 
-- **Document list** (per date): `GET https://disclosure.edinet-fsa.go.jp/api/v2/documents.json?date=YYYY-MM-DD&type=2`
-- **Document body** (PDF or XBRL): `GET https://disclosure.edinet-fsa.go.jp/api/v2/documents/{docID}?type=2`
-- **No auth key required** (as of 2026); rate limit is unstated but conservative — keep to ≤1 RPS.
-- Filter by `docTypeCode`:
-  - `120` — 有価証券報告書 (annual)
-  - `140` — 四半期報告書 (quarterly)
-  - `160` — 半期報告書
-
-To find a 4-digit securities code → EDINET CIK (`edinetCode`): use the document listing's `secCode` field.
+- **Status (2026-05)**: EDINET v2 now requires a `Subscription-Key` header. Free key obtainable from <https://disclosure2.edinet-fsa.go.jp/>.
+- v1 of this skill does NOT auto-fetch EDINET. For JP 有報 / 短信, paste the URL or PDF text alongside the ticker.
+- Once a key is configured (planned v1.1):
+  - **Document list** (per date): `GET https://disclosure.edinet-fsa.go.jp/api/v2/documents.json?date=YYYY-MM-DD&type=2`
+  - **Document body** (PDF or XBRL): `GET https://disclosure.edinet-fsa.go.jp/api/v2/documents/{docID}?type=2`
+  - Filter by `docTypeCode`: `120` 有価証券報告書 / `140` 四半期報告書 / `160` 半期報告書
+  - 4-digit securities code → `edinetCode` resolution: use the document listing's `secCode` field (4-digit ticker + trailing `0`)
 
 ### TDnet (適時開示)
 

--- a/dot_claude/skills/equity-decision/references/data-sources.md
+++ b/dot_claude/skills/equity-decision/references/data-sources.md
@@ -34,15 +34,17 @@ Key forms:
 
 ## JP Equities
 
-### EDINET — deferred to v1.1
+### EDINET
 
-- **Status (2026-05)**: EDINET v2 now requires a `Subscription-Key` header. Free key obtainable from <https://disclosure2.edinet-fsa.go.jp/>.
-- v1 of this skill does NOT auto-fetch EDINET. For JP 有報 / 短信, paste the URL or PDF text alongside the ticker.
-- Once a key is configured (planned v1.1):
-  - **Document list** (per date): `GET https://disclosure.edinet-fsa.go.jp/api/v2/documents.json?date=YYYY-MM-DD&type=2`
-  - **Document body** (PDF or XBRL): `GET https://disclosure.edinet-fsa.go.jp/api/v2/documents/{docID}?type=2`
-  - Filter by `docTypeCode`: `120` 有価証券報告書 / `140` 四半期報告書 / `160` 半期報告書
-  - 4-digit securities code → `edinetCode` resolution: use the document listing's `secCode` field (4-digit ticker + trailing `0`)
+- **Auth**: requires the `Ocp-Apim-Subscription-Key` header on every request. Free key obtainable from <https://disclosure2.edinet-fsa.go.jp/>.
+- **Key source** (used by `scripts/fetch_edinet.py`):
+  - `EDINET_SUBSCRIPTION_KEY` env var (preferred for CI), or
+  - 1Password at `op://Personal/EDINET/credential` (override path with `EDINET_OP_REF`).
+- **Document list** (per date): `GET https://disclosure.edinet-fsa.go.jp/api/v2/documents.json?date=YYYY-MM-DD&type=2`
+- **Document body** (PDF or XBRL): `GET https://disclosure.edinet-fsa.go.jp/api/v2/documents/{docID}?type=2`
+- Filter by `docTypeCode`: `120` 有価証券報告書 / `140` 四半期報告書 / `160` 半期報告書
+- 4-digit securities code → `edinetCode` resolution: use the document listing's `secCode` field (4-digit ticker + trailing `0`, e.g. `"7203"` → `"72030"`).
+- **Failure mode**: a missing/invalid key returns HTTP 200 with a JSON body whose `metadata.status` (or top-level `StatusCode`) is `401`. The fetcher raises on the first such response — do NOT silently walk the 400-day window.
 
 ### TDnet (適時開示)
 

--- a/dot_claude/skills/equity-decision/references/data-sources.md
+++ b/dot_claude/skills/equity-decision/references/data-sources.md
@@ -1,0 +1,80 @@
+> Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache License 2.0).
+> Modified for retail use without paid data sources.
+
+# Data Sources
+
+Free, retail-accessible sources used by the skill. Each source includes the URL pattern, what's available, and known limits.
+
+## US Equities
+
+### SEC EDGAR
+
+- **Company ticker → CIK map** (one-time fetch, cache yearly):
+  `GET https://www.sec.gov/files/company_tickers.json`
+- **Latest filings index**: `GET https://data.sec.gov/submissions/CIK{cik_10digit}.json`
+- **Filing body**: assembled from the recent filings index (returns `accessionNumber`, `primaryDocument`):
+  `GET https://www.sec.gov/Archives/edgar/data/{cik}/{accession_no_dashes}/{primary_document}`
+- **User-Agent required**: SEC blocks requests without a UA. Use `User-Agent: <name> <email>`.
+- **Rate limit**: 10 requests/second across all SEC endpoints.
+
+Key forms:
+
+- `10-K`: annual report → Phase 1 (Item 1, 1A), Phase 4 (Item 1A, 3, 9A)
+- `10-Q`: quarterly → updated balance sheet for Phase 2
+- `8-K`: material events → check for Item 4.02 (restatements), Item 5.02 (auditor change)
+- `DEF 14A`: proxy → SBC and dilution details
+
+### Yahoo Finance (via `yfinance`)
+
+- Quote, summary, key statistics (PE, PSR, market cap, beta).
+- Historical price (5-year daily for `30d %` and CAGR calculations).
+- Quarterly and annual income statement, balance sheet, cash flow.
+- **Rate limit**: undocumented; treat as soft. Add 1s sleep between calls.
+- **Reliability**: API breaks occasionally. Use Stooq as fallback (Phase D).
+
+## JP Equities
+
+### EDINET
+
+- **Document list** (per date): `GET https://disclosure.edinet-fsa.go.jp/api/v2/documents.json?date=YYYY-MM-DD&type=2`
+- **Document body** (PDF or XBRL): `GET https://disclosure.edinet-fsa.go.jp/api/v2/documents/{docID}?type=2`
+- **No auth key required** (as of 2026); rate limit is unstated but conservative — keep to ≤1 RPS.
+- Filter by `docTypeCode`:
+  - `120` — 有価証券報告書 (annual)
+  - `140` — 四半期報告書 (quarterly)
+  - `160` — 半期報告書
+
+To find a 4-digit securities code → EDINET CIK (`edinetCode`): use the document listing's `secCode` field.
+
+### TDnet (適時開示)
+
+- Per-day index HTML: `https://www.release.tdnet.info/inbs/I_list_001_{YYYYMMDD}.html`
+- Use for 8-K-equivalent events (短信 release, M&A announcement, guidance revisions).
+- **Scraping** — fragile. Treat as best-effort.
+
+### Yahoo Finance Japan (via `yfinance`)
+
+- Tickers as `{code}.T` (e.g., `7203.T` for Toyota).
+- Same surface as US; slightly fewer historical data points.
+
+## Industry medians
+
+### NYU Damodaran
+
+- Annual update; CSV download URLs (cache for one year):
+  - `https://pages.stern.nyu.edu/~adamodar/New_Home_Page/datafile/pedata.html` (PE by sector)
+  - `https://pages.stern.nyu.edu/~adamodar/New_Home_Page/datafile/wacc.html` (WACC by sector)
+  - `https://pages.stern.nyu.edu/~adamodar/New_Home_Page/datafile/Betas.html` (betas)
+- For JP equities, use US sector as proxy unless Damodaran's `globalEquity` table covers the sector explicitly.
+
+## Cache
+
+- All sources cached at `~/.cache/equity-decision/{source}-{ticker}-{YYYY-MM-DD}.json`
+- TTL 24h for prices and recent filings; 1 year for Damodaran tables.
+- `--no-cache` flag forces refetch.
+
+## Failure behaviour
+
+- Network error → 1 retry → write "数字取得失敗 — manual entry required" in the memo. Never hallucinate.
+- Symbol resolution fails → state which lookup failed (e.g., "EDGAR ticker→CIK miss for XYZ").
+- HTTP 429 → exponential backoff (2s, 4s, 8s) up to 3 attempts.

--- a/dot_claude/skills/equity-decision/references/dcf-rubric.md
+++ b/dot_claude/skills/equity-decision/references/dcf-rubric.md
@@ -1,0 +1,42 @@
+> Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache License 2.0).
+> Modified for retail use without paid data sources.
+
+# DCF Rubric — Defaults and Guardrails
+
+Used by Phase 3 of `equity-workflow.md`. The skill produces a 3-scenario DCF (Bear / Base / Bull); each scenario must respect these guardrails.
+
+## Inputs and defaults
+
+| Input | Default | Guardrail |
+|---|---|---|
+| Forecast horizon | 5 years | Fixed |
+| Revenue CAGR (Bear / Base / Bull) | sector median × {0.5 / 1.0 / 1.5} | ±50% around base; cap at 30% even for hyper-growth |
+| Operating margin (steady state) | average of last 3y | ±5pp from history unless step-change argued |
+| Tax rate | 25% (US) / 30% (JP) | Override only if disclosed effective rate ≠ statutory ≥ 5pp |
+| WACC | 8% (US large-cap) / 7% (US tech) / 6% (JP large-cap) | ±2pp; cite source in memo if outside |
+| Terminal growth | 2.5% | Hard cap 3.5%; never exceed long-term GDP+1 |
+| Net debt | from latest 10-Q / 短信 | Use book value; flag if off-balance-sheet ≥ 10% of market cap |
+
+## Method (skill internal)
+
+1. Build 5-year revenue projection per scenario.
+2. Apply operating margin to derive EBIT; subtract tax → NOPAT.
+3. Add back D&A, subtract capex and working-capital changes → FCF.
+4. Discount each year's FCF at WACC.
+5. Terminal value = year-5 FCF × (1+g) / (WACC − g). Discount to PV.
+6. Sum → enterprise value. Subtract net debt → equity value. Divide by diluted shares → fair value/share.
+
+## Sanity checks (apply before emitting numbers)
+
+- **Bull < Base × 2.0**: if Bull/Base > 2.0, the bull scenario is unrealistic — tighten growth or margin assumption.
+- **Bear > Base × 0.4**: if Bear/Base < 0.4, the base case is fragile — recheck steady-state margin.
+- **All scenarios > current price**: usually means consensus is too pessimistic OR assumptions are too aggressive. Flag in the memo.
+- **All scenarios < current price**: market is pricing growth/option value the model doesn't capture. Note in Phase 5 Invalidation.
+
+## When to skip DCF
+
+- Companies with negative FCF for ≥3 years and no path to profitability → use rNPV, PSR, or "not valued" with reason.
+- Financials (banks / insurers): DCF on FCF is misleading; use dividend discount model or P/TBV instead.
+- Holding companies / SOTP candidates: use sum-of-the-parts; DCF would mask segment economics.
+
+If skipping, state which alternative was used and why.

--- a/dot_claude/skills/equity-decision/references/equity-workflow.md
+++ b/dot_claude/skills/equity-decision/references/equity-workflow.md
@@ -1,0 +1,102 @@
+> Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache License 2.0).
+> Modified for retail use without paid data sources.
+
+# Individual Stock Workflow — 5 Phase Template
+
+When the skill is invoked with an individual stock ticker (US or JP), fill this exact template. Keep total output to 100–200 lines.
+
+## Template
+
+````markdown
+# {Company Name} ({TICKER}) — Purchase Memo
+*Generated: {YYYY-MM-DD} | Last close: {currency}{price} ({30d %} ↑↓)*
+
+> Research summary only — not investment advice.
+
+## 1. What they do
+
+{Two- or three-sentence business description, ≤80 chars per sentence}
+
+| Segment | % of revenue (FY{N}) | YoY growth |
+|---|---|---|
+| {Seg 1} | {%} | {%} |
+| {Seg 2} | {%} | {%} |
+| {Seg 3} | {%} | {%} |
+
+Customer concentration: {one line — top customer %, top-5 %, or "not disclosed"}
+
+## 2. Fundamentals (3y trend)
+
+| Metric | FY-2 | FY-1 | FY (TTM) | Comment |
+|---|---|---|---|---|
+| Revenue ({currency}) | … | … | … | CAGR {%} |
+| Gross / Operating / Net margin | … | … | … | {trend} |
+| FCF margin | … | … | … | {SBC-adjusted? yes/no} |
+| ROIC | … | … | … | {vs WACC} |
+| Net debt / EBITDA | … | … | … | {trend} |
+| Diluted share count Δ | … | … | … | {SBC dilution rate %} |
+
+## 3. Valuation
+
+**Multiples (vs sector median)**:
+
+| | This | Sector median | Gap |
+|---|---|---|---|
+| PER (TTM) | … | … | +{%} |
+| PSR | … | … | +{%} |
+| EV / EBITDA | … | … | +{%} |
+| EV / FCF | … | … | +{%} |
+
+**DCF (5y + terminal)** — guardrails per `dcf-rubric.md`:
+
+| Scenario | 売上 CAGR | Terminal g | WACC | Fair value / share |
+|---|---|---|---|---|
+| Bear | … | … | … | {currency}{value} |
+| Base | … | … | … | {currency}{value} |
+| Bull | … | … | … | {currency}{value} |
+
+→ Current {currency}{price} is in the **{bear/base/bull}** range. Upside +{%}, downside −{%}.
+
+## 4. Risks
+
+- 💰 **Debt**: {one line — net debt / EBITDA, refinancing schedule, covenants}
+- ⚔️ **Competition**: {one line — main rival(s), structural moat trend}
+- ⚖️ **Regulation / litigation**: {one line — pending probes, ongoing litigation cited in 10-K Item 3 / 有報 訴訟}
+- 📚 **Accounting / disclosure**: {one line — auditor change, restatements, SBC magnitude, working-capital tricks}
+- 🎯 **Customer concentration**: {one line — top customer share, single-product dependency}
+
+## 5. Verdict
+
+**Thesis (why buy now)**:
+1. {claim grounded in Phase 2 or 3 data}
+2. {claim}
+3. {claim}
+
+**Invalidation (these would break the thesis)**:
+1. {testable KPI — e.g., "Q3 で Data Center YoY が +30% を下回る"}
+2. {testable KPI}
+3. {testable KPI}
+
+**Verdict**: {Buy / Watch / Pass}
+**Suggested sizing**: {Small <2% / Medium 2–5% / Large >5%} of portfolio
+**Time horizon**: {6mo / 1–3y / 5y+}
+
+---
+
+深掘りする？
+  1. valuation を変数いじって再計算 (WACC / terminal / 売上 CAGR)
+  2. risks #N をフィリングから根拠引用つきで再構成
+  3. 競合 X 社との指標横並び比較
+  4. 直近 3 四半期の earnings call 言及トピック差分
+  5. KPI モニタを 5 つに絞り込む
+````
+
+## Filling rules
+
+- **Numbers must be sourced.** If a metric can't be pulled from a filing or Yahoo Finance, write `n/a — 数字取得失敗`. Never invent a number.
+- **Invalidation KPIs must be testable.** A line like "Macro turns sour" is invalid. A line like "Q3 で Data Center YoY が +30% を下回る" is valid.
+- **Thesis claims must reference data in earlier phases.** No claim should rely on information not shown in Phases 1–4.
+- **Verdict mapping**:
+  - **Buy**: thesis grounded, current price in bear or base range, no Tier-1 risks active
+  - **Watch**: thesis interesting but waiting on a catalyst or price → "what specifically would trigger?"
+  - **Pass**: thesis weak, valuation in bull range, or ≥1 unmitigated Tier-1 risk

--- a/dot_claude/skills/equity-decision/references/growth-stock-checks.md
+++ b/dot_claude/skills/equity-decision/references/growth-stock-checks.md
@@ -1,0 +1,51 @@
+> Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache License 2.0).
+> Modified for retail use without paid data sources.
+
+# Growth Stock Checks
+
+Extra checks to run during Phase 2 (Fundamentals) when the company is high-growth (revenue CAGR > 20%) or tech / SaaS. Surface findings in the **Comment** column of the Fundamentals table or in Phase 4 Risks.
+
+## SBC (Stock-Based Compensation)
+
+- Compute **SBC / Revenue** and **SBC / FCF** for each of the last 3 years.
+- **Yellow flag**: SBC > 10% of revenue OR SBC > 50% of GAAP net income.
+- **Red flag**: SBC > 20% of revenue OR FCF goes negative when SBC is subtracted.
+- Always show **FCF − SBC** (the "real" cash flow to shareholders) in the memo alongside reported FCF.
+
+## Dilution
+
+- Compute **YoY growth in diluted share count**.
+- **Yellow flag**: >3% per year.
+- **Red flag**: >5% per year, or buybacks barely offsetting SBC.
+
+## Rule of 40 (SaaS)
+
+For SaaS or recurring-revenue businesses: **Revenue growth % + FCF margin % ≥ 40**.
+
+- Above 40 → healthy. Above 60 → exceptional.
+- Below 40 → either growth or profitability needs to improve.
+
+## NRR (Net Revenue Retention)
+
+If disclosed (most SaaS companies report it):
+
+- **<100%**: churn problem.
+- **100–110%**: stable.
+- **110–130%**: healthy land-and-expand.
+- **>130%**: best in class.
+
+## TAM Reality Check
+
+When the company quotes a TAM:
+
+- Is the TAM defined per-product or per-market-vertical? (Per-product is more credible.)
+- What's the **current penetration** (revenue / TAM)? At <5%, runway is real. At >25%, growth is decelerating soon.
+- Cross-check TAM against an independent estimate (e.g., a sector analyst report).
+
+## Working Capital Tricks
+
+Watch for revenue growth that doesn't translate to FCF:
+
+- DSO (Days Sales Outstanding) climbing year over year → channel stuffing or quality of revenue declining.
+- Inventory turns falling → product not selling through.
+- Deferred revenue declining despite reported growth → real growth slowing.

--- a/dot_claude/skills/equity-decision/references/risk-taxonomy.md
+++ b/dot_claude/skills/equity-decision/references/risk-taxonomy.md
@@ -1,0 +1,60 @@
+> Adapted from [anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache License 2.0).
+> Modified for retail use without paid data sources.
+
+# Risk Taxonomy — 5 Axes
+
+Phase 4 of `equity-workflow.md` lists 5 risks. For each axis, the memo line states **whether the risk is materially active for this name today**, not generic warnings.
+
+## 1. 💰 Debt
+
+- **Active**: Net debt / EBITDA > 3.0×, OR upcoming refinancing > 20% of debt within 18 months, OR covenant headroom < 20%.
+- **Latent**: ratio rising but still < 3.0×.
+- **Inactive**: net cash, OR ratio < 1.5× with no near-term refinancing.
+
+Source: 10-K Item 7 (Liquidity), 10-Q balance sheet, 有報「財政状態」.
+
+## 2. ⚔️ Competition
+
+- **Active**: market share losing > 2pp/year, OR a credible new entrant disclosed (e.g., 10-K Item 1A, S-1 of a competitor) in the last 2 years.
+- **Latent**: moat narrowing but still dominant (>30% share); pricing power weakening.
+- **Inactive**: structural moat, market share stable or growing.
+
+Source: 10-K Item 1 (Business), Item 1A (Risk Factors), industry reports.
+
+## 3. ⚖️ Regulation / Litigation
+
+- **Active**: pending probe by a major regulator (DOJ, FTC, EU, JFTC), OR class action with damages claim > 5% of market cap, OR new rule (announced) that hits ≥10% of revenue.
+- **Latent**: industry under increasing scrutiny but no specific action.
+- **Inactive**: no disclosed material proceedings; regulation stable.
+
+Source: 10-K Item 3 (Legal Proceedings), 8-K material disclosures, 有報「訴訟事件等の概要」.
+
+## 4. 📚 Accounting / Disclosure
+
+- **Active**: auditor changed in the last 2 years (especially mid-cycle), OR restatement filed (8-K Item 4.02), OR going-concern paragraph, OR repeated material weakness in ICFR.
+- **Latent**: SBC > 20% of revenue, OR aggressive revenue recognition (long contracts, capitalized commissions ballooning), OR off-balance-sheet items > 10% of market cap.
+- **Inactive**: clean opinion, stable auditor, no flags.
+
+Source: 10-K Item 9A (ICFR), auditor's report, 有報「監査の状況」.
+
+## 5. 🎯 Customer / Product / Geographic Concentration
+
+- **Active**: top customer > 20% of revenue, OR top 3 customers > 50%, OR single product > 60% of revenue, OR single country > 70% with that country under political stress.
+- **Latent**: top customer 10–20%, OR single product / country between 50–70%.
+- **Inactive**: diversified across all three dimensions.
+
+Source: 10-K Item 1 (Customers), segment notes, 有報「販売の状況」.
+
+## How to write the memo line
+
+For each axis in Phase 4, write a single line in this shape:
+
+```
+{emoji} **{Axis}**: {Active/Latent/Inactive} — {specific reason with number}.
+```
+
+Examples:
+
+- `💰 **Debt**: Inactive — net cash $24B, no maturities < 24mo.`
+- `⚔️ **Competition**: Latent — Nvidia share holding ~80% datacenter GPU, AMD MI300 ramp + Intel Gaudi3 watch.`
+- `⚖️ **Regulation**: Active — China export controls on H100/H200 cut DC revenue ~15% in FY24.`

--- a/dot_claude/skills/equity-decision/scripts/fetch_edgar.py
+++ b/dot_claude/skills/equity-decision/scripts/fetch_edgar.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "requests>=2.31",
+# ]
+# ///
+"""fetch_edgar.py — SEC EDGAR filings for a US ticker.
+
+Usage:
+    uv run fetch_edgar.py <TICKER>
+
+Output (stdout, JSON):
+    {
+      "ticker": "AAPL",
+      "cik": "320193",
+      "filings": [
+        {"form": "10-K", "filedDate": "2024-11-01", "accessionNumber": "...", "primaryDocument": "aapl-20240928.htm", "url": "https://www.sec.gov/..."},
+        {"form": "10-Q", ...},
+        {"form": "8-K", ...},
+        ...
+      ]
+    }
+
+Returns the most recent 10-K, most recent 10-Q, and top-5 most recent 8-Ks.
+Exits 1 if ticker → CIK lookup fails or network errors.
+"""
+import json
+import sys
+
+import requests
+
+UA = "equity-decision-skill (pavegy@gmail.com)"
+TICKER_MAP_URL = "https://www.sec.gov/files/company_tickers.json"
+
+
+def lookup_cik(ticker: str) -> str:
+    """Return zero-padded 10-digit CIK for a US ticker."""
+    r = requests.get(TICKER_MAP_URL, headers={"User-Agent": UA}, timeout=10)
+    r.raise_for_status()
+    rows = r.json().values()
+    upper = ticker.upper()
+    for row in rows:
+        if row["ticker"].upper() == upper:
+            return str(row["cik_str"]).zfill(10)
+    raise ValueError(f"数字取得失敗: EDGAR ticker→CIK miss for {ticker!r}")
+
+
+def fetch_filings(ticker: str) -> dict:
+    cik_padded = lookup_cik(ticker)
+    cik = cik_padded.lstrip("0") or "0"
+    submissions_url = f"https://data.sec.gov/submissions/CIK{cik_padded}.json"
+    r = requests.get(submissions_url, headers={"User-Agent": UA}, timeout=15)
+    r.raise_for_status()
+    payload = r.json()
+
+    recent = payload["filings"]["recent"]
+    rows = list(zip(
+        recent["form"],
+        recent["filingDate"],
+        recent["accessionNumber"],
+        recent["primaryDocument"],
+    ))
+
+    selected = []
+    forms_seen = {"10-K": 0, "10-Q": 0, "8-K": 0}
+    for form, filed, accession, prim in rows:
+        if form == "10-K" and forms_seen["10-K"] == 0:
+            forms_seen["10-K"] += 1
+        elif form == "10-Q" and forms_seen["10-Q"] == 0:
+            forms_seen["10-Q"] += 1
+        elif form == "8-K" and forms_seen["8-K"] < 5:
+            forms_seen["8-K"] += 1
+        else:
+            continue
+        acc_clean = accession.replace("-", "")
+        selected.append({
+            "form": form,
+            "filedDate": filed,
+            "accessionNumber": accession,
+            "primaryDocument": prim,
+            "url": f"https://www.sec.gov/Archives/edgar/data/{cik}/{acc_clean}/{prim}",
+        })
+        if forms_seen["10-K"] >= 1 and forms_seen["10-Q"] >= 1 and forms_seen["8-K"] >= 5:
+            break
+
+    return {"ticker": ticker.upper(), "cik": cik, "filings": selected}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: fetch_edgar.py <TICKER>", file=sys.stderr)
+        return 2
+    try:
+        data = fetch_filings(sys.argv[1])
+    except Exception as e:
+        print(f"数字取得失敗: {e}", file=sys.stderr)
+        return 1
+    json.dump(data, sys.stdout, ensure_ascii=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dot_claude/skills/equity-decision/scripts/fetch_edinet.py
+++ b/dot_claude/skills/equity-decision/scripts/fetch_edinet.py
@@ -58,11 +58,12 @@ def get_key() -> str:
         return env_key
     op_ref = os.environ.get("EDINET_OP_REF", DEFAULT_OP_REF)
     try:
+        # op read via Desktop integration takes ~5s; a tight timeout flakes.
         result = subprocess.run(
             ["op", "read", op_ref],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=20,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         result = None

--- a/dot_claude/skills/equity-decision/scripts/fetch_edinet.py
+++ b/dot_claude/skills/equity-decision/scripts/fetch_edinet.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "requests>=2.31",
+# ]
+# ///
+"""fetch_edinet.py — EDINET filings for a JP 4-digit securities code.
+
+Usage:
+    uv run fetch_edinet.py <4-digit-secCode>
+
+Output (stdout, JSON):
+    {
+      "ticker": "7203",
+      "edinetCode": "E02144",
+      "docs": [
+        {"docTypeCode": "120", "docDescription": "...", "submitDateTime": "...", "docID": "S...", "url": "https://..."},
+        {"docTypeCode": "140", ...}
+      ]
+    }
+
+Walks back up to 400 days from today, listing one day at a time, until both the
+latest 有価証券報告書 (docTypeCode 120) and the latest 四半期報告書 (docTypeCode 140)
+have been collected (or 400 days exhausted).
+
+Authentication:
+    The EDINET v2 API requires the `Ocp-Apim-Subscription-Key` header. Obtain a
+    free key from https://disclosure2.edinet-fsa.go.jp/ and provide it via:
+      1. environment variable EDINET_SUBSCRIPTION_KEY, or
+      2. 1Password — defaults to op://Personal/EDINET/credential. Override with
+         the EDINET_OP_REF environment variable.
+
+Exit codes:
+    0 — JSON written to stdout
+    1 — fetch / auth / lookup failed (message on stderr begins with `数字取得失敗`)
+    2 — usage error
+"""
+import json
+import os
+import subprocess
+import sys
+from datetime import date, timedelta
+from time import sleep
+
+import requests
+
+API = "https://disclosure.edinet-fsa.go.jp/api/v2/documents.json"
+TARGET_TYPES = ("120", "140")
+MAX_DAYS_BACK = 400
+KEY_HEADER = "Ocp-Apim-Subscription-Key"
+DEFAULT_OP_REF = "op://Personal/EDINET/credential"
+
+
+def get_key() -> str:
+    env_key = os.environ.get("EDINET_SUBSCRIPTION_KEY", "").strip()
+    if env_key:
+        return env_key
+    op_ref = os.environ.get("EDINET_OP_REF", DEFAULT_OP_REF)
+    try:
+        result = subprocess.run(
+            ["op", "read", op_ref],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        result = None
+    if result is not None and result.returncode == 0:
+        op_key = result.stdout.strip()
+        if op_key:
+            return op_key
+    raise ValueError(
+        "数字取得失敗: EDINET key unavailable. Set EDINET_SUBSCRIPTION_KEY env var, "
+        "or store in 1Password at op://Personal/EDINET/credential "
+        "(override path via EDINET_OP_REF env)."
+    )
+
+
+def iter_days(start: date, days: int):
+    for offset in range(days):
+        yield start - timedelta(days=offset)
+
+
+def _doc_url(doc_id: str) -> str:
+    return f"https://disclosure.edinet-fsa.go.jp/api/v2/documents/{doc_id}?type=2"
+
+
+def fetch_docs(sec_code: str) -> dict:
+    key = get_key()
+    code_padded = sec_code.zfill(4) + "0"
+    headers = {KEY_HEADER: key}
+
+    found: dict[str, dict] = {}
+    edinet_code: str | None = None
+
+    for day in iter_days(date.today(), MAX_DAYS_BACK):
+        params = {"date": day.isoformat(), "type": "2"}
+        r = requests.get(API, headers=headers, params=params, timeout=15)
+        r.raise_for_status()
+        payload = r.json()
+
+        metadata_status = str(payload.get("metadata", {}).get("status", ""))
+        top_status = str(payload.get("StatusCode", ""))
+        if metadata_status not in ("", "200") or top_status not in ("", "200"):
+            raise ValueError(
+                f"数字取得失敗: EDINET API rejected key — {payload}"
+            )
+
+        for item in payload.get("results", []) or []:
+            if item.get("secCode") != code_padded:
+                continue
+            if edinet_code is None and item.get("edinetCode"):
+                edinet_code = item["edinetCode"]
+            doc_type = item.get("docTypeCode")
+            if doc_type in TARGET_TYPES and doc_type not in found:
+                found[doc_type] = {
+                    "docTypeCode": doc_type,
+                    "docDescription": item.get("docDescription", ""),
+                    "submitDateTime": item.get("submitDateTime", ""),
+                    "docID": item.get("docID", ""),
+                    "url": _doc_url(item.get("docID", "")),
+                }
+
+        if all(t in found for t in TARGET_TYPES):
+            break
+        sleep(0.3)
+
+    if edinet_code is None:
+        raise ValueError(
+            f"数字取得失敗: EDINET secCode→edinetCode miss for {sec_code!r}"
+        )
+
+    docs = [found[t] for t in TARGET_TYPES if t in found]
+    return {"ticker": sec_code, "edinetCode": edinet_code, "docs": docs}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: fetch_edinet.py <4-digit-secCode>", file=sys.stderr)
+        return 2
+    try:
+        data = fetch_docs(sys.argv[1])
+    except Exception as e:
+        print(f"{e}" if str(e).startswith("数字取得失敗") else f"数字取得失敗: {e}", file=sys.stderr)
+        return 1
+    json.dump(data, sys.stdout, ensure_ascii=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dot_claude/skills/equity-decision/scripts/fetch_yahoo.py
+++ b/dot_claude/skills/equity-decision/scripts/fetch_yahoo.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "yfinance>=0.2.40",
+# ]
+# ///
+"""fetch_yahoo.py — Yahoo Finance quote + summary metrics for a ticker.
+
+Usage:
+    uv run fetch_yahoo.py <TICKER>
+
+Examples:
+    uv run fetch_yahoo.py NVDA   # US
+    uv run fetch_yahoo.py 7203   # JP (auto .T suffix)
+
+Output (stdout, JSON):
+    {
+      "ticker": "AAPL",
+      "market": "US",
+      "price": 192.34,
+      "summary": {
+        "pe": 31.2,
+        "psr": 8.1,
+        "marketCap": 3000000000000,
+        "beta": 1.25,
+        "dividendYield": 0.005
+      },
+      "financials": {
+        "revenue_ttm": 385000000000,
+        "operatingIncome_ttm": 120000000000,
+        "freeCashFlow_ttm": 100000000000
+      }
+    }
+
+Exits 1 with a message on stderr if the ticker is unknown or the fetch fails.
+"""
+import json
+import re
+import sys
+
+import yfinance as yf
+
+
+def detect_market(raw_ticker: str) -> tuple[str, str]:
+    """Return (yahoo_symbol, market_label)."""
+    if re.fullmatch(r"\d{4}", raw_ticker):
+        return f"{raw_ticker}.T", "JP"
+    return raw_ticker.upper(), "US"
+
+
+def fetch_summary(raw_ticker: str) -> dict:
+    yahoo_symbol, market = detect_market(raw_ticker)
+    ticker = yf.Ticker(yahoo_symbol)
+    info = ticker.info or {}
+
+    if not info or not info.get("regularMarketPrice"):
+        raise ValueError(f"数字取得失敗: ticker {raw_ticker!r} not found on Yahoo Finance")
+
+    return {
+        "ticker": raw_ticker,
+        "market": market,
+        "price": info.get("regularMarketPrice"),
+        "summary": {
+            "pe": info.get("trailingPE"),
+            "psr": info.get("priceToSalesTrailing12Months"),
+            "marketCap": info.get("marketCap"),
+            "beta": info.get("beta"),
+            "dividendYield": info.get("dividendYield"),
+        },
+        "financials": {
+            "revenue_ttm": info.get("totalRevenue"),
+            "operatingIncome_ttm": info.get("ebitda"),
+            "freeCashFlow_ttm": info.get("freeCashflow"),
+        },
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: fetch_yahoo.py <TICKER>", file=sys.stderr)
+        return 2
+    try:
+        data = fetch_summary(sys.argv[1])
+    except Exception as e:
+        print(f"数字取得失敗: {e}", file=sys.stderr)
+        return 1
+    json.dump(data, sys.stdout, ensure_ascii=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/justfile
+++ b/justfile
@@ -54,6 +54,11 @@ test-hooks:
     @echo "Running hook tests..."
     @bash tests/hooks/run-tests.sh
 
+# Run skill fetcher tests
+test-skills:
+    @echo "Running skill fetcher tests..."
+    @bash tests/skills/equity-decision/run-tests.sh
+
 # Install formatter tools
 install:
     @echo "Installing formatters via devbox..."

--- a/tests/skills/equity-decision/conftest.py
+++ b/tests/skills/equity-decision/conftest.py
@@ -1,0 +1,18 @@
+"""Shared fixtures for equity-decision fetcher tests."""
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[3] / "dot_claude" / "skills" / "equity-decision" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+@pytest.fixture
+def us_tickers() -> list[str]:
+    return ["NVDA", "AAPL"]
+
+
+@pytest.fixture
+def jp_tickers() -> list[str]:
+    return ["7203", "9984"]

--- a/tests/skills/equity-decision/run-tests.sh
+++ b/tests/skills/equity-decision/run-tests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Test runner for dot_claude/skills/equity-decision/scripts/*.py
+# Runs all pytest tests in this directory using `uv run`.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+uv run --with pytest --with requests-mock --with yfinance --with beautifulsoup4 \
+  python -m pytest -v --tb=short

--- a/tests/skills/equity-decision/test_fetch_edgar.py
+++ b/tests/skills/equity-decision/test_fetch_edgar.py
@@ -1,0 +1,47 @@
+"""Tests for scripts/fetch_edgar.py.
+
+Contract:
+- argv[1] is the US ticker
+- prints JSON with shape: {ticker, cik, filings: [{form, filedDate, accessionNumber, primaryDocument, url}]}
+- only the latest 10-K, 10-Q, and most recent 8-Ks (top 5) need be returned
+- exits 1 on unknown ticker
+"""
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / "dot_claude" / "skills" / "equity-decision" / "scripts" / "fetch_edgar.py"
+
+
+def run_script(*args: str) -> dict:
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"script exited {result.returncode}\nstderr: {result.stderr}")
+    return json.loads(result.stdout)
+
+
+def test_known_us_ticker_returns_filings():
+    data = run_script("AAPL")
+    assert data["ticker"] == "AAPL"
+    assert data["cik"].isdigit() and len(data["cik"]) <= 10
+    assert isinstance(data["filings"], list) and len(data["filings"]) > 0
+    forms = {f["form"] for f in data["filings"]}
+    assert "10-K" in forms, f"no 10-K in filings: {forms}"
+
+
+def test_unknown_ticker_exits_nonzero():
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), "ZZZNOTAREALTICKER"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "数字取得失敗" in result.stderr or "not found" in result.stderr.lower()

--- a/tests/skills/equity-decision/test_fetch_edinet.py
+++ b/tests/skills/equity-decision/test_fetch_edinet.py
@@ -1,0 +1,80 @@
+"""Tests for scripts/fetch_edinet.py.
+
+Contract:
+- argv[1] is a 4-digit JP securities code
+- prints JSON: {ticker, edinetCode, docs: [{docTypeCode, docDescription, submitDateTime, docID, url}]}
+- exits 1 with `数字取得失敗` on stderr when the key is unavailable or lookup fails
+- exits 2 on usage error
+
+Integration tests requiring a live EDINET key are skipped automatically when neither
+the EDINET_SUBSCRIPTION_KEY env var nor `op read $EDINET_OP_REF` yields a key.
+The no-key path is always exercised so CI / agentless sessions still get coverage.
+"""
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / "dot_claude" / "skills" / "equity-decision" / "scripts" / "fetch_edinet.py"
+
+
+def _has_key() -> bool:
+    if os.environ.get("EDINET_SUBSCRIPTION_KEY"):
+        return True
+    op_ref = os.environ.get("EDINET_OP_REF", "op://Personal/EDINET/credential")
+    try:
+        result = subprocess.run(
+            ["op", "read", op_ref], capture_output=True, text=True, timeout=5
+        )
+        return result.returncode == 0 and bool(result.stdout.strip())
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+requires_key = pytest.mark.skipif(not _has_key(), reason="EDINET key not available")
+
+
+def run_script(*args: str) -> dict:
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), *args],
+        capture_output=True, text=True, timeout=120,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"script exited {result.returncode}\nstderr: {result.stderr}")
+    return json.loads(result.stdout)
+
+
+@requires_key
+def test_toyota_returns_yuho():
+    data = run_script("7203")
+    assert data["ticker"] == "7203"
+    assert data["edinetCode"].startswith("E")
+    type_codes = {d["docTypeCode"] for d in data["docs"]}
+    assert "120" in type_codes
+
+
+@requires_key
+def test_unknown_code_exits_nonzero():
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), "0000"],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert result.returncode != 0
+    assert "数字取得失敗" in result.stderr
+
+
+def test_missing_key_exits_nonzero(monkeypatch):
+    """When no key source is available, script must fail loudly."""
+    env = os.environ.copy()
+    env.pop("EDINET_SUBSCRIPTION_KEY", None)
+    env["EDINET_OP_REF"] = "op://nonexistent/path/__"  # force op read failure
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), "7203"],
+        capture_output=True, text=True, timeout=10,
+        env=env,
+    )
+    assert result.returncode != 0
+    assert "数字取得失敗" in result.stderr
+    assert "key unavailable" in result.stderr.lower() or "EDINET_SUBSCRIPTION_KEY" in result.stderr

--- a/tests/skills/equity-decision/test_fetch_yahoo.py
+++ b/tests/skills/equity-decision/test_fetch_yahoo.py
@@ -1,0 +1,56 @@
+"""Tests for scripts/fetch_yahoo.py.
+
+The script's contract:
+- argv[1] is the ticker (US: AAPL; JP: 7203 — auto-suffixed .T inside the script)
+- prints JSON to stdout with shape: {ticker, market, price, summary: {pe, psr, marketCap, ...}, financials: {...}}
+- exits 0 on success, 1 on hard failure (network, unknown ticker)
+"""
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / "dot_claude" / "skills" / "equity-decision" / "scripts" / "fetch_yahoo.py"
+
+
+def run_script(*args: str) -> dict:
+    """Run the script via uv run, return parsed JSON or raise."""
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"script exited {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}")
+    return json.loads(result.stdout)
+
+
+def test_us_ticker_returns_expected_shape():
+    data = run_script("AAPL")
+    assert data["ticker"] == "AAPL"
+    assert data["market"] == "US"
+    assert isinstance(data["price"], (int, float))
+    assert data["price"] > 0
+    assert "pe" in data["summary"]
+    assert "marketCap" in data["summary"]
+
+
+def test_jp_ticker_auto_suffix():
+    data = run_script("7203")
+    assert data["ticker"] == "7203"
+    assert data["market"] == "JP"
+    assert data["price"] > 0
+    assert "pe" in data["summary"]
+
+
+def test_unknown_ticker_exits_nonzero():
+    result = subprocess.run(
+        ["uv", "run", str(SCRIPT), "ZZZNOTAREALTICKER"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "数字取得失敗" in result.stderr or "not found" in result.stderr.lower()

--- a/tests/skills/equity-decision/test_smoke.py
+++ b/tests/skills/equity-decision/test_smoke.py
@@ -1,0 +1,3 @@
+def test_harness_loads():
+    """Trivial: confirms pytest can be invoked via the runner."""
+    assert True


### PR DESCRIPTION
## Summary

新しい Claude Code skill `equity-decision` を追加。`/equity-decision NVDA` / `/equity-decision 7203` のように銘柄を渡すと、5 phase (Business / Fundamentals / Valuation / Risks / Verdict) の purchase memo を 1 枚で出して、末尾に「深掘りする？」5 件の選択肢を提示する。

[anthropics/financial-services](https://github.com/anthropics/financial-services) (Apache 2.0) の retail で使える部分 — DCF / comps / 3-statement / earnings analysis / thesis tracker / risk taxonomy — を採用し、無料データソース (SEC EDGAR / EDINET / Yahoo Finance / NYU Damodaran) へ全置換した。

> ⚠️ Not investment advice. memo は research summary であり、最終判断はユーザー自身で。

## アーキテクチャ

```
dot_claude/skills/equity-decision/
├── SKILL.md                  # entry, ルーティング, fail-loud rules
├── README.md                 # ユーザ向け使用例
├── references/
│   ├── equity-workflow.md    # 5 phase テンプレ
│   ├── dcf-rubric.md         # WACC / 成長率 / terminal の defaults & guardrails
│   ├── growth-stock-checks.md  # SBC, NRR, Rule of 40
│   ├── risk-taxonomy.md      # 5 axes Active/Latent/Inactive
│   └── data-sources.md       # EDGAR / EDINET / Yahoo / Damodaran query notes
└── scripts/
    ├── fetch_yahoo.py        # Yahoo Finance: 価格 + 主要指標 (US + JP via .T)
    ├── fetch_edgar.py        # SEC EDGAR: 10-K / 10-Q / 5 × 8-K
    └── fetch_edinet.py       # EDINET v2: 有価証券報告書 + 四半期報告書
```

すべての Python script は `uv run` 単体実行 (PEP 723 inline metadata)。devbox / global pip 不要。

## v1 スコープ

- US 個別株 (NVDA / AAPL …) — Yahoo + EDGAR auto-fetch
- JP 個別株 (7203 / 9984 …) — Yahoo + EDINET auto-fetch
- 入力: ticker、4 桁コード、URL、ticker + メモ の 4 形態 サポート

## v1.x で後回し

- ETF / インデックス (v1.1) — 評価軸が個別株と違うので別 workflow
- 配当 / インカム重視の screen (v1.2)
- Cache (24h TTL) / Stooq fallback / polish
- Hong Kong / Shanghai / 欧州市場
- NISA 残枠計算 (個人口座データが必要)

## Test plan

- [x] `just test-skills` → **7 passed, 2 skipped** (skip 2 件は EDINET key が op CLI 経由で取れない subagent 環境向け)
- [x] Phase A scaffold 8/8 ファイル deploy 済み
- [x] `uv run scripts/fetch_yahoo.py NVDA` → JSON 出力 (PE 32.7、market cap $5.17T 確認)
- [x] `uv run scripts/fetch_yahoo.py 7203` → JSON 出力 (Toyota PE 10.3、市価 ¥3030 確認)
- [x] `uv run scripts/fetch_edgar.py NVDA` → 7 filings (10-K + 10-Q + 5 × 8-K)
- [x] `uv run scripts/fetch_edinet.py 7203` — EDINET 公式 API key の activate 待ち。Key 設定後にローカルで smoke 確認

## EDINET 認証

```python
def get_key():
    # 1. env var が優先
    if key := os.environ.get("EDINET_SUBSCRIPTION_KEY"): return key
    # 2. 1Password op CLI 経由
    op_ref = os.environ.get("EDINET_OP_REF", "op://Personal/EDINET/credential")
    result = subprocess.run(["op", "read", op_ref], ...)
    ...
```

Key 未取得時は `数字取得失敗: EDINET key unavailable. Set EDINET_SUBSCRIPTION_KEY env var, or store in 1Password at op://Personal/EDINET/credential (override path via EDINET_OP_REF env).` を stderr に出して exit 1。Hallucination ではなく明示的失敗。

## Fail-loud 設計

`SKILL.md` 内で明示:

- フェッチ失敗時は memo に「数字取得失敗 — manual entry required」を書く。**Claude が数字を捏造することは禁止。**
- EDINET v2 は HTTP 200 を返しつつ body の `metadata.status` / `StatusCode` に 401 を入れてくる。fetcher は 1 回目の 401 で即 raise (400 日 silent walk を回避)

## Brainstorming → Spec → Plan の足跡

- Brainstorming → 個別株 5 phase / ETF 4 phase / Approach C (一発レポート + 深掘りメニュー) で合意
- `docs/superpowers/specs/2026-05-29-equity-decision-skill-design.md` — design doc
- `docs/superpowers/plans/2026-05-29-equity-decision-skill.md` — 17 task の TDD 計画
- Phase A (scaffold) は inline で書き、Phase B (Python fetchers) を subagent + TDD で実装

途中 EDINET API が auth 必須に変わったことを発見 (subagent が黙ってモックせずに止めて報告 → 良い generator-evaluator separation の例)。一度 v1.1 に deferral commit (`0a7d15c`) を入れたが、key を取得していただいたので `e5febc1` で v1 に戻した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
