### PR TITLE
fix(claude): resolve spec-reviewer findings in empirical-prompt-tuning fold

### DIFF
--- a/dot_claude/references/model-profiles/README.md
+++ b/dot_claude/references/model-profiles/README.md
@@ -16,7 +16,7 @@ model-agnostic writing hygiene stays in the consuming skill.
 - `claude-md-layout` — designs directory-level CLAUDE.md
 - `empirical-prompt-tuning` — reviews/improves skills and prompts
 
-Both open by loading `~/.claude/references/model-profiles/<session-model>.md`. If
+Both open by loading `~/.claude/references/model-profiles/<session-model-id>.md`. If
 no exact match, fall back to the nearest same-family profile and note the gap.
 
 ## Updating (the anti-obsolescence contract)

--- a/dot_claude/skills/empirical-prompt-tuning/SKILL.md
+++ b/dot_claude/skills/empirical-prompt-tuning/SKILL.md
@@ -15,8 +15,8 @@ Prompt quality is invisible to its author. The more "clear" a writer thinks some
 ## Before you start
 
 - Load `~/.claude/references/model-profiles/<session-model-id>.md` and apply its Remove / Rewrite / Keep guidance when judging and editing the target — it is where model-specific writing changes live. No profile match → fall back to the nearest same-family one and note the gap.
-- Dispatch executors and judges at the **session model** by default. Do not hardcode a model name in the target prompt; name a model only for a mechanical substep. A prompt pinned to today's model re-breaks on the next upgrade.
-- When the target is a skill, read it through the `skill-creator` (Anthropic official) methodology first — it names the structural defects to look for.
+- Dispatch executors and judges at the session model by default. Do not hardcode a model name in the target prompt; name a model only for a mechanical substep. A prompt pinned to today's model re-breaks on the next upgrade.
+- When the target is a skill, read it through the `skill-creator` (Anthropic official) methodology first — it names the structural defects to look for. If `skill-creator` is not available in this environment, read for the same defects manually: unclear trigger in `description`, missing prerequisites, steps that assume unstated context.
 
 ## Two modes
 
@@ -61,15 +61,15 @@ Read the frontmatter `description` and the body independently.
 
 Fix these two artifacts before dispatching any subagent:
 
-**Evaluation scenarios** (2–3):
+**Evaluation scenarios** (2–3 for the loop, plus 1 sealed hold-out):
 - 1 median-difficulty scenario representing typical real-world usage
 - 1–2 edge scenarios
+- 1 additional hold-out, sealed: never used during the loop, run once at convergence (see Stopping Criteria → Overfitting check) to detect overfitting. This is on top of the 2–3 loop scenarios, so the loop always keeps its minimum of 2.
 
 **Requirements checklist** (3–7 items per scenario):
 - Each item = a concrete verifiable requirement the output must satisfy
 - Tag at least 1 item `[critical]` per scenario
-- **Do not modify the checklist after fixing it** — accuracy = items satisfied / total items. The only permitted change is tightening (a stricter bar or a new item); if you tighten, re-run every scenario from scratch. Loosening the checklist to make a fix pass is the failure this rule exists to block.
-- Hold one scenario back as a sealed hold-out: do not use it during the loop; run it once at the end (Stopping Criteria) to detect overfitting to the loop scenarios.
+- Do not loosen the checklist after fixing it — accuracy = items satisfied / total items. The only permitted change is tightening (a stricter bar or a new item); if you tighten, re-run every scenario from scratch.
 
 ### Step 2 — Bias-Free Read
 
@@ -93,7 +93,7 @@ Record the following from the returned result:
 
 **Who judges** (the improver stays out of subjective scoring):
 - Mechanical criteria — tie pass/fail to a verification command (exit code / output string / diff). No model judgment.
-- Non-mechanical criteria — dispatch a separate judge subagent that sees only the deliverable and the criteria, never the target's diff, the iteration history, or the improvement intent. An improver who scores its own executor's output drifts toward leniency.
+- Non-mechanical criteria — dispatch a separate judge subagent that sees only the deliverable and the criteria, never the target's diff, the iteration history, or the improvement intent. An improver who scores its own executor's output drifts toward leniency. The executor's own ○ / × / partial from the Launch Contract report is provisional signal for these items; the judge's verdict is authoritative.
 - Persist each run's full transcript to a file; return only the fail list and confusion summary to the improver's context, not the whole log. Keep the eval set (scenarios, verification commands, per-iteration logs) in the repo alongside the target so a human can audit it later.
 
 **Caller-side measurements** (judgment rules are authoritative here — reference only this section):


### PR DESCRIPTION
## 概要

独立 spec-reviewer（生成に非関与の別 agent）による PR #178 の事後評価で検出した運用上のギャップを修正する。generator-evaluator 分離の評価フェーズの結果対応。

## 背景

PR #178 の A-2 fold（既存 `empirical-prompt-tuning` への6点追補）を、生成に関与していない spec-reviewer で評価した。契約違反（モデル固有事実の漏れ）とモデル事実の正確性は clean。内部矛盾・過少定義が5件見つかった。

## 修正内容

| 指摘 | 内容 | 対応 |
|---|---|---|
| hold-out 重複 | fold で追加した hold-out が既存 "Overfitting check" と二重定義。かつ2本中1本を封印すると最小2本ルールに矛盾 | 重複削除。Step1 で hold-out を「ループ2-3本に加算」と明示し、定義は Overfitting check に一本化 |
| judge 未接続 | executor が Launch Contract で自己申告(○/×)する一方、新ルールは「別 judge が非機械判定」と要求し接続が曖昧 | executor 自己申告は非機械項目では暫定、judge の判定を権威と明記 |
| checklist 矛盾文 | 「変更禁止」と「厳格化のみ可」が同一文で矛盾 | 「緩めるな(Do not loosen)」に言い換え |
| skill-creator | 参照にフォールバック無し | 環境に無い場合の手動確認手順を追記 |
| 装飾 bold | 新規セクションに純装飾 bold | `session model` の装飾のみ削除（ラベル様式は既存 house style と整合のため維持） |
| placeholder 表記ゆれ | README のみ `<session-model>` | `<session-model-id>` に統一 |

## レビューを鵜呑みにしなかった点

指摘の一つ「Judge Launch Contract テンプレートの新設」は却下した。fold（既存スキルへの追補）に対し新テンプレート追加は過剰設計で、「executor 自己申告は暫定・judge が権威」の1行明確化で矛盾は解消できるため。

## 検証

- hold-out が単一定義（Step1 は参照のみ、定義は Overfitting check）
- 矛盾する checklist bold の解消
- placeholder 全ファイル統一
- `just fmt-check` 緑

## Test plan

- [ ] `chezmoi apply` 後、更新版 `empirical-prompt-tuning` が live に反映されること


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [],
      "participants": [],
      "sha": "d8390340c10fc46831a1ac2e60abe4b427ca7a00",
      "status": "unmetered",
      "subject": "fix(claude): resolve spec-reviewer findings in empirical-prompt-tuning fold",
      "totals": {
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0,
        "input_tokens": 0,
        "output_tokens": 0,
        "total_context_tokens": 0
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 0,
  "pr": {
    "base": "main",
    "head": "fix/empirical-tuning-review-followup",
    "number": 180
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 1,
  "totals": {
    "cache_creation_input_tokens": 0,
    "cache_read_input_tokens": 0,
    "input_tokens": 0,
    "output_tokens": 0,
    "total_context_tokens": 0
  },
  "totals_by_model": [],
  "updated_at": "2026-07-03T07:41:12Z"
}
```

</details>
<!-- code-flow-usage-json:end -->
