### PR TITLE
feat(macos): keyboard shortcut scheme for launcher/clipboard/voice

### DIFF
--- a/docs/macos-keyboard-shortcuts.md
+++ b/docs/macos-keyboard-shortcuts.md
@@ -1,0 +1,47 @@
+# macOS Global Keyboard Shortcut Scheme
+
+Global hotkeys are assigned one "address" (modifier home) per functional layer,
+so launcher, clipboard, voice input, and passwords never collide.
+
+| Role                     | Key     | Owner             | How it is set                                         |
+| ------------------------ | ------- | ----------------- | ----------------------------------------------------- |
+| Launcher (main window)   | ⌘Space  | Raycast           | Scripted (`raycastGlobalHotkey = Command-49`)         |
+| Clipboard History        | ⌃Space  | Raycast extension | Manual (Raycast UI; stored in Raycast's encrypted DB) |
+| Dictation (hold to talk) | ⌥Space  | superwhisper      | App default; nothing to configure                     |
+| Password Quick Access    | ⇧⌘Space | 1Password         | App default                                           |
+| Autofill                 | ⌘\      | 1Password         | App default                                           |
+
+superwhisper is the single voice-input app (VoiceOS was dropped), so all voice
+lives on ⌥Space and no fn-based shortcut is needed.
+
+## Scripted part
+
+`home/.chezmoiscripts/run_onchange_after_configure-macos-keyboard.sh` (darwin only) writes:
+
+- `AppleFnUsageType = 0` — fn/globe alone does nothing.
+  IME switching is handled by Karabiner (left/right ⌘ alone → 英数/かな),
+  so the macOS fn-based input-source switch is redundant. (Only affects the
+  built-in keyboard anyway; the HHKB Fn key never reaches macOS.)
+- Symbolic hotkeys 60/61 disabled — frees ⌃Space (input-source switch) for Clipboard History.
+- Symbolic hotkeys 64/65 disabled — frees ⌘Space (Spotlight) for the Raycast launcher.
+- `raycastGlobalHotkey = Command-49` — Raycast main window on ⌘Space
+  (undocumented but stable key; falls back to setting it in Raycast UI if ignored).
+
+## Manual part (new machine checklist)
+
+1. Raycast → Extensions → Clipboard History → hotkey ⌃Space.
+1. Restart Raycast so the scripted ⌘Space launcher hotkey takes effect;
+   verify in Raycast Settings → General.
+1. superwhisper: leave the record hotkey at its default ⌥Space.
+
+No global shortcut may include fn: the HHKB Fn key is a firmware-level layer key
+that never reaches macOS, so fn-based shortcuts only work on Apple keyboards.
+
+## Known tradeoffs
+
+- ⌃Space globally shadows in-app bindings such as VS Code completion trigger
+  and Emacs `set-mark-command`.
+  Acceptable in a Neovim/terminal-centric setup; revisit if that changes.
+- Caps Lock is ⌃ (Karabiner), so ⌃Space is typed as Caps+Space from home row.
+  On HHKB, Control is natively at that position — no remap involved.
+- ⌃⌘Space is intentionally unused: it is the macOS emoji picker default.

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -7,6 +7,7 @@
 .config/karabiner/
 Library/
 homebrew/
+.chezmoiscripts/run_onchange_after_configure-macos-keyboard.sh
 {{ end }}
 
 # Linux specific (servers don't need GUI terminal config)

--- a/home/.chezmoiscripts/run_onchange_after_configure-macos-keyboard.sh
+++ b/home/.chezmoiscripts/run_onchange_after_configure-macos-keyboard.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Configure the macOS global-hotkey layer so launcher, clipboard history,
+# and voice-input apps stop colliding. Full scheme (including the manual,
+# non-scriptable pieces) is documented in docs/macos-keyboard-shortcuts.md.
+#
+# Triggered on chezmoi apply when this script changes.
+
+set -euo pipefail
+
+# fn/globe alone does nothing; IME switching is Karabiner's job
+# (left/right cmd alone -> eisuu/kana)
+defaults write com.apple.HIToolbox AppleFnUsageType -int 0
+
+# Free the key slots the scheme needs:
+#   60/61 = input-source switch (ctrl-space / ctrl-opt-space)
+#   64/65 = Spotlight / Finder search (cmd-space / cmd-opt-space)
+for id in 60 61 64 65; do
+  defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys \
+    -dict-add "$id" '<dict><key>enabled</key><false/></dict>'
+done
+
+# Raycast main window on cmd-space (49 = space keycode).
+# Clipboard History lives on ctrl-space, set manually in the Raycast UI.
+# Takes effect after Raycast restarts.
+if [ -d "/Applications/Raycast.app" ]; then
+  defaults write com.raycast.macos raycastGlobalHotkey -string "Command-49"
+fi
+
+# Flush the symbolic-hotkey cache so changes apply without re-login
+activate_settings="/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings"
+if [ -x "$activate_settings" ]; then
+  "$activate_settings" -u
+fi


### PR DESCRIPTION
## Why

superwhisper, Raycast (launcher + Clipboard History), and 1Password were colliding on global hotkeys — most painfully both defaulting to ⌥Space. This assigns one modifier "address" per functional layer so nothing fights over the same key.

## Scheme

| Role | Key | Owner | How set |
|------|-----|-------|---------|
| Launcher | ⌘Space | Raycast | Scripted (`raycastGlobalHotkey = Command-49`) |
| Clipboard History | ⌃Space | Raycast extension | Manual (Raycast UI) |
| Dictation (hold) | ⌥Space | superwhisper | App default |
| Password Quick Access | ⇧⌘Space | 1Password | App default |
| Autofill | ⌘\ | 1Password | App default |

## What the script does

`home/.chezmoiscripts/run_onchange_after_configure-macos-keyboard.sh` (darwin only):

- `AppleFnUsageType = 0` — fn/globe alone does nothing (IME is Karabiner's job via single-cmd → 英数/かな).
- Disables symbolic hotkeys 60/61 (input-source switch) and 64/65 (Spotlight), freeing ⌃Space and ⌘Space.
- Sets the Raycast launcher to ⌘Space.

## Notes

- HHKB-aware: no shortcut uses fn, because the HHKB Fn key is a firmware-layer key that never reaches macOS. Documented in `docs/macos-keyboard-shortcuts.md`.
- Manual steps that can't be scripted (Clipboard History → ⌃Space in the Raycast UI) are listed in the doc's new-machine checklist.
- Verified on this machine: `raycastGlobalHotkey = Command-49` persists across restart; superwhisper inserts on ⌥Space.
- Rebased onto the `home/` source root introduced by #212. The script and the ignore entry moved under `home/`; script logic is unchanged. At the old repo-root path chezmoi would have skipped the script silently, and CI's shellcheck/shfmt (`./home/.chezmoiscripts/*.sh`) would never have seen it. Confirmed after the move with `chezmoi managed --include=scripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ7jiThmqAoCdSVHsr1shU
