### PR TITLE
docs: isolate chezmoi init test runs (dry-run rewrites real config)

### DIFF
--- a/.claude/rules/chezmoi-templates.md
+++ b/.claude/rules/chezmoi-templates.md
@@ -24,8 +24,22 @@ paths: "**/*.tmpl"
 
 ## Testing Changes
 
-Always test template changes with both environments:
+`chezmoi execute-template < file.tmpl` renders with the current config and touches nothing.
+
+**DANGER:** `chezmoi init` regenerates the real `~/.config/chezmoi/chezmoi.yaml`
+**even with `--dry-run`**. A `BUSINESS_USE=1` test run (or one launched from a shell
+that inherited `BUSINESS_USE=1`) silently flips the real config to business mode,
+and the next `chezmoi apply` writes a business `~/.zshenv` that re-poisons every
+later shell — a self-perpetuating loop. Always isolate test inits behind a
+throwaway `XDG_CONFIG_HOME` with a seeded config (prompts cannot run headless):
+
 ```bash
-chezmoi execute-template < file.tmpl              # Test with current config
-BUSINESS_USE=1 chezmoi init --source=. --dry-run  # Test business mode
+tmpdir=$(mktemp -d) && mkdir -p "$tmpdir/chezmoi"
+printf 'data:\n  name: "Test User"\n  email: "test@example.com"\n  work_email: "test@work.example.com"\n' > "$tmpdir/chezmoi/chezmoi.yaml"
+XDG_CONFIG_HOME="$tmpdir" BUSINESS_USE=1 chezmoi init --source=. --dry-run        # business mode
+XDG_CONFIG_HOME="$tmpdir" env -u BUSINESS_USE chezmoi init --source=. --dry-run   # personal mode
 ```
+
+Recovery if the real config got flipped: `env -u BUSINESS_USE chezmoi init
+--source ~/.local/share/chezmoi && env -u BUSINESS_USE chezmoi apply`, then kill
+the tmux server and restart shells (inherited env survives `exec $SHELL -l`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,25 @@ just diff        # Show pending chezmoi changes
 | `.osid` | OS identifier (e.g., `darwin`, `linux-ubuntu`) |
 | `.name`, `.email`, `.work_email` | User info prompted on first run |
 
+### Template Testing
+
+`chezmoi init` rewrites the real `~/.config/chezmoi/chezmoi.yaml` **even with
+`--dry-run`**. Never run it against the real config (especially with
+`BUSINESS_USE=1`, or from a shell that inherited it) — once flipped, the applied
+`~/.zshenv` exports `BUSINESS_USE=1` and re-poisons every later shell, including
+new `chezmoi init` runs. Isolate test inits:
+
+```bash
+tmpdir=$(mktemp -d) && mkdir -p "$tmpdir/chezmoi"
+printf 'data:\n  name: "Test"\n  email: "t@example.com"\n  work_email: "t@work.example.com"\n' > "$tmpdir/chezmoi/chezmoi.yaml"
+XDG_CONFIG_HOME="$tmpdir" BUSINESS_USE=1 chezmoi init --source=. --dry-run        # business mode
+XDG_CONFIG_HOME="$tmpdir" env -u BUSINESS_USE chezmoi init --source=. --dry-run   # personal mode
+```
+
+Recovery: `env -u BUSINESS_USE chezmoi init --source ~/.local/share/chezmoi &&
+env -u BUSINESS_USE chezmoi apply`, then kill the tmux server and restart shells
+(inherited env survives `exec $SHELL -l`).
+
 ### Configuration Directories
 
 - `dot_config/nvim/` - Neovim config (kickstart-based, uses lazy.nvim)


### PR DESCRIPTION
## Why

The test command this repo recommended — `BUSINESS_USE=1 chezmoi init --source=. --dry-run` — rewrites the real `~/.config/chezmoi/chezmoi.yaml` despite `--dry-run` (verified by mtime). That flipped a personal machine to business mode; the next `chezmoi apply` wrote a business `~/.zshenv` exporting `BUSINESS_USE=1`, which re-poisoned every later shell (including ones running `chezmoi init`), making the flip self-perpetuating. `exec $SHELL -l` does not recover because inherited env survives exec, and the tmux server keeps redistributing the variable to new panes.

## What

- `CLAUDE.md`: always-loaded warning with the isolated test recipe and the recovery one-liner (`env -u BUSINESS_USE chezmoi init && apply`, kill tmux server)
- `.claude/rules/chezmoi-templates.md`: replace the dangerous recommendation with the `XDG_CONFIG_HOME=$(mktemp -d)` recipe (seeded config required — prompts cannot run headless)

Both verified empirically: the isolated run exits 0, exercises business mode in the temp config (`business_use: true` there), and leaves the real config untouched (mtime unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
