### PR TITLE
feat(claude): loop-engineering rule + loop-design skill

### DIFF
--- a/dot_claude/rules/loop-engineering.md
+++ b/dot_claude/rules/loop-engineering.md
@@ -1,0 +1,54 @@
+---
+paths:
+  - "**/STATE.md"
+  - "**/LOOP.md"
+  - "**/run-log*"
+  - "**/run-logs/**"
+---
+
+# Loop Engineering
+
+Conventions for autonomous or long-running agent loops (`/loop`, `/schedule`,
+ralph-loop, pr-monitor) — where the agent iterates toward a goal across runs
+without a human in every turn.
+Most of the machinery lives in other rules; this file covers only what loops add.
+
+Reuse, do not restate:
+
+- Maker/checker split is the generator-evaluator separation in `harness-engineering.md`. The writer never grades its own homework.
+- "Stronger verification earns more autonomy", and where to enforce a constraint, is the escalation ladder in `harness-meta.md`.
+
+## STATE.md — the loop's spine
+
+A loop's conversation is volatile; the repo is not.
+Persist what a run needs to resume in a `STATE.md` at the loop's working root
+(repo or worktree), and read it at the start of every iteration.
+
+- Holds **what's done** and **what's next**, plus open questions and the load-bearing decisions of THIS run.
+- Keep it distinct from the other memory layers, and do not mix them:
+  - persistent memory (`~/.claude/.../memory/`) — cross-session facts Claude recalls.
+  - `.ai/` — the user's learning notes (see `repo-notes.md`).
+  - STATE.md — one autonomous run's working state, disposable once the loop ends.
+- Decisions that outlive the loop graduate to an ADR (`harness-engineering.md`), not STATE.md.
+- History and rationale never go in code comments — that is comment rot (`development-principles.md`); STATE.md and git carry history.
+
+## Autonomy staging
+
+Graduate a loop's trust over runs; never start unattended.
+These names are descriptive, separate from the `harness-meta.md` L1–L4 ladder
+(which is about where a constraint lives, not how much a loop is trusted).
+
+- **report-only** — the loop discovers and proposes; a human applies. Start every new loop here.
+- **assisted** — patch-only or single-file fixes behind a gate; risky or ambiguous calls still escalate.
+- **unattended** — only after the mechanical gates (tests, CI, checker subagent) have caught a real regression on this loop.
+
+Promote a stage only when the gate beneath it has actually fired on a real
+failure. Promotion is earned by evidence, not by elapsed time.
+
+## Comprehension debt
+
+> The faster the loop ships code you did not write, the bigger the gap between
+> what exists and what you actually get.
+
+- Read the diff a loop ships before the next iteration builds on it. A green checker subagent is not a license to skip reading.
+- If you cannot explain what the last run changed, stop the loop and catch up before the gap compounds.

--- a/dot_claude/skills/loop-design/SKILL.md
+++ b/dot_claude/skills/loop-design/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: loop-design
+description: >
+  Use when the user wants to set up a recurring or autonomous agent loop and
+  needs to design it before running it. Triggers: 「ループを設計」「自律ループを
+  作りたい」「loop を組みたい」, turning a vague "I want a loop that does X" into
+  a concrete spec, or choosing a runner (/loop, /schedule, ralph-loop,
+  pr-monitor) for repeated work. NOT for running an already-designed loop, and
+  NOT for one-off tasks.
+disable-model-invocation: false
+---
+
+# Loop Design
+
+A guided interview that turns "I want a loop for X" into a concrete, runnable
+loop spec. It produces design artifacts and stops — it does not run the loop or
+register any schedule.
+
+**REQUIRED BACKGROUND:** `~/.claude/rules/loop-engineering.md` defines the
+conventions (STATE.md spine, autonomy staging, comprehension debt). This skill
+is the *process* that produces a spec conforming to them; it does not restate
+them.
+
+## When to use
+
+- The user wants a repeated/automated agent process and the shape is not yet pinned down.
+- A loop is worth designing before running because it will act across runs without a human in every turn.
+
+Do NOT use for a one-shot task, or to run a loop whose design already exists.
+
+## The interview — one question at a time
+
+Ask these in order, one per message. Do not assume answers; if the user gives a
+vague goal, the whole point is to extract the rest by asking. Skip a question
+only if the user already answered it.
+
+| # | Ask | Captures |
+|---|---|---|
+| 1 | What does the loop converge toward, and how do you know it's done / when does it stop? | goal + done/stop |
+| 2 | What triggers it — `/loop <interval>`, `/schedule <cron>`, ralph-loop, pr-monitor, or an event? | runner |
+| 3 | Who writes and who independently checks each iteration? | maker/checker (generator ≠ evaluator) |
+| 4 | What mechanical gates must pass every iteration (tests, CI, lint, checker verdict)? | gates that earn autonomy |
+| 5 | What does this loop's STATE.md need to track (done / next / decisions / open questions)? | spine schema |
+| 6 | What must be true before it graduates report-only → assisted → unattended? | autonomy staging |
+| 7 | When does a human read the diff the loop shipped, and what stops the loop? | comprehension-debt checkpoint |
+
+## Output
+
+After the interview, write two files at the loop's working root (ask: repo root,
+or a worktree) and print one launch command:
+
+1. `LOOP.md` — the spec (template below).
+2. `STATE.md` — initialized skeleton, ready for run 1.
+3. A copy-paste launch command, **pinned to report-only**. Print it; never run it.
+
+### LOOP.md template
+
+```markdown
+# Loop: <name>
+
+## Goal / Done
+<what it converges toward; stop criteria>
+
+## Runner
+<runner> — <why this one>
+
+## Maker / Checker
+- Maker: <who writes>
+- Checker: <independent verifier>
+
+## Gates (each iteration)
+- <tests / CI / lint / checker verdict>
+
+## Autonomy
+- Stage: report-only
+- → assisted when: <gate that must fire on a real failure first>
+- → unattended when: <mechanical gate proven on a real regression>
+
+## STATE.md
+- Location: <repo root | worktree>
+- Tracks: done, next, decisions, open questions
+
+## Comprehension-debt checkpoint
+- <when the human reads the shipped diff; stop condition>
+```
+
+### STATE.md skeleton
+
+```markdown
+# STATE — <loop name>
+
+Read at the start of every iteration; write at the end.
+One run's working spine — see loop-engineering.md.
+
+## Done
+- (nothing yet)
+
+## Next
+- (first action)
+
+## Decisions
+- (load-bearing decisions for this run)
+
+## Open questions
+- (none yet)
+```
+
+## Guardrails
+
+- Start every new loop at **report-only**. Never emit an unattended launch command on first design.
+- Stop at artifacts. Running the loop or registering a schedule is a separate, explicit step the user takes.
+- Reference `loop-engineering.md` for "what good looks like"; do not paste its contents into LOOP.md.
+
+## Common mistakes
+
+- Producing a design without asking — the value is the interview. A vague goal is the signal to ask more, not to assume.
+- Inventing a runner the user didn't choose, or skipping the maker/checker split.
+- Emitting an unattended or auto-merge launch command. Report-only first, always.


### PR DESCRIPTION
## Why

「loop engineering」（[Addy Osmani](https://addyo.substack.com/p/loop-engineering) / [cobusgreyling](https://github.com/cobusgreyling/loop-engineering)）の構成要素を既存ハーネスと突き合わせた。5/6 は実装済みで、maker/checker は generator-evaluator 分離と同一だった。残る実質ギャップを、規約（rule）とそれを使う設計プロセス（skill）の2点で埋める。

## What

### 1. `dot_claude/rules/loop-engineering.md`（規約）

`paths:` で `STATE.md` / `LOOP.md` / `run-log*` を触る時だけロードされるようスコープし、always-loaded の命令予算（〜150）を汚さない（`harness-meta.md` の grow-by-replace に準拠）。

| 項目 | 内容 |
|---|---|
| STATE.md spine | 1ランの作業状態。persistent memory（横断的事実）・`.ai/`（学習ノート）と明示分離 |
| Autonomy staging | report-only → assisted → unattended。ゲートが本物の失敗を捕まえた時だけ昇格 |
| Comprehension debt | ループが ship した diff を次イテレーション前に読む |

maker/checker と「検証が強いほど自律」は既存の generator-evaluator 分離・escalation ladder への参照に留め、再記述しない。staging の段階名は `harness-meta.md` の L1–L4 ladder と衝突しない descriptive 名にした。

### 2. `dot_claude/skills/loop-design/SKILL.md`（設計プロセス）

曖昧な「ループが欲しい」を、上の規約に準拠した具体的なループ仕様に変える誘導インタビュー。

- 7問を1問ずつ（goal/done・runner・maker/checker・gates・STATE.md・autonomy・comprehension）
- 出力: `LOOP.md` + `STATE.md` 雛形 + **report-only 固定の起動コマンド文字列**
- 成果物の生成で止まる。ループ実行・schedule 配線はしない。規約は参照のみで再記述しない

## TDD（skill）

| フェーズ | 結果 |
|---|---|
| RED（スキル無し・曖昧要望） | シナリオを捏造し一方的に全設計をダンプ、インタビューせず |
| GREEN（スキル有り・同じ要望） | Q1だけ提示、捏造なし、ファイル未生成 |

ルールは観測した失敗へのパッチではなく規約の先行文書化（rule 側の Red は未実施）。ただしスコープ済みで常時ロードコストはゼロ。

## Notes

- 反映には `just apply` が必要。
- skill は rule を REQUIRED BACKGROUND に持つため、両者を同一 PR で出している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
