### PR TITLE
feat(claude): pin fable as default model on personal machines

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -1,4 +1,7 @@
 {
+{{- if not .business_use }}
+  "model": "claude-fable-5[1m]",
+{{- end }}
   "permissions": {
     "allow": [
       "Bash(mysql:*)",


### PR DESCRIPTION
## Why

`/model` saves the chosen default into `~/.claude/settings.json`, but that file is chezmoi-managed — every `chezmoi apply` silently deleted the saved `model` key (observed: the Fable 5 default vanished on apply and had to be restored by hand). Encode the preference in the template so apply preserves it.

## What

- Personal mode: render `"model": "claude-fable-5[1m]"` — the exact value the `/model` picker saves for Fable 5, so behavior is byte-identical to picking it interactively
- Business mode: omit the key entirely; the session follows the account-tier default

Known tradeoff: switching models via `/model` on a personal machine now drifts from the template and reverts on the next apply — the template is the source of truth for the standing default.

## Verification

- Personal render: valid JSON, `model: claude-fable-5[1m]`
- Business render (XDG-isolated seeded init per the CLAUDE.md recipe, real config untouched): valid JSON, `model` absent
- `just test` exit 0 (5 hook suites green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
