### PR TITLE
ci: merge chezmoi jobs into matrix; fix vacuous zsh lint sed

### DIFF
--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -3,8 +3,8 @@
 {{-   $osID = printf "%s-%s" .chezmoi.os .chezmoi.osRelease.id -}}
 {{- end -}}
 
-{{- $businessUse := env "BUSINESS_USE" | not | not -}}
-{{- $hasOp := lookPath "op" | not | not -}}
+{{- $businessUse := ne (env "BUSINESS_USE") "" -}}
+{{- $hasOp := ne (lookPath "op") "" -}}
 
 {{- $name := "" -}}
 {{- $email := "" -}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,23 +129,27 @@ jobs:
           sudo apt-get install -y lua5.4
           find dot_config/nvim -name "*.lua" -exec lua5.4 -p {} \; -print
 
-  chezmoi-linux:
-    name: Chezmoi (Linux, ${{ matrix.env_name }})
+  chezmoi:
+    name: Chezmoi (${{ matrix.os }}, ${{ matrix.env_name }})
     needs: changes
     if: needs.changes.outputs.chezmoi == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
+        env_name: [personal, business]
         include:
-          - business_use: ''
-            env_name: personal
-          - business_use: '1'
-            env_name: business
+          - env_name: personal
+            business_use: ''
+          - env_name: business
+            business_use: '1'
     steps:
       - uses: actions/checkout@v4
 
       - name: Install chezmoi
-        run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+        run: |
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Setup test config (provide prompted values)
         run: |
@@ -171,48 +175,6 @@ jobs:
           chezmoi init --source="${PWD}"
           chezmoi managed | head -20
           chezmoi cat ~/.config/git/config || true
-
-  chezmoi-macos:
-    name: Chezmoi (macOS, ${{ matrix.env_name }})
-    needs: changes
-    if: needs.changes.outputs.chezmoi == 'true'
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        include:
-          - business_use: ''
-            env_name: personal
-          - business_use: '1'
-            env_name: business
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install chezmoi
-        run: brew install chezmoi
-
-      - name: Setup test config (provide prompted values)
-        run: |
-          mkdir -p ~/.config/chezmoi
-          cat > ~/.config/chezmoi/chezmoi.yaml << 'EOF'
-          data:
-            name: "Test User"
-            email: "test@example.com"
-            work_email: "test@work.example.com"
-          EOF
-
-      - name: Test chezmoi init (dry-run)
-        env:
-          BUSINESS_USE: ${{ matrix.business_use }}
-        run: |
-          echo "Testing chezmoi template expansion..."
-          chezmoi init --source="${PWD}" --dry-run --verbose
-
-      - name: Verify template expansion
-        env:
-          BUSINESS_USE: ${{ matrix.business_use }}
-        run: |
-          chezmoi init --source="${PWD}"
-          chezmoi managed | head -20
 
   devbox:
     name: Devbox Validation
@@ -281,7 +243,7 @@ jobs:
   # This job always runs and reports success only if all required jobs passed or were skipped
   ci-complete:
     name: CI Complete
-    needs: [format, lint, chezmoi-linux, chezmoi-macos, devbox, neovim]
+    needs: [format, lint, chezmoi, devbox, neovim]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ lint:
     @echo "Checking zsh syntax..."
     @for file in dot_zshrc.tmpl dot_zshenv.tmpl; do \
         if [ -f "$file" ]; then \
-            sed 's/\{\{[^}]*\}\}//g' "$file" > /tmp/check.zsh; \
+            sed 's/{{{{[^}]*}}}}//g' "$file" > /tmp/check.zsh; \
             zsh -n /tmp/check.zsh && echo "✓ $file"; \
         fi \
     done


### PR DESCRIPTION
## Why

The `chezmoi-linux` / `chezmoi-macos` CI jobs were ~80 near-identical lines, and the justfile's zsh-lint sed pattern silently broke on GNU sed.

## What

- Merge the two chezmoi jobs into one `chezmoi` matrix job (os × env_name, 4 legs). Both OSes now install via the curl installer into `$HOME/.local/bin` (no sudo, no slow `brew install`). The `chezmoi cat git/config || true` check now runs on macOS too. `ci-complete` needs updated.
- Replace the obscure `| not | not` boolean coercion in `.chezmoi.yaml.tmpl` with `ne (env "BUSINESS_USE") ""` / `ne (lookPath "op") ""` — identical semantics, readable intent.
- Unify the template-stripping sed with CI's spelling. **This is a real fix, not cosmetics**: the old `\{\{[^}]*\}\}` is invalid BRE for GNU sed ("Invalid preceding regular expression"), which left `/tmp/check.zsh` empty, so `zsh -n` passed vacuously — the zsh lint was a no-op on GNU-sed machines. In a justfile the literal `{{` must be written `{{{{`, which renders to exactly the CI pattern `{{[^}]*}}`.

## Verification

- `just test` exit 0, with the zsh lint now actually parsing both templates (no sed error)
- `chezmoi init --dry-run` clean in both personal and `BUSINESS_USE=1` modes
- Workflow parsed by yq; job list: changes, chezmoi, ci-complete, devbox, format, lint, neovim

Note for review: job names change to `Chezmoi (ubuntu-latest, personal)` etc. If branch protection pins the old names (rather than `CI Complete`), update it after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
