### PR TITLE
feat(claude): add .ai learning-notes convention and learning-primer skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,10 @@ just diff        # Show pending chezmoi changes
 - `dot_config/ghostty/` - Terminal emulator config
 - `private_dot_ssh/` - SSH config (common settings only)
 
+## Authoring rules & skills
+
+Rules (`dot_claude/rules/`) and skills (`dot_claude/skills/`) added to this repo are written in **English**. Japanese is allowed only where nuance requires it — e.g. a skill `description`'s trigger phrases that the user types in Japanese, or a generated-output template whose reader is Japanese.
+
 ## CI
 
 GitHub Actions runs on every push/PR to main:

--- a/dot_claude/rules/repo-notes.md
+++ b/dot_claude/rules/repo-notes.md
@@ -1,0 +1,10 @@
+# Repository Learning Notes
+
+Repository-specific learning notes go in `.ai/` at the repo root, written as
+Markdown (globally git-ignored; never committed).
+
+- Capture durable repo-specific knowledge: gotchas, non-obvious constraints, investigation results
+- One topic per file, kebab-case names (e.g. `auth-flow.md`)
+- At the start of work on a repo, skim the relevant `.ai/*.md`
+- Do NOT write here: facts the code/git already records, secrets, throwaway scratch
+- Per-repo and uncommitted; cross-project facts go to global memory instead

--- a/dot_claude/skills/learning-primer/SKILL.md
+++ b/dot_claude/skills/learning-primer/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: learning-primer
+description: |
+  Research a repo/docs in parallel for a given topic and generate a disposable
+  GFM+mermaid learning primer (Markdown). Triggers (Japanese): 「〜の学習資料を作って」
+  「オンボーディング資料がほしい」「〜をキャッチアップしたい」「primer 作って」.
+  Output is not committed (defaults to repo-local `.ai/`, globally git-ignored);
+  view with mo or any GFM+mermaid viewer.
+argument-hint: <topic> <audience> [sources] [out]
+---
+
+# learning-primer
+
+Research target repositories/docs in parallel for a topic and generate a
+**disposable learning primer (Markdown, with mermaid diagrams)** tailored to the
+reader. Domain-agnostic: never hardcode domain knowledge — research it from
+`sources` each time.
+
+Initial request: $ARGUMENTS
+
+## Diagram-first (top priority)
+
+Diagrams are the centerpiece. Use mermaid aggressively to maximize the reader's
+comprehension and knowledge retention.
+
+- **Any explanation involving structure, time order, relationships, or before/after gets a mermaid diagram** — do not settle for prose alone
+- Aim for **at least one diagram per section** across skeleton §1–§4 (skip sections with no such structure)
+- Give each diagram a one-line caption (what it shows) right before or after it, so it reads standalone
+- One diagram = one concept. Show the `audience` before → after and the prerequisite Tier dependencies as diagrams too
+- Do not cram — **split** instead (node cap and diagram types per "Mermaid diagram types" below)
+
+## Inputs
+
+| Arg | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `topic` | ✓ | — | Subject to learn |
+| `audience` | ✓ | — | Reader profile; frame as "current state → target state" |
+| `sources` | optional | cwd | Repos/dirs to research (multiple allowed) |
+| `out` | optional | `.ai/<topic-slug>-primer.md` | Output path |
+
+The default `out` lives in `.ai/`, which is **globally git-ignored**
+(`~/.config/git/ignore`), so it is never committed. Override with `out=/tmp/...`
+to write outside the repo. Outside a git repo where `.ai/` is not ignored, set
+`out` explicitly.
+
+**Early return**: if `topic` or `audience` is missing, ask for it. Do not guess.
+
+## Procedure (research harness)
+
+1. **Validate inputs**: confirm `topic` / `audience`; ask if missing (early return)
+2. **Classify sources**: detect whether `sources` (default cwd) is a docs site / plain Markdown / code-only, and adapt
+   > [!WARNING]
+   > Landing / index / category pages are often **stubs**. Do not trust the index — read the real files (design docs, ADRs, how-tos, code).
+3. **Decompose**: split `topic` into 3–5 sub-areas. Generic categories: concept & motivation / how it works / workflow & lifecycle / surrounding ecosystem & tools / prerequisites
+4. **Parallel fan-out**: assign each sub-area to an Explore subagent; have it return **only "conclusion + evidence `path(:line)`"** (no long quotations — preserve main context)
+5. **Synthesize**: pour into the skeleton below. Open with the `audience` before → after to create the perspective shift
+6. Pass the **quality gates** (below)
+7. **Write** to `out` (create `.ai/` if absent). Finish by presenting the viewer command `mo <out>`. Installs (brew/npm/gh ext, etc.) need network — delegate to the user; automate only generation (file write) and localhost viewing
+
+## Output skeleton (fixed)
+
+Write the primer in the audience's language; translate the headings accordingly.
+
+```
+# <topic> Learning Primer (for <audience>)
+0. Mindset (current → target / perspective-shift table)
+1. Big picture and the "why" + diagram
+2. Components & related repos/tools map + diagram
+3. Workflow / lifecycle + diagram
+4. Sub-area deep dives (structure/relationship diagram per area)
+5. Prerequisites (Tier 1/2/3 table + dependency diagram)
+6. What to read (source paths, by priority)
+7. First steps (concrete actions)
+Appendix: glossary (optional)
+```
+
+### Mermaid diagram types (derive from content; one per concept, ~4–8 total)
+
+| Purpose | Syntax |
+|---------|--------|
+| Structure/dependency, before/after | `graph TD` |
+| Data flow / pipeline | `flowchart LR` |
+| Lifecycle / phases | `stateDiagram-v2` |
+| Cross-system calls | `sequenceDiagram` |
+| Schema / relationships | `erDiagram` |
+
+≤ ~10 nodes per diagram; concrete labels (no `ServiceA` — use `UserService`).
+
+### Output format constraints (viewer-independent)
+
+- Mermaid only in ` ```mermaid ` fences (no image/HTML embeds)
+- Notes use GitHub Alerts (`> [!NOTE]` etc.); `:::note` and MDX-specific syntax are forbidden
+- Tables, task lists, footnotes: GFM standard only; no frontmatter
+- → renders intact in mo, GitHub, and VS Code (with extension)
+
+## Quality gates (anti-slop)
+
+- **Fact-grounding**: attach `path(:line)` to every non-obvious claim. If you cannot cite it, do not write it
+- **Generator ≠ evaluator**: after generation, have a **separate subagent** do one pass flagging ungrounded or wrong claims (Generator-Evaluator separation from `harness-engineering.md`). The evaluator verifies grounding, not implementation
+- **Honest coverage**: when prioritizing from a large set, state "read M of N; reverse-lookup recommended for the rest" (no silent truncation)
+- **Absolute dates**: no "recently" — use `YYYY-MM-DD`
+
+## General lessons (what actually helps)
+
+- **Don't trust landing/index pages**: often heading stubs. Read the real files
+- **Don't win by volume**: sort large doc sets (e.g. ADRs) by date/importance and prioritize "foundational → specific". Distinguish old foundational decisions from recent one-off ones hit in operations
+- **Verify external tools' real capabilities**: outcomes diverge on things like a renderer's mermaid support. Verify before recommending — do not guess
+- **The reader's current state is the strongest hook**: framing `audience` as before → after gives a foothold for understanding
+- **State environment constraints**: installs (network) are delegated to the user; automate only generation (write) and localhost viewing

--- a/dot_config/git/ignore
+++ b/dot_config/git/ignore
@@ -40,3 +40,6 @@ devbox.lock
 sourcemaps
 
 .claude/worktrees/
+
+# AI working notes (per-repo, never committed)
+.ai/


### PR DESCRIPTION
## Summary

Introduce a repo-local **`.ai/`** directory for AI-written learning notes, globally git-ignored so it is never committed, and add the **`learning-primer`** skill that generates disposable GFM+mermaid learning primers into it.

## Why

We want per-repo scratch space where the agent can accumulate learning/understanding notes without polluting the repo's tracked history. Globally ignoring `.ai/` gives the same "never committed" guarantee as `/tmp` while keeping the notes alongside the repo for later reference.

## Changes

| File | Change |
|------|--------|
| `dot_config/git/ignore` | Ignore `.ai/` globally (XDG-default excludesfile, matches existing `.claude/` subpath convention) |
| `dot_claude/rules/repo-notes.md` | New rule describing `.ai/` usage |
| `dot_claude/skills/learning-primer/SKILL.md` | New diagram-first primer generator (default output `.ai/<topic-slug>-primer.md`) |
| `CLAUDE.md` | Document the English authoring convention for repo rules/skills (Japanese allowed only for nuance, e.g. trigger phrases) |

## Design notes

- `.ai/` ignore is a **specific subpath**, not a blanket `.claude/`-style wipe, so it never shadows committed config.
- `learning-primer` is a **skill** (on-demand), not a rule, to avoid consuming the always-loaded rule budget.
- Skill body is English per the new convention; only the `description` trigger phrases stay Japanese so they match what the user types.

## Verification

- `.ai/` confirmed ignored at repo root **and** nested dirs via `git check-ignore` against the XDG-default excludesfile (no explicit `core.excludesfile`); control file stays tracked.
- `chezmoi diff` maps both files to the correct `~/.config/...` and `~/.claude/...` targets.
- After apply, the skill appears in the harness skill list (valid frontmatter) and `~/.config/git/ignore` contains `.ai/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 121273,
          "cache_creation_input_tokens": 121273,
          "cache_read_input_tokens": 5946465,
          "input_tokens": 11519,
          "model": "claude-opus-4-8",
          "output_tokens": 49530,
          "total_context_tokens": 6128787,
          "turns": 31
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 121273,
          "cache_creation_input_tokens": 121273,
          "cache_read_input_tokens": 5946465,
          "input_tokens": 11519,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 49530,
          "total_context_tokens": 6128787,
          "turns": 31
        }
      ],
      "recorded_at": "2026-05-29T07:18:04Z",
      "sha": "b2863440a706ef07608536c2a56183f6c1d4728b",
      "subject": "feat(claude): add .ai learning-notes convention and learning-primer skill",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 121273,
        "cache_creation_input_tokens": 121273,
        "cache_read_input_tokens": 5946465,
        "input_tokens": 11519,
        "output_tokens": 49530,
        "total_context_tokens": 6128787,
        "turns": 31
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 1,
  "pr": {
    "base": "main",
    "head": "feat/ai-learning-notes",
    "number": 148
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 1,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 121273,
    "cache_creation_input_tokens": 121273,
    "cache_read_input_tokens": 5946465,
    "input_tokens": 11519,
    "output_tokens": 49530,
    "total_context_tokens": 6128787,
    "turns": 31
  },
  "totals_by_model": [
    {
      "cache_creation_ephemeral_1h_input_tokens": 121273,
      "cache_creation_input_tokens": 121273,
      "cache_read_input_tokens": 5946465,
      "input_tokens": 11519,
      "model": "claude-opus-4-8",
      "output_tokens": 49530,
      "total_context_tokens": 6128787,
      "turns": 31
    }
  ],
  "updated_at": "2026-05-29T07:19:10Z"
}
```

</details>
<!-- code-flow-usage-json:end -->
