### PR TITLE
feat(herdr): add tmux-parity split and pane-cycle keybindings

### DIFF
--- a/dot_config/herdr/config.toml
+++ b/dot_config/herdr/config.toml
@@ -7,6 +7,15 @@ name = "tokyo-night"
 # Match tmux prefix (dot_tmux.conf) so muscle memory carries over during the trial
 prefix = "ctrl+a"
 
+# prefix+| : side-by-side split, matching tmux `bind | split-window -h` (herdr default: prefix+v).
+# Use the literal | — herdr only names grammar-conflicting keys (minus, plus); "pipe" is rejected.
+# The stacked split already matches: herdr split_horizontal = prefix+minus == tmux `bind -`.
+split_vertical = "prefix+|"
+
+# prefix+o: cycle focus to the next pane, matching tmux's built-in `prefix o`.
+# herdr binds one key per action, so this replaces the default prefix+tab.
+cycle_pane_next = "prefix+o"
+
 # prefix+u: extract URLs from the focused pane's scrollback, fzf-pick, open
 # (parity with tmux `bind u` in dot_tmux.conf)
 [[keys.command]]


### PR DESCRIPTION
## Summary

herdr trial 中に不足していた tmux のキーバインドを2つ補う。

- `split_vertical = "prefix+|"` — 左右分割を tmux の `bind | split-window -h` に合わせる（herdr 既定は `prefix+v`）
- `cycle_pane_next = "prefix+o"` — 次ペインへのフォーカス移動を tmux 組み込みの `prefix o` に合わせる（herdr 既定 `prefix+tab` を置き換え）

## Design notes

- `|` はリテラルで指定する。herdr が名前表記を要求するのは文法衝突するキーだけ（`-`→`minus`、`+`→`plus`）で、`|` は衝突しないためリテラルが通る。`"pipe"` は herdr に拒否される（reload 時に `invalid keybinding` 診断が出て該当バインドが無効化される）
- herdr は1アクション＝1キーのため、`cycle_pane_next` を `prefix+o` にすると既定の `prefix+tab` は無効になる。tmux で tab を使っていないため実害はない。逆回しは `cycle_pane_previous`（`prefix+shift+tab`）が既定のまま残る
- 上下分割は既定 `prefix+minus` が tmux の `bind -` と一致済みのため変更しない

## Verification

- `chezmoi apply` + `herdr server reload-config` を適用。両バインドとも `diagnostics: []`（`invalid keybinding` 警告なし）で受理を確認
- `prefix+|` は稼働中セッションで左右分割を実機確認済み
- `prefix+o` は reload 診断での受理まで確認。実機でのキー押下確認は残タスク

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 410285,
          "cache_creation_input_tokens": 410285,
          "cache_read_input_tokens": 10005052,
          "input_tokens": 12151,
          "model": "claude-opus-4-8",
          "output_tokens": 54267,
          "total_context_tokens": 10481755,
          "turns": 60
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 410285,
          "cache_creation_input_tokens": 410285,
          "cache_read_input_tokens": 10005052,
          "input_tokens": 12151,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 54267,
          "total_context_tokens": 10481755,
          "turns": 60
        }
      ],
      "recorded_at": "2026-07-09T02:39:32Z",
      "sha": "67ace39d8a7cd37f381f61a1f213ddc28b70df20",
      "subject": "feat(herdr): add tmux-parity split and pane-cycle keybindings",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 410285,
        "cache_creation_input_tokens": 410285,
        "cache_read_input_tokens": 10005052,
        "input_tokens": 12151,
        "output_tokens": 54267,
        "total_context_tokens": 10481755,
        "turns": 60
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 1,
  "pr": {
    "base": "main",
    "head": "feat/herdr-tmux-keybindings",
    "number": 184
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 1,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 410285,
    "cache_creation_input_tokens": 410285,
    "cache_read_input_tokens": 10005052,
    "input_tokens": 12151,
    "output_tokens": 54267,
    "total_context_tokens": 10481755,
    "turns": 60
  },
  "totals_by_model": [
    {
      "cache_creation_ephemeral_1h_input_tokens": 410285,
      "cache_creation_input_tokens": 410285,
      "cache_read_input_tokens": 10005052,
      "input_tokens": 12151,
      "model": "claude-opus-4-8",
      "output_tokens": 54267,
      "total_context_tokens": 10481755,
      "turns": 60
    }
  ],
  "updated_at": "2026-07-09T02:40:32Z"
}
```

</details>
<!-- code-flow-usage-json:end -->
