### PR TITLE
feat(equity-decision): extract 監査/訴訟 sections from EDINET XBRL

### DIFF
--- a/docs/superpowers/plans/2026-05-31-edinet-section-extract.md
+++ b/docs/superpowers/plans/2026-05-31-edinet-section-extract.md
@@ -1,0 +1,455 @@
+# EDINET 有報セクション自動抽出 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `fetch_edinet.py --sections <docID>` で有報 XBRL から監査セクション本文と訴訟関連スニペットを JSON 抽出し、equity-decision memo の Phase 4 を一次情報で自動的に埋められるようにする。
+
+**Architecture:** 既存の一覧モード（`<code>` → 書類インデックス）は不変のまま、`--sections <docID>` モードを追加。type=1 XBRL ZIP を落とし、PublicDoc インスタンスを lxml でパース。監査は要素 `AuditsTextBlock` 直指定、訴訟は全 TextBlock を `訴訟|係争|損害賠償` でスキャン。純粋関数 `extract_sections_from_instance(bytes)` をオフラインのフィクスチャでTDD。
+
+**Tech Stack:** Python 3.11+ (uv single-file script, PEP723), requests, lxml, pytest。
+
+**Pre-req:** 1Password デスクトップアプリの CLI 連携が有効（`op read op://Personal/EDINET/credential` が非対話で通る）。フィクスチャ `scripts/tests/fixtures/jpcrp030000-asr-001_E04707-000_2025-03-31_01_2025-06-26.xbrl`（OLC 第65期、4.8MB）は配置済み。
+
+**Note on commits:** このスキルディレクトリ（`~/.claude/skills/equity-decision`）は git 管理外。各タスクの「Commit」ステップは git init 済みの場合のみ実行（未管理ならスキップしてよい）。
+
+---
+
+### Task 1: lxml 依存と抽出ヘルパ（監査）
+
+**Files:**
+- Modify: `scripts/fetch_edinet.py`（PEP723 ヘッダ + 新規関数）
+- Create: `scripts/tests/test_extract_sections.py`
+- Test fixture (already present): `scripts/tests/fixtures/jpcrp030000-asr-001_E04707-000_2025-03-31_01_2025-06-26.xbrl`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+Create `scripts/tests/test_extract_sections.py`:
+
+```python
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from fetch_edinet import extract_sections_from_instance  # noqa: E402
+
+FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "jpcrp030000-asr-001_E04707-000_2025-03-31_01_2025-06-26.xbrl"
+)
+
+
+def test_audit_section_extracted():
+    out = extract_sections_from_instance(FIXTURE.read_bytes())
+    assert out["audit"]["found"] is True
+    assert out["audit"]["element"] == "AuditsTextBlock"
+    assert "監査の状況" in out["audit"]["text"]
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd ~/.claude/skills/equity-decision && uv run --with pytest --with lxml --with requests pytest scripts/tests/test_extract_sections.py -v`
+Expected: FAIL — `ImportError: cannot import name 'extract_sections_from_instance'`
+
+- [ ] **Step 3: 最小実装（PEP723 に lxml 追加 + 抽出関数）**
+
+`scripts/fetch_edinet.py` の PEP723 dependencies を更新:
+
+```python
+# dependencies = [
+#   "requests>=2.31",
+#   "lxml>=5.0",
+# ]
+```
+
+`import requests` の直後に追加:
+
+```python
+import re
+from lxml import etree, html as lhtml
+
+LITIGATION_RE = re.compile(r"訴訟|係争|損害賠償")
+_WS_RE = re.compile(r"\s+")
+
+
+def _detag(raw: str) -> str:
+    if not raw:
+        return ""
+    try:
+        text = lhtml.fromstring(raw).text_content()
+    except Exception:
+        text = raw
+    return _WS_RE.sub(" ", text).strip()
+
+
+def extract_sections_from_instance(instance_bytes: bytes) -> dict:
+    root = etree.fromstring(instance_bytes)
+    audit = {"element": "AuditsTextBlock", "found": False, "text": None}
+    matches: list[dict] = []
+    for el in root.iter():
+        local = etree.QName(el).localname
+        if "TextBlock" not in local:
+            continue
+        raw = el.text
+        if not raw or not raw.strip():
+            continue
+        text = _detag(raw)
+        if local == "AuditsTextBlock" and not audit["found"]:
+            audit = {"element": local, "found": True, "text": text}
+        m = LITIGATION_RE.search(text)
+        if m:
+            start = max(0, m.start() - 60)
+            end = min(len(text), m.end() + 120)
+            matches.append({"element": local, "snippet": text[start:end]})
+    return {
+        "audit": audit,
+        "litigation": {"found": bool(matches), "matches": matches},
+    }
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cd ~/.claude/skills/equity-decision && uv run --with pytest --with lxml --with requests pytest scripts/tests/test_extract_sections.py -v`
+Expected: PASS (`test_audit_section_extracted`)
+
+- [ ] **Step 5: Commit（git管理時のみ）**
+
+```bash
+git add scripts/fetch_edinet.py scripts/tests/test_extract_sections.py
+git commit -m "feat(edinet): extract 監査の状況 from 有報 XBRL"
+```
+
+---
+
+### Task 2: 訴訟キーワードスキャンのテスト
+
+**Files:**
+- Modify: `scripts/tests/test_extract_sections.py`（テスト追加のみ。実装は Task 1 で完了済み）
+
+- [ ] **Step 1: 失敗しないことを期待するテストを追加**（実装済み機能の固定化）
+
+`test_extract_sections.py` に追記:
+
+```python
+def test_litigation_scan_returns_matches():
+    out = extract_sections_from_instance(FIXTURE.read_bytes())
+    lit = out["litigation"]
+    assert lit["found"] is True
+    assert all({"element", "snippet"} <= set(m) for m in lit["matches"])
+    assert any(
+        ("訴訟" in m["snippet"]) or ("係争" in m["snippet"]) or ("損害賠償" in m["snippet"])
+        for m in lit["matches"]
+    )
+
+
+def test_litigation_no_dedicated_textblock_element():
+    # 有報タクソノミに訴訟専用要素は無い前提を固定。
+    # OLC では BusinessRisksTextBlock 等にキーワードが散在する。
+    out = extract_sections_from_instance(FIXTURE.read_bytes())
+    elems = {m["element"] for m in out["litigation"]["matches"]}
+    assert "BusinessRisksTextBlock" in elems
+```
+
+- [ ] **Step 2: テストが通ることを確認**
+
+Run: `cd ~/.claude/skills/equity-decision && uv run --with pytest --with lxml --with requests pytest scripts/tests/test_extract_sections.py -v`
+Expected: PASS（3 tests）
+
+- [ ] **Step 3: Commit（git管理時のみ）**
+
+```bash
+git add scripts/tests/test_extract_sections.py
+git commit -m "test(edinet): pin litigation keyword-scan behavior"
+```
+
+---
+
+### Task 3: `--sections <docID>` CLI モード
+
+**Files:**
+- Modify: `scripts/fetch_edinet.py`（ZIP取得関数 + main 引数分岐）
+
+- [ ] **Step 1: ZIP→インスタンス抽出とダウンロード関数を追加**
+
+`extract_sections_from_instance` の下に追加:
+
+```python
+import io
+import zipfile
+
+
+def _instance_from_zip(zip_bytes: bytes) -> bytes:
+    zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    for name in zf.namelist():
+        if "/PublicDoc/" in name and name.endswith(".xbrl"):
+            return zf.read(name)
+    raise ValueError("数字取得失敗: PublicDoc .xbrl not found in EDINET ZIP")
+
+
+def fetch_sections(doc_id: str) -> dict:
+    key = get_key()
+    url = f"https://disclosure.edinet-fsa.go.jp/api/v2/documents/{doc_id}?type=1"
+    r = requests.get(url, headers={KEY_HEADER: key}, timeout=60)
+    r.raise_for_status()
+    instance = _instance_from_zip(r.content)
+    return {"docID": doc_id, "sections": extract_sections_from_instance(instance)}
+```
+
+（`io`/`zipfile` は既存 import に無ければファイル冒頭の import 群へ移動してよい。）
+
+- [ ] **Step 2: main() に `--sections` 分岐を追加**
+
+既存 `main()` の先頭を以下に置換:
+
+```python
+def main() -> int:
+    args = sys.argv[1:]
+    if len(args) == 2 and args[0] == "--sections":
+        try:
+            data = fetch_sections(args[1])
+        except Exception as e:
+            msg = f"{e}" if str(e).startswith("数字取得失敗") else f"数字取得失敗: {e}"
+            print(msg, file=sys.stderr)
+            return 1
+        json.dump(data, sys.stdout, ensure_ascii=False)
+        return 0
+    if len(args) != 1:
+        print(
+            "usage: fetch_edinet.py <4-digit-secCode> | --sections <docID>",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        data = fetch_docs(args[0])
+    except Exception as e:
+        print(f"{e}" if str(e).startswith("数字取得失敗") else f"数字取得失敗: {e}", file=sys.stderr)
+        return 1
+    json.dump(data, sys.stdout, ensure_ascii=False)
+    return 0
+```
+
+- [ ] **Step 3: ライブ smoke test（要 op 認証 / ネット）**
+
+Run: `cd ~/.claude/skills/equity-decision && uv run scripts/fetch_edinet.py --sections S100VY55 | python3 -m json.tool | head -30`
+Expected: JSON。`sections.audit.found == true`、`sections.audit.text` が「監査の状況」を含む、`sections.litigation.matches` が非空。
+
+- [ ] **Step 4: 既存一覧モードが壊れていないことを確認**
+
+Run: `cd ~/.claude/skills/equity-decision && uv run scripts/fetch_edinet.py 4661 | python3 -m json.tool`
+Expected: 従来どおり `edinetCode` と `docs`（有報）を含む JSON。
+
+- [ ] **Step 5: Commit（git管理時のみ）**
+
+```bash
+git add scripts/fetch_edinet.py
+git commit -m "feat(edinet): add --sections <docID> mode"
+```
+
+---
+
+### Task 4: `TARGET_TYPES` 140→160 修正（四半期報告書廃止対応）
+
+**Files:**
+- Modify: `scripts/fetch_edinet.py`（定数 + 日次マッチ部の小リファクタ + テスト）
+- Modify: `scripts/tests/test_extract_sections.py`（または新規 `test_target_types.py`）
+
+- [ ] **Step 1: 日次マッチを純粋関数へ抽出して失敗テストを書く**
+
+`scripts/tests/test_target_types.py` を新規作成:
+
+```python
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from fetch_edinet import TARGET_TYPES, collect_targets  # noqa: E402
+
+
+def test_target_types_use_160_not_140():
+    assert TARGET_TYPES == ("120", "160")
+
+
+def test_collect_targets_picks_120_and_160():
+    results = [
+        {"secCode": "46610", "edinetCode": "E04707", "docTypeCode": "120",
+         "docDescription": "有価証券報告書", "submitDateTime": "2025-06-26 15:30", "docID": "S1"},
+        {"secCode": "46610", "edinetCode": "E04707", "docTypeCode": "160",
+         "docDescription": "半期報告書", "submitDateTime": "2025-12-01 15:00", "docID": "S2"},
+        {"secCode": "99990", "edinetCode": "E99999", "docTypeCode": "120",
+         "docDescription": "別会社", "submitDateTime": "2025-06-26 15:30", "docID": "S3"},
+    ]
+    found: dict = {}
+    edinet = collect_targets(results, "46610", found)
+    assert edinet == "E04707"
+    assert set(found) == {"120", "160"}
+    assert found["120"]["docID"] == "S1"
+    assert found["160"]["docID"] == "S2"
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd ~/.claude/skills/equity-decision && uv run --with pytest --with lxml --with requests pytest scripts/tests/test_target_types.py -v`
+Expected: FAIL — `ImportError: cannot import name 'collect_targets'`（かつ TARGET_TYPES がまだ 140）
+
+- [ ] **Step 3: 定数変更 + 純粋関数を実装し fetch_docs から呼ぶ**
+
+定数を変更:
+
+```python
+TARGET_TYPES = ("120", "160")  # 120=有報, 160=半期報告書（140 四半期報告書は2024改正で廃止）
+```
+
+`fetch_docs` の日次ループ内マッチ処理を関数化して追加:
+
+```python
+def collect_targets(results: list, code_padded: str, found: dict) -> str | None:
+    edinet_code = None
+    for item in results or []:
+        if item.get("secCode") != code_padded:
+            continue
+        if edinet_code is None and item.get("edinetCode"):
+            edinet_code = item["edinetCode"]
+        doc_type = item.get("docTypeCode")
+        if doc_type in TARGET_TYPES and doc_type not in found:
+            found[doc_type] = {
+                "docTypeCode": doc_type,
+                "docDescription": item.get("docDescription", ""),
+                "submitDateTime": item.get("submitDateTime", ""),
+                "docID": item.get("docID", ""),
+                "url": _doc_url(item.get("docID", "")),
+            }
+    return edinet_code
+```
+
+`fetch_docs` 内の該当 for ループ本体を以下に置換:
+
+```python
+        ec = collect_targets(payload.get("results", []), code_padded, found)
+        if ec and edinet_code is None:
+            edinet_code = ec
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cd ~/.claude/skills/equity-decision && uv run --with pytest --with lxml --with requests pytest scripts/tests/test_target_types.py -v`
+Expected: PASS（2 tests）
+
+- [ ] **Step 5: Commit（git管理時のみ）**
+
+```bash
+git add scripts/fetch_edinet.py scripts/tests/test_target_types.py
+git commit -m "fix(edinet): replace deprecated docType 140 with 160 (半期報告書)"
+```
+
+---
+
+### Task 5: `op read` timeout を 45s に延長
+
+**Files:**
+- Modify: `scripts/fetch_edinet.py`（`get_key()` 内 `timeout=20` → `timeout=45`）
+
+- [ ] **Step 1: 値を変更**
+
+`get_key()` 内:
+
+```python
+        result = subprocess.run(
+            ["op", "read", op_ref],
+            capture_output=True,
+            text=True,
+            timeout=45,
+        )
+```
+
+コメントも更新: `# op read via Desktop integration prompts biometrics; allow time to approve.`
+
+- [ ] **Step 2: 既存呼び出しが通ることを確認**
+
+Run: `cd ~/.claude/skills/equity-decision && uv run scripts/fetch_edinet.py 4661 >/dev/null && echo OK`
+Expected: `OK`（認証→一覧取得が成功）
+
+- [ ] **Step 3: Commit（git管理時のみ）**
+
+```bash
+git add scripts/fetch_edinet.py
+git commit -m "chore(edinet): bump op read timeout for biometric approval"
+```
+
+---
+
+### Task 6: ワークフロー結線（SKILL.md / equity-workflow.md）
+
+**Files:**
+- Modify: `SKILL.md`（データ fetcher 表 + JP フォールバック節）
+- Modify: `references/equity-workflow.md`（Phase 4 手順）
+
+- [ ] **Step 1: SKILL.md のデータ fetcher 表に行を追加**
+
+「JP code → EDINET filings」行の直後に追加:
+
+```markdown
+| JP 有報本文 → 訴訟・監査 | `uv run scripts/fetch_edinet.py --sections {docID}` | `sections.audit`（監査の状況本文）+ `sections.litigation.matches`（訴訟/係争/損害賠償スニペット） |
+```
+
+- [ ] **Step 2: SKILL.md の JP フォールバック節に追記**
+
+「## JP fallback when EDINET is unavailable」節の冒頭付近に1行追加:
+
+```markdown
+> EDINET が通る場合: まず `fetch_edinet.py {code}` で有報 docID を取得し、続けて `fetch_edinet.py --sections {docID}` で Phase 4 の ⚖️訴訟・📚監査 を一次情報から埋める（このとき Phase 4 は手動補完不要）。
+```
+
+- [ ] **Step 3: equity-workflow.md の Phase 4  filling rules に追記**
+
+「## Filling rules」の最初の箇条書き群に追加:
+
+```markdown
+- **Phase 4（JP）**: EDINET が使える場合、`fetch_edinet.py --sections {docID}` の出力で `⚖️ Regulation/litigation` と `📚 Accounting` を埋める。`sections.audit.text` から監査体制（監査役会/監査等委員会、会計監査人、非監査報酬の有無）を要約。`sections.litigation.found == false` または事業リスクの一般言及のみなら「重大な係争の個別開示なし」と記す。捏造禁止は同様に適用。
+```
+
+- [ ] **Step 4: 結線の目視確認**
+
+Run: `cd ~/.claude/skills/equity-decision && grep -n "\-\-sections" SKILL.md references/equity-workflow.md`
+Expected: 3 箇所（SKILL 表 / SKILL フォールバック / workflow Phase4）でヒット。
+
+- [ ] **Step 5: Commit（git管理時のみ）**
+
+```bash
+git add SKILL.md references/equity-workflow.md
+git commit -m "docs(edinet): wire --sections into Phase 4 workflow"
+```
+
+---
+
+### Task 7: 全テスト緑 + dev ツール整理
+
+**Files:**
+- Modify/Delete: `scripts/_devtools/fetch_fixture.py`（残置 or 削除の判断）
+
+- [ ] **Step 1: 全テストを実行**
+
+Run: `cd ~/.claude/skills/equity-decision && uv run --with pytest --with lxml --with requests pytest scripts/tests/ -v`
+Expected: PASS（test_extract_sections の3件 + test_target_types の2件 = 5 tests）
+
+- [ ] **Step 2: dev ツールの扱いを決める**
+
+`scripts/_devtools/fetch_fixture.py` はフィクスチャ再生成用の一回限りツール。残すなら docstring に「フィクスチャ更新時のみ使用」と明記、不要なら削除:
+
+```bash
+rm -rf scripts/_devtools   # 残置する場合はこの行を実行しない
+```
+
+- [ ] **Step 3: Commit（git管理時のみ）**
+
+```bash
+git add -A
+git commit -m "chore(edinet): finalize fixture tooling"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage**: A 抽出CLI → Task3 / B XBRLパイプライン（監査=AuditsTextBlock, 訴訟=keyword scan）→ Task1,2 / C 140→160 → Task4 / D TDD+fixture → Task1,2,4,7 / E ワークフロー結線 → Task6 / F auth timeout → Task5。全項目に対応タスクあり。
+- **Placeholder scan**: 各コードステップに実コードを記載。実物フィクスチャで検証済み（AuditsTextBlock 存在・監査の状況本文・訴訟は BusinessRisksTextBlock 等に散在）。
+- **Type consistency**: `extract_sections_from_instance(bytes)->dict`、`collect_targets(results,code_padded,found)->str|None`、`fetch_sections(doc_id)->dict`、`_instance_from_zip(bytes)->bytes`、`_detag(str)->str` は全タスクで整合。出力キー `audit.{element,found,text}` / `litigation.{found,matches[].{element,snippet}}` は spec の出力例と一致。

--- a/docs/superpowers/specs/2026-05-31-edinet-section-extract-design.md
+++ b/docs/superpowers/specs/2026-05-31-edinet-section-extract-design.md
@@ -1,0 +1,80 @@
+# Design: EDINET 有報セクション自動抽出
+
+*Date: 2026-05-31 | Target: `~/.claude/skills/equity-decision/scripts/fetch_edinet.py` + workflow docs*
+
+## Problem
+
+`fetch_edinet.py` は書類インデックス（有報の docID + URL）を返すところまでしか自動化されておらず、有報本文の「訴訟事件等」「監査の状況」は人手で取得・解析する必要がある。equity-decision memo の Phase 4 で `⚖️ Regulation/litigation` と `📚 Accounting` が `数字取得失敗` のまま残る原因。
+
+加えて2つの隣接課題:
+- `TARGET_TYPES = ("120","140")` の `140`（四半期報告書）は2024年の開示制度改正で廃止済み。早期 break 条件を満たせず常に400日フル探索になり遅い。
+- `op` がツールシェル（非対話）で認証できず、キー取得が手動 `!` に依存していた。
+
+## Goal / Done criteria
+
+1. `fetch_edinet.py --sections <docID>` が有報 XBRL から訴訟・監査セクションのプレーンテキストを JSON で返す。
+2. オフラインのフィクスチャに対するテストが Red→Green で通る。
+3. `TARGET_TYPES` を `("120","160")` に修正し、四半期報告書探索の無駄を除去。
+4. `SKILL.md` / `equity-workflow.md` に抽出ステップが結線され、EDINET が通れば Phase 4 が一次情報で自動的に埋まる。
+5. キーは op 経由のまま、stdout・設定ファイル平文に露出しない。
+
+## Out of scope (YAGNI)
+
+セグメント数値抽出、事業等のリスク全文、PDF 経路、複数銘柄バッチ。
+
+## Design
+
+### A. CLI surface（後方互換維持）
+
+- 既存: `fetch_edinet.py <4桁コード>` → 書類一覧 JSON（**不変**）。
+- 追加: `fetch_edinet.py --sections <docID>` → セクション抽出 JSON。
+
+一覧（安い）と抽出（ZIP DL で重い）を分離。ワークフローは2段: 一覧で有報 docID を得る → `--sections` で本文抽出。
+
+### B. 抽出パイプライン
+
+実物調査（OLC 第65期 S100VY55）で確定した事実:
+- 監査 → 専用要素 `jpcrp_cor:AuditsTextBlock`（「(3)【監査の状況】…」）が存在。
+- 訴訟 → 専用 TextBlock は**存在しない**。`訴訟|係争|損害賠償` は `BusinessRisksTextBlock` 等に一般言及として散在するのみ。
+- → ラベル linkbase parsing は不要。要素 local-name 直指定＋キーワードスキャンで足りる。
+
+1. `GET documents/{docID}?type=1`（XBRL ZIP）をキーヘッダ付きで取得 → `io.BytesIO` → `zipfile.ZipFile`。
+2. ZIP 内 `XBRL/PublicDoc/*asr*.xbrl`（有報インスタンス）を特定。
+3. `lxml` でパース（依存に `lxml` 追加）。
+4. **監査**: local-name == `AuditsTextBlock` の要素を取得 → de-tag。
+5. **訴訟**: 全 `*TextBlock` 要素の de-tag テキストを `訴訟|係争|損害賠償` でスキャンし、ヒットしたスニペット＋出所 local-name を収集。
+6. de-tag は `lxml.html.fromstring(text).text_content()` ＋空白正規化。
+7. 出力:
+   ```json
+   {"docID": "...", "sections": {
+     "audit": {"element": "AuditsTextBlock", "found": true, "text": "..."},
+     "litigation": {"found": true, "matches": [{"element": "BusinessRisksTextBlock", "snippet": "..."}]}}}
+   ```
+   監査要素が無ければ `audit.found=false, text=null`。訴訟ヒット無しは `litigation.found=false, matches=[]`（memo は「重大な係争の個別開示なし」と扱う）。
+
+### C. バグ修正
+
+`TARGET_TYPES = ("120","140")` → `("120","160")`。160=半期報告書。docstring も更新。
+
+### D. テスト（TDD）
+
+- フィクスチャ: OLC 第65期有報の `.xbrl` インスタンスを `scripts/tests/fixtures/` に保存済み（オフライン解析）。ラベル linkbase は不要。
+- `test_extract_sections.py`: フィクスチャをパース → 訴訟・監査が期待部分文字列を含むことを assert。
+- `TARGET_TYPES` 変更は documents.json の録画レスポンスで軽くカバー。
+- 実行: `uv run --with pytest pytest scripts/tests/`。
+
+### E. ワークフロー結線
+
+- `SKILL.md` のデータ fetcher 表に `--sections <docID>` 行を追加。
+- `equity-workflow.md` Phase 4 に「有報 docID を `--sections` で抽出し ⚖️訴訟・📚監査 を一次情報で埋める」手順を明記。
+- JP フォールバック節に「EDINET が通れば Phase 4 まで自動」と追記。
+
+### F. auth（コード最小）
+
+`get_key()` の `op read` パスはそのまま。`timeout=20`→`timeout=45` に延長（生体認証プロンプトの往復吸収）。前提として 1Password デスクトップアプリの CLI 連携を有効化（ユーザー側作業、ドキュメントに明記）。
+
+## Risks / open questions（調査で解消済み）
+
+- ~~訴訟が専用 TextBlock を持たない可能性~~ → 確定（持たない）。キーワードスキャン方式に決定。
+- 有報 XBRL は PublicDoc と AuditDoc を含む。対象は PublicDoc インスタンス（`jpcrp030000-asr-*.xbrl`）。
+- 銘柄により監査が監査役会設置/監査等委員会で表現差あり得るが、`AuditsTextBlock` は共通要素なので問題なし。

--- a/dot_claude/skills/equity-decision/SKILL.md
+++ b/dot_claude/skills/equity-decision/SKILL.md
@@ -55,13 +55,16 @@ Run these from `~/.claude/skills/equity-decision/scripts/` via `uv run`:
 | US ticker → price + multiples | `uv run scripts/fetch_yahoo.py NVDA` | quote, PE/PSR, market cap, TTM revenue/FCF |
 | US ticker → recent filings | `uv run scripts/fetch_edgar.py NVDA` | latest 10-K, 10-Q, 5 × 8-K (with URLs) |
 | JP ticker → price + multiples | `uv run scripts/fetch_yahoo.py 7203` | same shape, auto `.T` suffix |
-| JP code → EDINET filings | `uv run scripts/fetch_edinet.py 7203` | latest 有報 + 四半期報告書 (with URLs) |
+| JP code → EDINET filings | `uv run scripts/fetch_edinet.py 7203` | latest 有報 + 半期報告書 (with URLs) |
+| JP 有報本文 → 訴訟・監査 | `uv run scripts/fetch_edinet.py --sections {docID}` | `sections.audit`（監査の状況本文）+ `sections.litigation.matches`（訴訟/係争/損害賠償スニペット） |
 
 Each script outputs JSON to stdout. On failure, exit code is non-zero and stderr contains `数字取得失敗: ...` — propagate that text into the memo, do not invent numbers.
 
 `fetch_edinet.py` needs a Subscription-Key. Set `EDINET_SUBSCRIPTION_KEY`, or store it in 1Password at `op://Personal/EDINET/credential` (override path via `EDINET_OP_REF`).
 
 ## JP fallback when EDINET is unavailable
+
+> EDINET が通る場合: まず `fetch_edinet.py {code}` で有報 docID を取得し、続けて `fetch_edinet.py --sections {docID}` で Phase 4 の ⚖️訴訟・📚監査 を一次情報から埋める（Phase 4 の手動補完は不要）。
 
 EDINET API is occasionally down, key activation can be delayed, and the portal has had outages. When `fetch_edinet.py` exits non-zero for a JP ticker:
 

--- a/dot_claude/skills/equity-decision/references/equity-workflow.md
+++ b/dot_claude/skills/equity-decision/references/equity-workflow.md
@@ -100,3 +100,4 @@ Customer concentration: {one line — top customer %, top-5 %, or "not disclosed
   - **Buy**: thesis grounded, current price in bear or base range, no Tier-1 risks active
   - **Watch**: thesis interesting but waiting on a catalyst or price → "what specifically would trigger?"
   - **Pass**: thesis weak, valuation in bull range, or ≥1 unmitigated Tier-1 risk
+- **Phase 4（JP）**: EDINET が使える場合、`fetch_edinet.py --sections {docID}` の出力で `⚖️ Regulation/litigation` と `📚 Accounting` を埋める。`sections.audit.text` から監査体制（監査役会/監査等委員会、会計監査人、非監査報酬の有無）を要約。`sections.litigation.found == false` または事業リスクの一般言及のみなら「重大な係争の個別開示なし」と記す。捏造禁止は同様に適用。 `sections.audit.found == false` の稀なケース（外国会社報告書等）は「監査体制の開示取得失敗 — 有報を直接確認」と記す。

--- a/dot_claude/skills/equity-decision/scripts/fetch_edinet.py
+++ b/dot_claude/skills/equity-decision/scripts/fetch_edinet.py
@@ -3,12 +3,14 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests>=2.31",
+#   "lxml>=5.0",
 # ]
 # ///
 """fetch_edinet.py — EDINET filings for a JP 4-digit securities code.
 
 Usage:
-    uv run fetch_edinet.py <4-digit-secCode>
+    uv run fetch_edinet.py <4-digit-secCode>   # list latest filings
+    uv run fetch_edinet.py --sections <docID>  # extract 監査/訴訟 from a 有報
 
 Output (stdout, JSON):
     {
@@ -16,13 +18,17 @@ Output (stdout, JSON):
       "edinetCode": "E02144",
       "docs": [
         {"docTypeCode": "120", "docDescription": "...", "submitDateTime": "...", "docID": "S...", "url": "https://..."},
-        {"docTypeCode": "140", ...}
+        {"docTypeCode": "160", ...}
       ]
     }
 
 Walks back up to 400 days from today, listing one day at a time, until both the
-latest 有価証券報告書 (docTypeCode 120) and the latest 四半期報告書 (docTypeCode 140)
-have been collected (or 400 days exhausted).
+latest 有価証券報告書 (docTypeCode 120) and the latest 半期報告書 (docTypeCode 160)
+have been collected (or 400 days exhausted). 四半期報告書 (140) was abolished in
+the 2024 disclosure reform.
+
+The --sections mode downloads the 有報 XBRL (type=1) for a given docID and returns
+{"docID": ..., "sections": {"audit": {...}, "litigation": {...}}}.
 
 Authentication:
     The EDINET v2 API requires the `Ocp-Apim-Subscription-Key` header. Obtain a
@@ -36,17 +42,78 @@ Exit codes:
     1 — fetch / auth / lookup failed (message on stderr begins with `数字取得失敗`)
     2 — usage error
 """
+import io
 import json
 import os
+import re
 import subprocess
 import sys
+import zipfile
 from datetime import date, timedelta
 from time import sleep
 
 import requests
+from lxml import etree
+from lxml import html as lhtml
+
+LITIGATION_RE = re.compile(r"訴訟|係争|損害賠償")
+_WS_RE = re.compile(r"\s+")
+
+
+def _detag(raw: str) -> str:
+    if not raw:
+        return ""
+    try:
+        text = lhtml.fromstring(raw).text_content()
+    except Exception:
+        text = raw
+    return _WS_RE.sub(" ", text).strip()
+
+
+def extract_sections_from_instance(instance_bytes: bytes) -> dict:
+    root = etree.fromstring(instance_bytes)
+    audit = {"element": "AuditsTextBlock", "found": False, "text": None}
+    matches: list[dict] = []
+    for el in root.iter():
+        local = etree.QName(el).localname
+        if "TextBlock" not in local:
+            continue
+        raw = el.text
+        if not raw or not raw.strip():
+            continue
+        text = _detag(raw)
+        if local == "AuditsTextBlock" and not audit["found"]:
+            audit = {"element": local, "found": True, "text": text}
+        m = LITIGATION_RE.search(text)
+        if m:
+            start = max(0, m.start() - 60)
+            end = min(len(text), m.end() + 120)
+            matches.append({"element": local, "snippet": text[start:end]})
+    return {
+        "audit": audit,
+        "litigation": {"found": bool(matches), "matches": matches},
+    }
+
+
+def _instance_from_zip(zip_bytes: bytes) -> bytes:
+    zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    for name in zf.namelist():
+        if "/PublicDoc/" in name and name.endswith(".xbrl"):
+            return zf.read(name)
+    raise ValueError("数字取得失敗: PublicDoc .xbrl not found in EDINET ZIP")
+
+
+def fetch_sections(doc_id: str) -> dict:
+    key = get_key()
+    url = f"https://disclosure.edinet-fsa.go.jp/api/v2/documents/{doc_id}?type=1"
+    r = requests.get(url, headers={KEY_HEADER: key}, timeout=60)
+    r.raise_for_status()
+    instance = _instance_from_zip(r.content)
+    return {"docID": doc_id, "sections": extract_sections_from_instance(instance)}
+
 
 API = "https://disclosure.edinet-fsa.go.jp/api/v2/documents.json"
-TARGET_TYPES = ("120", "140")
+TARGET_TYPES = ("120", "160")  # 120=有報, 160=半期報告書（140 四半期報告書は2024改正で廃止）
 MAX_DAYS_BACK = 400
 KEY_HEADER = "Ocp-Apim-Subscription-Key"
 DEFAULT_OP_REF = "op://Personal/EDINET/credential"
@@ -58,12 +125,12 @@ def get_key() -> str:
         return env_key
     op_ref = os.environ.get("EDINET_OP_REF", DEFAULT_OP_REF)
     try:
-        # op read via Desktop integration takes ~5s; a tight timeout flakes.
+        # op read via Desktop integration prompts biometrics; allow time to approve.
         result = subprocess.run(
             ["op", "read", op_ref],
             capture_output=True,
             text=True,
-            timeout=20,
+            timeout=45,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         result = None
@@ -87,6 +154,25 @@ def _doc_url(doc_id: str) -> str:
     return f"https://disclosure.edinet-fsa.go.jp/api/v2/documents/{doc_id}?type=2"
 
 
+def collect_targets(results: list, code_padded: str, found: dict) -> str | None:
+    edinet_code = None
+    for item in results or []:
+        if item.get("secCode") != code_padded:
+            continue
+        if edinet_code is None and item.get("edinetCode"):
+            edinet_code = item["edinetCode"]
+        doc_type = item.get("docTypeCode")
+        if doc_type in TARGET_TYPES and doc_type not in found:
+            found[doc_type] = {
+                "docTypeCode": doc_type,
+                "docDescription": item.get("docDescription", ""),
+                "submitDateTime": item.get("submitDateTime", ""),
+                "docID": item.get("docID", ""),
+                "url": _doc_url(item.get("docID", "")),
+            }
+    return edinet_code
+
+
 def fetch_docs(sec_code: str) -> dict:
     key = get_key()
     code_padded = sec_code.zfill(4) + "0"
@@ -108,20 +194,9 @@ def fetch_docs(sec_code: str) -> dict:
                 f"数字取得失敗: EDINET API rejected key — {payload}"
             )
 
-        for item in payload.get("results", []) or []:
-            if item.get("secCode") != code_padded:
-                continue
-            if edinet_code is None and item.get("edinetCode"):
-                edinet_code = item["edinetCode"]
-            doc_type = item.get("docTypeCode")
-            if doc_type in TARGET_TYPES and doc_type not in found:
-                found[doc_type] = {
-                    "docTypeCode": doc_type,
-                    "docDescription": item.get("docDescription", ""),
-                    "submitDateTime": item.get("submitDateTime", ""),
-                    "docID": item.get("docID", ""),
-                    "url": _doc_url(item.get("docID", "")),
-                }
+        ec = collect_targets(payload.get("results", []), code_padded, found)
+        if ec and edinet_code is None:
+            edinet_code = ec
 
         if all(t in found for t in TARGET_TYPES):
             break
@@ -137,11 +212,24 @@ def fetch_docs(sec_code: str) -> dict:
 
 
 def main() -> int:
-    if len(sys.argv) != 2:
-        print("usage: fetch_edinet.py <4-digit-secCode>", file=sys.stderr)
+    args = sys.argv[1:]
+    if len(args) == 2 and args[0] == "--sections":
+        try:
+            data = fetch_sections(args[1])
+        except Exception as e:
+            msg = f"{e}" if str(e).startswith("数字取得失敗") else f"数字取得失敗: {e}"
+            print(msg, file=sys.stderr)
+            return 1
+        json.dump(data, sys.stdout, ensure_ascii=False)
+        return 0
+    if len(args) != 1:
+        print(
+            "usage: fetch_edinet.py <4-digit-secCode> | --sections <docID>",
+            file=sys.stderr,
+        )
         return 2
     try:
-        data = fetch_docs(sys.argv[1])
+        data = fetch_docs(args[0])
     except Exception as e:
         print(f"{e}" if str(e).startswith("数字取得失敗") else f"数字取得失敗: {e}", file=sys.stderr)
         return 1

--- a/tests/skills/equity-decision/run-tests.sh
+++ b/tests/skills/equity-decision/run-tests.sh
@@ -5,5 +5,5 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-uv run --with pytest --with requests-mock --with yfinance --with beautifulsoup4 \
+uv run --with pytest --with requests-mock --with yfinance --with beautifulsoup4 --with lxml \
   python -m pytest -v --tb=short

--- a/tests/skills/equity-decision/test_extract_sections.py
+++ b/tests/skills/equity-decision/test_extract_sections.py
@@ -1,0 +1,86 @@
+"""Tests for fetch_edinet.py --sections extraction (監査の状況 / 訴訟).
+
+Offline unit tests use a tiny synthetic XBRL instance — what matters is the
+element local-name (AuditsTextBlock / BusinessRisksTextBlock), not real filing
+size. The real-filing path is covered by the @requires_key live test in
+test_fetch_edinet.py.
+"""
+import io
+import zipfile
+
+from fetch_edinet import (
+    _instance_from_zip,
+    extract_sections_from_instance,
+)
+
+# Minimal XBRL: one AuditsTextBlock (監査の状況) + one BusinessRisksTextBlock (訴訟).
+# TextBlock bodies are escaped XHTML, exactly as EDINET stores them.
+_XBRL_WITH_AUDIT = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<xbrli:xbrl xmlns:xbrli="http://www.xbrl.org/2003/instance" '
+    'xmlns:jpcrp_cor="http://disclosure.edinet-fsa.go.jp/taxonomy/jpcrp/cor">'
+    '<jpcrp_cor:AuditsTextBlock contextRef="c">'
+    "&lt;p&gt;(3) 監査の状況 当社は監査役会設置会社です&lt;/p&gt;"
+    "</jpcrp_cor:AuditsTextBlock>"
+    '<jpcrp_cor:BusinessRisksTextBlock contextRef="c">'
+    "&lt;p&gt;事業等のリスク 当社が損害賠償請求の訴訟を受ける可能性&lt;/p&gt;"
+    "</jpcrp_cor:BusinessRisksTextBlock>"
+    "</xbrli:xbrl>"
+).encode("utf-8")
+
+# Same shape but no AuditsTextBlock and no litigation keyword.
+_XBRL_NO_AUDIT = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<xbrli:xbrl xmlns:xbrli="http://www.xbrl.org/2003/instance" '
+    'xmlns:jpcrp_cor="http://disclosure.edinet-fsa.go.jp/taxonomy/jpcrp/cor">'
+    '<jpcrp_cor:DescriptionOfBusinessTextBlock contextRef="c">'
+    "&lt;p&gt;事業の内容&lt;/p&gt;"
+    "</jpcrp_cor:DescriptionOfBusinessTextBlock>"
+    "</xbrli:xbrl>"
+).encode("utf-8")
+
+
+def test_audit_section_extracted():
+    out = extract_sections_from_instance(_XBRL_WITH_AUDIT)
+    assert out["audit"]["found"] is True
+    assert out["audit"]["element"] == "AuditsTextBlock"
+    assert "監査の状況" in out["audit"]["text"]
+
+
+def test_litigation_scan_returns_matches():
+    out = extract_sections_from_instance(_XBRL_WITH_AUDIT)
+    lit = out["litigation"]
+    assert lit["found"] is True
+    assert all({"element", "snippet"} <= set(m) for m in lit["matches"])
+    assert any("訴訟" in m["snippet"] for m in lit["matches"])
+    assert any(m["element"] == "BusinessRisksTextBlock" for m in lit["matches"])
+
+
+def test_audit_not_found_returns_none_text():
+    out = extract_sections_from_instance(_XBRL_NO_AUDIT)
+    assert out["audit"]["found"] is False
+    assert out["audit"]["text"] is None
+    assert out["litigation"]["found"] is False
+    assert out["litigation"]["matches"] == []
+
+
+def test_instance_from_zip_raises_when_no_publicdoc():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("XBRL/AuditDoc/something.xbrl", b"<x/>")
+    try:
+        _instance_from_zip(buf.getvalue())
+        raised = None
+    except ValueError as e:
+        raised = str(e)
+    assert raised is not None
+    assert raised.startswith("数字取得失敗")
+
+
+def test_instance_from_zip_returns_publicdoc():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("XBRL/PublicDoc/jpcrp030000-asr.xbrl", _XBRL_WITH_AUDIT)
+        zf.writestr("XBRL/AuditDoc/jpaud.xbrl", b"<x/>")
+    instance = _instance_from_zip(buf.getvalue())
+    assert b"AuditsTextBlock" in instance

--- a/tests/skills/equity-decision/test_fetch_edinet.py
+++ b/tests/skills/equity-decision/test_fetch_edinet.py
@@ -78,3 +78,14 @@ def test_missing_key_exits_nonzero(monkeypatch):
     assert result.returncode != 0
     assert "数字取得失敗" in result.stderr
     assert "key unavailable" in result.stderr.lower() or "EDINET_SUBSCRIPTION_KEY" in result.stderr
+
+
+@requires_key
+def test_sections_extracts_audit_and_litigation():
+    """--sections <docID> pulls 監査の状況 + 訴訟 from a real 有報 (OLC 第65期)."""
+    data = run_script("--sections", "S100VY55")
+    assert data["docID"] == "S100VY55"
+    audit = data["sections"]["audit"]
+    assert audit["found"] is True
+    assert "監査の状況" in audit["text"]
+    assert data["sections"]["litigation"]["found"] is True

--- a/tests/skills/equity-decision/test_target_types.py
+++ b/tests/skills/equity-decision/test_target_types.py
@@ -1,0 +1,38 @@
+"""Tests for fetch_edinet.py document-type targeting.
+
+docTypeCode 140 (四半期報告書) was abolished in the 2024 disclosure reform;
+the fetcher targets 120 (有報) + 160 (半期報告書).
+"""
+from fetch_edinet import TARGET_TYPES, collect_targets
+
+
+def test_target_types_use_160_not_140():
+    assert TARGET_TYPES == ("120", "160")
+
+
+def test_collect_targets_picks_120_and_160():
+    results = [
+        {"secCode": "46610", "edinetCode": "E04707", "docTypeCode": "120",
+         "docDescription": "有価証券報告書", "submitDateTime": "2025-06-26 15:30", "docID": "S1"},
+        {"secCode": "46610", "edinetCode": "E04707", "docTypeCode": "160",
+         "docDescription": "半期報告書", "submitDateTime": "2025-12-01 15:00", "docID": "S2"},
+        {"secCode": "99990", "edinetCode": "E99999", "docTypeCode": "120",
+         "docDescription": "別会社", "submitDateTime": "2025-06-26 15:30", "docID": "S3"},
+    ]
+    found: dict = {}
+    edinet = collect_targets(results, "46610", found)
+    assert edinet == "E04707"
+    assert set(found) == {"120", "160"}
+    assert found["120"]["docID"] == "S1"
+    assert found["160"]["docID"] == "S2"
+    assert found["120"]["url"].endswith("S1?type=2")
+
+
+def test_collect_targets_ignores_other_seccodes():
+    results = [
+        {"secCode": "99990", "edinetCode": "E99999", "docTypeCode": "120", "docID": "X"},
+    ]
+    found: dict = {}
+    edinet = collect_targets(results, "46610", found)
+    assert edinet is None
+    assert found == {}


### PR DESCRIPTION
## Why

Phase 4 of the equity memo (⚖️ regulation/litigation, 📚 accounting) was filled by hand for JP tickers. EDINET already publishes this in the 有報 XBRL — this PR pulls it from the primary source.

## What

- **`fetch_edinet.py --sections {docID}`**: downloads the 有報 XBRL (`type=1`), extracts `AuditsTextBlock` (監査の状況) and 訴訟/係争/損害賠償 snippets, returns them as JSON.
- **Listing target 140 → 160**: 四半期報告書 (140) was abolished in the 2024 disclosure reform; switch to 半期報告書 (160).
- **op-read timeout 20s → 45s**: allow time for biometric approval.
- **Skill + workflow docs** updated so Phase 4 (JP) uses `--sections` output; manual fallback wording preserved for the rare `found == false` case (外国会社報告書 etc.).

## Test

- `test_extract_sections.py` — unit tests for XBRL parsing / de-tagging / litigation matching.
- `test_target_types.py` — verifies the 120/160 target set.
- `test_fetch_edinet.py` — live `--sections S100VY55` (OLC 第65期) integration test, key-gated.
- Adds `lxml` to the test runner deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)