### PR TITLE
fix(claude): advisor model opus, fable unavailable

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -1,6 +1,6 @@
 {
 {{- if not .business_use }}
-  "advisorModel": "fable",
+  "advisorModel": "opus",
 {{- end }}
   "permissions": {
     "allow": [


### PR DESCRIPTION
## Why

fable が利用できなくなった。personal モードは advisor に fable を pin していた（#171 で default model の fable pin は解除済み、残るのは advisor 用途のみ）が、fable が使えない以上この指定は機能しない。

## What

`dot_claude/settings.json.tmpl` の personal ブロック1行のみ変更。

```diff
-  "advisorModel": "fable",
+  "advisorModel": "opus",
```

## なぜ削除ではなく opus か（一次ソース確認済み）

当初「main も opus なら advisorModel は冗長では」という疑いがあったが、公式 docs で逆と確定した。

- **`advisorModel` は advisor の on スイッチ**。未設定だと advisor は完全に無効で、main モデルにフォールバックしない（[Advisor tool docs](https://code.claude.com/docs/en/advisor) "If any of these sets an advisor model, the advisor is enabled"）。削除 = advisor を切ること。
- **advisor は main 以上の capability が必須**。Opus main が受け付ける advisor は「Fable、または main 以上のバージョンの Opus」のみ。fable が使えない今、**opus が唯一の有効な advisor**。
- `opus` + `opus` は docs 公認の組み合わせ（"A second Opus reviews the first. Useful for high-stakes tasks where an independent check matters more than cost"）。決定点での独立レビューとして、harness の generator-evaluator 分離の自動版になる。

business モードはこの行を元々除外しており、account default に従う（変更なし）。

## 検証

- `chezmoi execute-template`（personal）で `"advisorModel": "opus"` 描画・`jq empty` で JSON 妥当を確認。
- 反映には `just apply` が必要。

## 補足（別対応）

グローバルの `~/.claude/rules/workflow.md`（chezmoi 管理外）はまだ fable advisor 前提の記述が残る。本 PR の対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
