### PR TITLE
fix(herdr): keep split_vertical prefix+|, drop conflicting cycle_pane_next

### DIFF
--- a/dot_config/herdr/config.toml
+++ b/dot_config/herdr/config.toml
@@ -7,12 +7,12 @@ name = "tokyo-night"
 # Match tmux prefix (dot_tmux.conf) so muscle memory carries over during the trial
 prefix = "ctrl+a"
 
-# prefix+shift+backslash: side-by-side split, matching tmux `bind | split-window -h`
-# (herdr default: prefix+v). shift+backslash is the physical `|` key. herdr matches
-# punctuation only as explicit modified chords, so a literal "prefix+|" parses cleanly
-# but never fires at runtime — the chord form is required.
-# The stacked split already matches: herdr split_horizontal = prefix+minus == tmux `bind -`.
-split_vertical = "prefix+shift+backslash"
+# prefix+|: side-by-side split, matching tmux `bind | split-window -h`
+# (herdr default: prefix+v). The terminal delivers shift+backslash as the composed
+# character `|`, so the binding must be the literal char — a "shift+backslash" chord
+# never reaches herdr. Named punctuation (minus, comma, ...) is also accepted, which
+# is why the stacked split uses split_horizontal = prefix+minus == tmux `bind -`.
+split_vertical = "prefix+|"
 
 # prefix+u: extract URLs from the focused pane's scrollback, fzf-pick, open
 # (parity with tmux `bind u` in dot_tmux.conf)

--- a/dot_config/herdr/config.toml
+++ b/dot_config/herdr/config.toml
@@ -7,14 +7,12 @@ name = "tokyo-night"
 # Match tmux prefix (dot_tmux.conf) so muscle memory carries over during the trial
 prefix = "ctrl+a"
 
-# prefix+| : side-by-side split, matching tmux `bind | split-window -h` (herdr default: prefix+v).
-# Use the literal | — herdr only names grammar-conflicting keys (minus, plus); "pipe" is rejected.
+# prefix+shift+backslash: side-by-side split, matching tmux `bind | split-window -h`
+# (herdr default: prefix+v). shift+backslash is the physical `|` key. herdr matches
+# punctuation only as explicit modified chords, so a literal "prefix+|" parses cleanly
+# but never fires at runtime — the chord form is required.
 # The stacked split already matches: herdr split_horizontal = prefix+minus == tmux `bind -`.
-split_vertical = "prefix+|"
-
-# prefix+o: cycle focus to the next pane, matching tmux's built-in `prefix o`.
-# herdr binds one key per action, so this replaces the default prefix+tab.
-cycle_pane_next = "prefix+o"
+split_vertical = "prefix+shift+backslash"
 
 # prefix+u: extract URLs from the focused pane's scrollback, fzf-pick, open
 # (parity with tmux `bind u` in dot_tmux.conf)


### PR DESCRIPTION
## What

Net change vs `main`:

- `split_vertical = "prefix+|"` — value unchanged from `main`; the comment is rewritten to record *why* the literal `|` is required.
- Remove `cycle_pane_next = "prefix+o"` (reverts to herdr default `prefix+tab`).

## Why

**`split_vertical` — write the literal `|`, not a `shift+backslash` chord.** The terminal delivers `shift+backslash` as the already-composed character `|`, so herdr's input layer never sees a `backslash` keycode or a shift modifier. A `prefix+shift+backslash` binding reloads with empty diagnostics (the parser accepts it) but never fires at runtime. Verified by keypress: `prefix` (ctrl+a) → `|` triggers the side-by-side split after `herdr server reload-config`.

**`cycle_pane_next` — dropped to resolve a keybind conflict.** `cycle_pane_next = "prefix+o"` collided with herdr's default `open_notification_target = "prefix+o"`. herdr binds one key per action, so the conflict resolver kept the default and dropped the custom binding, making reload return `status: partial`; repeating that partial reload left prefix itself unresponsive. Pane cycling is already covered by `prefix+tab` and `prefix+h/j/k/l`, so the redundant binding is removed and reloads return `status: applied`.

## History note

This branch's first commit (3d6796e) rebound `split_vertical` to `prefix+shift+backslash` on the theory that "the chord form is required." That was a misdiagnosis: the original `prefix+|` was correct, and the earlier "doesn't fire" symptom was the config-reload trap (config edited, but the running server never `reload-config`'d). This PR restores `prefix+|` and corrects the comment. Squash-merge collapses the round-trip.

## Verification

- `herdr server reload-config` → `{"status":"applied","diagnostics":[]}`
- `prefix` (ctrl+a) → `|` split confirmed firing by keypress (parse-acceptance alone is not proof a binding fires)
- Deployed config matches chezmoi source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
