### PR TITLE
fix(zsh): repair rub merged-branch filtering

### DIFF
--- a/dot_config/zsh/features/branch-cleanup.zsh
+++ b/dot_config/zsh/features/branch-cleanup.zsh
@@ -6,7 +6,9 @@ rub() {
     return 1
   fi
   local merged
-  merged=$(git branch --merged | grep -Ev "*|${PROTECTED_BRANCHES}")
+  merged=$(git branch --format='%(refname:short)' --merged \
+    | grep -Evx "${PROTECTED_BRANCHES}" \
+    | grep -Fvx "$(git branch --show-current)")
   [[ -z "$merged" ]] && echo "No merged branches to delete" && return 0
   echo "$merged" | xargs git branch -d
 }

--- a/dot_local/share/devbox/global/default/devbox.json.tmpl
+++ b/dot_local/share/devbox/global/default/devbox.json.tmpl
@@ -32,6 +32,7 @@
     "peco@latest",
     "kubectl@latest",
 {{- if .business_use }}
+    "aws-sso-util@latest",
     "colima@latest",
     "docker-client@latest",
     "docker-compose@latest",


### PR DESCRIPTION
## Summary
- fix `rub`: the grep pattern began with a bare `*`, an invalid ERE repetition operator, so grep always failed and `rub` reported "No merged branches to delete" even when merged branches existed
- list branches via `git branch --format='%(refname:short)' --merged` so no current-branch marker (`* `) needs stripping
- anchor protected-branch matching with `grep -x`, fixing a latent substring bug where e.g. `main-feature` was excluded by `main`
- exclude the current branch explicitly via `git branch --show-current` (fixed-string, whole-line match)
- add `aws-sso-util` to devbox business packages (unrelated staged change, included per request)

## Verification
- temp-repo test: merged branches deleted via `git branch -d`; protected (`main`/`develop`) and current branch preserved; clean repo prints "No merged branches to delete" (exit 0)
- `zsh -n dot_config/zsh/features/branch-cleanup.zsh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 13645,
          "cache_creation_input_tokens": 13645,
          "cache_read_input_tokens": 2124684,
          "input_tokens": 281,
          "model": "claude-fable-5",
          "output_tokens": 5534,
          "total_context_tokens": 2144144,
          "turns": 12
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 13645,
          "cache_creation_input_tokens": 13645,
          "cache_read_input_tokens": 2124684,
          "input_tokens": 281,
          "kind": "main",
          "model": "claude-fable-5",
          "name": "main",
          "output_tokens": 5534,
          "total_context_tokens": 2144144,
          "turns": 12
        }
      ],
      "recorded_at": "2026-06-10T07:59:40Z",
      "sha": "7c1e7275215304b233d918dc8a1670190573a299",
      "subject": "fix(zsh): repair rub merged-branch filtering",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 13645,
        "cache_creation_input_tokens": 13645,
        "cache_read_input_tokens": 2124684,
        "input_tokens": 281,
        "output_tokens": 5534,
        "total_context_tokens": 2144144,
        "turns": 12
      }
    },
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 1409,
          "cache_creation_input_tokens": 1409,
          "cache_read_input_tokens": 550680,
          "input_tokens": 6,
          "model": "claude-fable-5",
          "output_tokens": 1147,
          "total_context_tokens": 553242,
          "turns": 3
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 1409,
          "cache_creation_input_tokens": 1409,
          "cache_read_input_tokens": 550680,
          "input_tokens": 6,
          "kind": "main",
          "model": "claude-fable-5",
          "name": "main",
          "output_tokens": 1147,
          "total_context_tokens": 553242,
          "turns": 3
        }
      ],
      "recorded_at": "2026-06-10T07:59:47Z",
      "sha": "9894f2d6ea338208053ae46056c27a3c78013124",
      "subject": "chore(devbox): add aws-sso-util to business packages",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 1409,
        "cache_creation_input_tokens": 1409,
        "cache_read_input_tokens": 550680,
        "input_tokens": 6,
        "output_tokens": 1147,
        "total_context_tokens": 553242,
        "turns": 3
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 2,
  "pr": {
    "base": "main",
    "head": "fix/rub-merged-branch-grep",
    "number": 158
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 2,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 15054,
    "cache_creation_input_tokens": 15054,
    "cache_read_input_tokens": 2675364,
    "input_tokens": 287,
    "output_tokens": 6681,
    "total_context_tokens": 2697386,
    "turns": 15
  },
  "totals_by_model": [
    {
      "cache_creation_ephemeral_1h_input_tokens": 15054,
      "cache_creation_input_tokens": 15054,
      "cache_read_input_tokens": 2675364,
      "input_tokens": 287,
      "model": "claude-fable-5",
      "output_tokens": 6681,
      "total_context_tokens": 2697386,
      "turns": 15
    }
  ],
  "updated_at": "2026-06-10T08:00:35Z"
}
```

</details>
<!-- code-flow-usage-json:end -->
