### PR TITLE
test(hooks): backfill block-rot-comments coverage; cross-ref guards

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -32,7 +32,7 @@
       "Bash(helm delete:*)",
       "Bash(helm upgrade:*)"
     ],
-{{- /* Destructive-command guards below overlap with dot_codex/rules/custom.rules.tmpl — when adding a pattern, update both. */ -}}
+{{- /* Destructive-command guards below overlap with dot_codex/rules/custom.rules.tmpl — when adding a pattern, update both. */}}
     "deny": [
       "Bash(sudo:*)",
       "Bash(rm -rf /:*)",

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -32,6 +32,7 @@
       "Bash(helm delete:*)",
       "Bash(helm upgrade:*)"
     ],
+{{- /* Destructive-command guards below overlap with dot_codex/rules/custom.rules.tmpl — when adding a pattern, update both. */ -}}
     "deny": [
       "Bash(sudo:*)",
       "Bash(rm -rf /:*)",

--- a/dot_codex/rules/custom.rules.tmpl
+++ b/dot_codex/rules/custom.rules.tmpl
@@ -1,4 +1,6 @@
 # Hand-authored Codex execution-policy rules, managed by chezmoi.
+# NOTE: destructive-command guards overlap with dot_claude/settings.json.tmpl
+# ("deny" list) — when adding a pattern, update both files.
 #
 # Why a dedicated file (not default.rules): Codex auto-appends Smart-Approval
 # rules to ~/.codex/rules/default.rules, so that file drifts and stays

--- a/tests/hooks/block-rot-comments.test.sh
+++ b/tests/hooks/block-rot-comments.test.sh
@@ -110,4 +110,28 @@ new='function f() {}\n'
 out=$(run "{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"a.ts\",\"old_string\":\"$old\",\"new_string\":\"$new\"}}")
 [[ -z $out ]] || fail "blocked edit that removed a rot comment: $out"
 
+# === MultiEdit: all edits clean → ALLOW ===
+out=$(run '{"tool_name":"MultiEdit","tool_input":{"file_path":"a.ts","edits":[{"old_string":"function a() { return 1; }\n","new_string":"function a() { return 2; }\n"},{"old_string":"function b() { return 1; }\n","new_string":"function b() { return 2; }\n"}]}}')
+[[ -z $out ]] || fail "MultiEdit with clean edits was blocked: $out"
+
+# === MultiEdit: rot marker in a later edit → BLOCK ===
+# Rot pattern assembled at runtime so this source line is not flagged.
+_rot_marker='TO''DO: fix later'
+_me_payload=$(printf '{"tool_name":"MultiEdit","tool_input":{"file_path":"a.ts","edits":[{"old_string":"function a() {}\\n","new_string":"function a() {}\\n"},{"old_string":"function b() {}\\n","new_string":"// %s\\nfunction b() {}\\n"}]}}' "$_rot_marker")
+out=$(run "$_me_payload")
+is_block "$out" || fail "MultiEdit with rot marker in later edit was not blocked: $out"
+reason_has "$out" "rot" || fail "MultiEdit deny reason missing 'rot' keyword: $out"
+
+# === Write: line-comment rot marker (HA-CK style) → BLOCK ===
+_hack='HA''CK: workaround for upstream bug'
+_hack_payload=$(printf '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":"// %s\\nfunction f() {}\\n"}}' "$_hack")
+out=$(run "$_hack_payload")
+is_block "$out" || fail "did not block line-comment rot marker: $out"
+
+# === Write: block-comment rot marker (TE-MP style) → BLOCK ===
+_temp='TE''MP: remove after launch'
+_temp_payload=$(printf '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":"/* %s */\\nfunction f() {}\\n"}}' "$_temp")
+out=$(run "$_temp_payload")
+is_block "$out" || fail "did not block block-comment rot marker: $out"
+
 echo "all assertions passed"


### PR DESCRIPTION
## Why

The Claude deny list and the Codex prefix rules guard the same destructive commands but are synced by hand with nothing marking the coupling. Separately, `block-rot-comments` implements MultiEdit/block-comment/marker handling that the test suite never covered.

## What

- Cross-reference comments on both sides: a Go-template comment above the `deny` block in `dot_claude/settings.json.tmpl` (stripped at render time — rendered JSON is byte-identical to main) and a `#` note atop `dot_codex/rules/custom.rules.tmpl`
- Backfill `tests/hooks/block-rot-comments.test.sh`: MultiEdit clean → allow, MultiEdit with rot in a later edit → block, `HACK:` line comment → block, `TEMP:` block comment → block. Rot strings are assembled at runtime (`'TO''DO: …'`) so the test source itself doesn't trip the very hook it tests.

## Verification

- Hook suite: 3/3 pass (all new assertions green)
- Rendered `settings.json` parses as JSON and diffs empty against main's render
- `BUSINESS_USE=1 chezmoi init --dry-run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
