### PR TITLE
docs: A/B-verified CLAUDE.md improvements + nvim README refresh

### DIFF
--- a/.claude/rules/zsh.md
+++ b/.claude/rules/zsh.md
@@ -1,5 +1,7 @@
 ---
-paths: "dot_zsh*.tmpl"
+paths:
+  - "dot_zsh*.tmpl"
+  - "dot_config/zsh/**"
 ---
 
 # Zsh Configuration Rules
@@ -7,7 +9,8 @@ paths: "dot_zsh*.tmpl"
 ## Structure
 
 - `dot_zshenv.tmpl` - Environment variables only (loaded for all shells)
-- `dot_zshrc.tmpl` - Interactive shell config (aliases, functions, plugins)
+- `dot_zshrc.tmpl` - Interactive shell config; loads every `dot_config/zsh/` file via explicit `{{ include }}` lines (a new file there is a no-op until registered)
+- `dot_config/zsh/` layer (init/ features/ modules/, header convention): see docs/superpowers/specs/2026-04-26-zsh-restructure-design.md
 
 ## Syntax Checking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Personal dotfiles managed with [chezmoi](https://www.chezmoi.io/) and [devbox](https://www.jetify.com/devbox). Files prefixed with `dot_` become dotfiles (e.g., `dot_zshrc.tmpl` → `~/.zshrc`).
 
+Every file in this repo is a deployment source by default: a new repo-level
+file (docs, configs, CI helpers — anything meant for the repo, not for `$HOME`)
+needs a matching entry in `.chezmoiignore`, or the next `chezmoi apply` deploys
+it into `$HOME`. This applies to any nested CLAUDE.md too — and a deployed
+`~/.claude/rules/CLAUDE.md` would even load as an always-on global rule.
+
 ## Commands
 
 ```bash
-just test        # Run all checks (lint + format)
+just test        # All checks: lint, zsh header lint, format, hook & skill-script tests (CI runs only a subset)
 just fmt         # Format all files (Lua, JSON)
 just fmt-check   # Check formatting without changes
 just lint        # Check zsh and lua syntax
@@ -70,6 +76,10 @@ Out of the waterfall (always Homebrew): GUI apps (`cask`), Mac App Store (`mas`)
 ## Authoring rules & skills
 
 Rules (`dot_claude/rules/`) and skills (`dot_claude/skills/`) added to this repo are written in **English**. Japanese is allowed only where nuance requires it — e.g. a skill `description`'s trigger phrases that the user types in Japanese, or a generated-output template whose reader is Japanese.
+
+Project-scoped rules live in repo-root `.claude/rules/` (`paths:`-scoped). The
+whole `.claude/` directory is gitignored, so a new file there needs `git add -f`
+— a plain `git add` silently does nothing.
 
 ## CI
 

--- a/dot_config/nvim/README.md
+++ b/dot_config/nvim/README.md
@@ -6,10 +6,12 @@
 
 | Key              | Action                        |
 | ---------------- | ----------------------------- |
-| `<leader>e`      | Toggle file explorer          |
+| `<leader>e`      | Open file explorer (oil)      |
+| `-`              | Open parent directory (oil)   |
 | `<leader>ff`     | Find files                    |
 | `<leader>fg`     | Live grep search              |
 | `<leader>fb`     | List buffers                  |
+| `<leader>fh`     | Help tags                     |
 | `<leader>fr`     | Recent files                  |
 | `<leader>fc`     | Git commits                   |
 | `<leader>fs`     | Git status                    |
@@ -43,6 +45,7 @@
 | `[d` / `]d`  | Prev/Next diagnostic   |
 | `<leader>d`  | Show diagnostic float  |
 | `<leader>q`  | Diagnostic list        |
+| `<leader>cf` | Format buffer (conform)|
 
 ## Git (gitsigns)
 
@@ -54,7 +57,7 @@
 | `<leader>hp` | Preview hunk    |
 | `<leader>hb` | Blame line      |
 
-## Copilot
+## Copilot (inline suggestions; chat is handled by Claude Code)
 
 | Key                | Action                   |
 | ------------------ | ------------------------ |
@@ -63,10 +66,6 @@
 | `Ctrl` + `End`     | Accept line              |
 | `Alt` + `]` / `[`  | Next/Prev suggestion     |
 | `Ctrl` + `]`       | Dismiss suggestion       |
-| `<leader>cc`       | Copilot Chat             |
-| `<leader>ce`       | Explain code (visual)    |
-| `<leader>cr`       | Review code (visual)     |
-| `<leader>cf`       | Fix code (visual)        |
 
 ## Comment
 
@@ -86,16 +85,16 @@
 | `ds{char}`         | Surround delete           |
 | `cs{old}{new}`     | Surround change           |
 
-## Completion
+## Completion (blink.cmp)
 
-| Key                  | Action                 |
-| -------------------- | ---------------------- |
-| `Ctrl` + `Space`     | Trigger completion     |
-| `Ctrl` + `n` / `p`   | Next/Prev item         |
-| `Tab` / `Shift+Tab`  | Navigate / Expand      |
-| `Enter`              | Confirm selection      |
-| `Ctrl` + `e`         | Abort completion       |
-| `Ctrl` + `b` / `f`   | Scroll docs            |
+| Key                  | Action                    |
+| -------------------- | ------------------------- |
+| `Ctrl` + `Space`     | Trigger completion        |
+| `Ctrl` + `n` / `p`   | Next/Prev item            |
+| `Tab` / `Shift+Tab`  | Snippet jump forward/back |
+| `Enter`              | Confirm selection         |
+| `Ctrl` + `e`         | Abort completion          |
+| `Ctrl` + `b` / `f`   | Scroll docs               |
 
 ## Text Objects (mini.ai)
 
@@ -116,13 +115,14 @@
 
 ## Plugins
 
-| Category   | Plugins                               |
-| ---------- | ------------------------------------- |
-| LSP        | mason, nvim-lspconfig, conform        |
-| Completion | nvim-cmp, LuaSnip, friendly-snippets  |
-| Navigation | telescope, nvim-tree                  |
-| Git        | gitsigns                              |
-| UI         | lualine, bufferline, noice, which-key |
-| Theme      | tokyonight (night)                    |
-| AI         | copilot, copilot-chat                 |
-| Syntax     | treesitter                            |
+| Category   | Plugins                                              |
+| ---------- | ---------------------------------------------------- |
+| LSP        | mason, nvim-lspconfig, conform                       |
+| Completion | blink.cmp                                            |
+| Navigation | telescope, oil                                       |
+| Git        | gitsigns                                             |
+| Editing    | Comment, nvim-surround, nvim-autopairs, todo-comments |
+| UI         | lualine, bufferline, noice, notify, which-key, indent-blankline |
+| Theme      | tokyonight (night)                                   |
+| AI         | copilot (inline only)                                |
+| Syntax     | treesitter, mini.ai                                  |


### PR DESCRIPTION
## Summary

Applies the outcome of an A/B verification exercise (8 Opus subagents running typical repo tasks with and without candidate CLAUDE.md content) plus a staleness sync of the nvim README against the actual config.

- `CLAUDE.md`
  - Add the `.chezmoiignore` tandem-update rule: a new repo-level file is a deployment source unless ignored, so it must land together with its `.chezmoiignore` entry. This was the only candidate instruction that changed agent behavior in verification (without it, agents added a root file and reported the repo healthy; with it, they included the ignore entry and called out the trap — the same failure previously fixed in #32).
  - Fix the stale `just test` description (it also runs zsh header lint, hook tests, and skill-script tests; CI runs only a subset).
  - Note that repo-root `.claude/` is gitignored, so new project-scoped rule files need `git add -f`. (This very PR hit that behavior while staging.)
- `.claude/rules/zsh.md`
  - Extend `paths:` to cover `dot_config/zsh/**` (previously only the root `dot_zsh*.tmpl` templates were in scope, leaving the zsh layer body uncovered).
  - Document that files there are no-ops until registered via `{{ include }}` in `dot_zshrc.tmpl`, and point to the layer design doc.
- `dot_config/nvim/README.md`
  - Remove CopilotChat keymaps (plugin removed in #95); title the section as inline-suggestions only.
  - Correct `<leader>cf` to conform's Format buffer (was documented as a CopilotChat binding).
  - Completion section: nvim-cmp -> blink.cmp semantics (`Tab`/`S-Tab` are snippet jumps).
  - File explorer rows: nvim-tree -> oil (`<leader>e`, add `-` and `<leader>fh`).
  - Plugin table synced with `lua/plugins/*.lua`.

Verification notes: directory-level CLAUDE.md drafts for zsh/nvim/skills/devbox/CI were tested the same way and produced no behavior delta (pattern-dense code plus the root CLAUDE.md and existing paths-scoped rules already carry those conventions), so they are deliberately not added.

## Test plan

- `just test` passes (lint, lint-headers, fmt-check, hook tests, skill-script tests)
- `chezmoi diff` shows no new deployment targets; the only managed-file change is the already-deployed `~/.config/nvim/README.md`
- nvim README rows were checked line-by-line against `init.lua` and `lua/plugins/{lsp,editor,completion,copilot,treesitter}.lua`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
