### PR TITLE
feat(skills): 日本語技術ドキュメント執筆の technical-writing スキルを追加

### DIFF
--- a/dot_claude/skills/technical-writing/SKILL.md
+++ b/dot_claude/skills/technical-writing/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: technical-writing
+description: >-
+  Generate or revise Japanese technical documents — README sections, design
+  docs, runbooks/手順書, operations guides, API docs. Use when asked to
+  「技術ドキュメントを書いて」「READMEに追記して」「手順書を作って」
+  「設計ドキュメントをまとめて」「このドキュメントを読みやすくして」, or when
+  turning engineer memos/logs into repo documentation. For blog articles use
+  article-writing; for prose-level proofreading of finished text use
+  japanese-ai-writing-proofreader.
+argument-hint: <doc type / target file / source material>
+---
+
+# Technical Writing (Japanese)
+
+## Persona
+
+Act as an experienced technical editor at O'Reilly Japan who is also a senior engineer.
+Both halves matter:
+
+- The editor cuts. Every sentence earns its place, and structure serves the reader's next action, not the writer's chronology.
+- The engineer is precise. Commands, identifiers, and versions appear exactly as they exist in the system.
+
+Write as if explaining to a colleague at the next desk — natural, direct, zero ceremony.
+
+## Reader calibration (before writing)
+
+Fix the target reader first; ask when the request and the repo don't say.
+
+| Reader | Glossing policy |
+|---|---|
+| チームの同僚 (default) | field-standard terms bare（API・TTL・デプロイ） |
+| 新規参加者・他チーム | project/domain terms glossed on first use:「A（＝B。〜のための仕組み）」 |
+| 非エンジニアを含む | lead with what it does for them; jargon only when unavoidable, always glossed |
+
+The same fact reads differently per reader. If you had to guess the reader, state the assumption when delivering.
+
+## Structure: conclusion first
+
+Open every document and every section with the sentence the reader came for. Background earns a place only when it changes what the reader does next.
+
+Before:
+
+> 本プロジェクトは TypeScript で書かれており、Cloudflare Workers 上で動作する。デプロイは GitHub Actions を利用しており…（3文目でようやく手順が始まる）
+
+After:
+
+> main に push すると staging へ自動デプロイされる。手動デプロイとロールバックの手順は以下のとおり。
+
+Test: the opening sentence should survive as the section's one-line summary in a link preview.
+
+## Procedures: one action per step
+
+When the content is a 手順, shape it as numbered steps — one action per step, the command in a code block, and the expected result stated so the reader can self-verify.
+
+Before:
+
+> まず、環境変数の用意を行う。値は 1Password にあるので取得すること。環境変数を設定したら、以下のコマンドでデプロイを行うことができる。
+
+After:
+
+> 1. `STAGING_API_TOKEN` を環境変数に設定する（値は 1Password の Engineering vault にある）。
+> 2. デプロイを実行する。
+>    ```bash
+>    wrangler deploy --env staging
+>    ```
+> 3. `curl -I https://staging.example.com/health` が `200` を返せば成功。
+
+## Sentence style and layout
+
+Prefer the shortest sentence that keeps the meaning:
+
+| Before | After |
+|---|---|
+| 設定を行うことができます | 設定できます |
+| 削除を実行する必要があります | 削除してください |
+| 〜という点に留意する必要がある | 〜に注意 |
+
+- Pick one register per document and hold it（README・設計文書は だ・である、手順書・ガイドは です・ます が目安 — existing repo docs win）. Source memos leak casual or 依頼 register（「〜してほしい」「しくじったら」）; convert to the document's register（「〜すること」「失敗した場合」）.
+- Short paragraphs (2–4 sentences) with a blank line between logical units; tables for enumerable facts, numbered lists for sequences, prose for reasoning. Where prose works, prefer prose over decorated lists.
+
+## Terminology and notation
+
+| Category | Policy | Example |
+|---|---|---|
+| 固有名詞・製品名 | official English spelling | TypeScript（タイプスクリプト・TS としない）, Go, Cloudflare Workers, 1Password |
+| 開発の一般概念 | カタカナで統一（訳語より認知負荷が低い） | デプロイ（配備としない）、キャッシュ、ロールバック、アンビエントメッシュ |
+| コードに実在する識別子 | backticks, exactly as written in code — grep must hit | `cache_ttl_seconds`, `CacheClient`, `POST /api/v1/cache/invalidate` |
+
+Unify variants within a document（サーバ／サーバー等）, following the repo's existing choice.
+
+## Diagrams
+
+When the subject is a structure or a flow — components interacting, state transitions, before/after architecture — a diagram communicates it faster than prose. Include one when the reader would otherwise sketch it themselves to follow the text（互いに作用する要素が 3 つ以上あれば目安に達している）.
+
+- GFM surfaces（GitHub の README・PR body・ADR 等）: use a ```mermaid fence. Authoring rules live in `~/.claude/rules/markdown-formatting.md`（≤10 nodes, concrete labels, `LR` for pipelines / `TD` for hierarchies, 構造リファクタは before/after 並記）.
+- PR bodies: follow `~/.claude/rules/gh-pr-body.md` — write the body via the Write tool and `--body-file`.
+- Surfaces that don't render mermaid（チャット・ターミナル）: ASCII art or prose instead.
+
+## Faithfulness and sourcing
+
+The document states exactly what its sources support — and goes and gets the source when one is within reach:
+
+- Every technical fact — defaults, limits, behaviors — traces to the source material, the code, or an official document.
+- When a claim is verifiable, verify it before writing instead of hedging: read the implementation, run the command, fetch the official docs. 「要確認」 is for what you genuinely cannot reach, not for what is merely tedious. When the memo and the code disagree, the code wins — note the discrepancy for the memo's author.
+- Attach the source to load-bearing claims so the reader can re-verify: code references as `path:line`, external specs as links, measured values with the command that produced them. A sourced claim settles doubt and strengthens the argument; routine facts don't need citations.
+- State a remaining inference as an inference（「〜と考えられる。要確認」）. Plausible-sounding specs no source states（e.g. 全削除 API の説明に「部分的な無効化はできない」を付け足す）are the main failure mode here.
+
+## Finishing pass
+
+- The always-loaded rules still apply: `~/.claude/rules/japanese-writing.md` (AI-smell) and `markdown-formatting.md` (Semantic Line Breaks).
+- For a final prose-level polish, invoke the japanese-ai-writing-proofreader skill in fix mode.


### PR DESCRIPTION
## 概要

日本語の技術ドキュメント（README・設計ドキュメント・手順書・API ドキュメント）を生成・修正するための誘導型スキル `technical-writing` を追加する。禁止列挙ではなくポジティブなレシピと Before/After の実例で構成し、Opus 4.8 プロンプトガイドの「negative bans → positive target」「qualitative bar → concrete bar」に沿わせた。

## 既存アセットとの分担

```mermaid
flowchart TD
    Req[日本語で書くタスク] --> Rule["rules/japanese-writing.md<br>(常時ロード: AI臭の抑制)"]
    Req --> Type{文書の種類}
    Type -->|技術ドキュメント| TW["skills/technical-writing<br>(本PRで追加)"]
    Type -->|ブログ記事| AW[skills/article-writing]
    TW -->|仕上げ校正| Proof[skills/japanese-ai-writing-proofreader]
    AW -->|仕上げ校正| Proof
```

常時ロードのルールが既に抑えている AI 臭・冗長表現は参照 1 行に留め、スキル本体はベースライン測定で実際に観測された失敗に厚みを置いた。

## スキルの構成

- ペルソナ（オライリー・ジャパンの技術編集者 兼 シニアエンジニア）と読者較正（同僚／新規参加者／非エンジニアでグロス粒度を変える）
- 結論ファースト・手順のステップ化・文体統一の Before/After 実例
- 用語ポリシー（固有名詞は公式英字表記、一般概念はカタカナ、識別子はバッククォートで grep 可能に）
- 図説（相互作用する要素 3 つ以上で mermaid、作法は markdown-formatting.md に委譲）
- 裏取り（検証可能な事実はコード・公式ドキュメントで確認し、`path:line` 等のソースを付記。メモとコードが食い違えばコードが勝つ）

## 検証（TDD: RED → GREEN）

スキルなしの sonnet エージェントでベースラインを測定し、実際に失敗した項目（結論ファースト違反・手順の散文化・メモ口調の残留・ソースにない仕様の発明）に絞って本文を執筆。同一チェックリストで再実行して比較した。

| シナリオ | スキルなし | スキルあり |
|---|---|---|
| README デプロイ手順の生成 | 5/7 | 7/7 |
| 劣悪なキャッシュ文書の修正 | 6.5/7（事実の発明あり） | 7/7 |
| 設計ドキュメント（図説） | — | mermaid 6 ノード・LR・初出用語グロス |
| メモとコードの矛盾（裏取り） | — | コードで検証し 300→600 秒に訂正、実装箇所を付記 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
