### PR TITLE
feat(herdr): persist onboarding/pane_history/UI toast settings in source

### DIFF
--- a/dot_config/herdr/config.toml
+++ b/dot_config/herdr/config.toml
@@ -1,5 +1,8 @@
 # herdr configuration — only deviations from `herdr --default-config` defaults
 
+# onboarding flow already completed
+onboarding = false
+
 [theme]
 name = "tokyo-night"
 
@@ -25,3 +28,10 @@ command = "herdr-url-open"
 # macOS: switch to ASCII input source while prefix mode is active, so prefix
 # commands register even when the Japanese IME is on (best-effort)
 switch_ascii_input_source_in_prefix = true
+pane_history = true
+
+[ui]
+show_agent_labels_on_pane_borders = true
+
+[ui.toast]
+delivery = "terminal"


### PR DESCRIPTION
## Why

herdr の4設定がライブファイル (`~/.config/herdr/config.toml`) にのみ存在し、chezmoi ソースに無かったため、`chezmoi apply` で消える状態だった。ソースへ取り込んで永続化する。

## What

`dot_config/herdr/config.toml` に以下を追加:

| 設定 | 配置 | 効果 |
|---|---|---|
| `onboarding = false` | トップレベル | 初回セットアップ案内を抑止（構成済み） |
| `pane_history = true` | `[experimental]` | サーバ完全再起動後もペイン画面履歴を復元 |
| `show_agent_labels_on_pane_borders = true` | `[ui]` | 手動ペイン名が無いとき枠にエージェント名を表示 |
| `delivery = "terminal"` | `[ui.toast]` | 背景通知を外側ターミナル経由のデスクトップ通知に |

配置は `herdr --default-config` のスキーマに準拠（`pane_history` は `[experimental]` 配下が正）。TOML パースと4値を検証済み。

## Note

適用後 `chezmoi diff` に残るのは並べ替えのみで、設定の増減は無い。値は不変のため herdr の `reload-config` は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)