### PR TITLE
feat(herdr): port tmux prefix+u URL opener to herdr

### DIFF
--- a/dot_config/herdr/config.toml
+++ b/dot_config/herdr/config.toml
@@ -7,6 +7,13 @@ name = "tokyo-night"
 # Match tmux prefix (dot_tmux.conf) so muscle memory carries over during the trial
 prefix = "ctrl+a"
 
+# prefix+u: extract URLs from the focused pane's scrollback, fzf-pick, open
+# (parity with tmux `bind u` in dot_tmux.conf)
+[[keys.command]]
+key = "prefix+u"
+type = "pane"
+command = "herdr-url-open"
+
 [experimental]
 # macOS: switch to ASCII input source while prefix mode is active, so prefix
 # commands register even when the Japanese IME is on (best-effort)

--- a/dot_local/bin/executable_herdr-url-open
+++ b/dot_local/bin/executable_herdr-url-open
@@ -1,0 +1,23 @@
+#!/bin/zsh
+# Extract URLs from the invoking pane's scrollback, pick one with fzf, open it.
+# Bound to prefix+u in ~/.config/herdr/config.toml (herdr equivalent of the
+# tmux `bind u` in dot_tmux.conf). Runs inside a temporary herdr command pane;
+# HERDR_ACTIVE_PANE_ID is the pane that had focus when the key fired.
+set -u
+
+pane_id="${HERDR_ACTIVE_PANE_ID:-${HERDR_PANE_ID:-}}"
+if [[ -z "$pane_id" ]]; then
+  print -u2 "herdr-url-open: no pane id (run from a herdr keybinding)"
+  exit 1
+fi
+
+urls=$(herdr pane read "$pane_id" --source recent-unwrapped --lines 5000 \
+  | grep -oE 'https?://[^[:space:]"<>()]+' | sort -u)
+
+if [[ -z "$urls" ]]; then
+  print "No URLs in pane scrollback."
+  sleep 1
+  exit 0
+fi
+
+print -r -- "$urls" | fzf --reverse | xargs -r open


### PR DESCRIPTION
## Summary

herdr trial 中に失われていた tmux の `prefix + u`（スクロールバックから URL を抽出 → fzf で選択 → open）を herdr で再現する。

- `dot_local/bin/executable_herdr-url-open` — `herdr pane read` でキー押下時にフォーカスされていたペイン（`HERDR_ACTIVE_PANE_ID`）のスクロールバック 5000 行を読み、tmux 版と同じ正規表現で URL を抽出して fzf → `open` に渡す
- `dot_config/herdr/config.toml` — `[[keys.command]]` で `prefix+u` に `type = "pane"`（一時ペイン、終了で自動クローズ）としてバインド

## Design notes

- `--source recent-unwrapped` を採用。tmux `capture-pane -p` は画面幅で折り返された長い URL が分断されたが、論理行で取得するため壊れない
- fzf は devbox 経由だが、スクリプトは `#!/bin/zsh` で `~/.zshenv`（devbox shellenv cache）が PATH を通すため一時ペインからも解決できる
- tmux の `fzf-tmux -p` ポップアップに対し、herdr にはポップアップ API がないため一時分割ペインで代替

## Verification

- スクリプトの配線（pane ID 解決 → `pane read` → URL 抽出 → fzf 起動）は実ペインに対して `zsh -x` トレースで確認済み
- `chezmoi apply` + `herdr server reload-config` 適用済み（diagnostics なし）
- `just test` 全パス
- fzf の対話選択のみ TTY が必要なため、実機での `ctrl+a` → `u` 押下による確認が残タスク

🤖 Generated with [Claude Code](https://claude.com/claude-code)