### PR TITLE
fix(claude): use Edit() instead of Write() for file deny rules

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -80,10 +80,10 @@
       "Read(**/*secret*)",
       "Read(**/.netrc)",
       "Read(**/.npmrc)",
-      "Write(**/.env*)",
-      "Write(**/secrets/**)",
-      "Write(**/.ssh/*)",
-      "Write(**/authorized_keys)",
+      "Edit(**/.env*)",
+      "Edit(**/secrets/**)",
+      "Edit(**/.ssh/*)",
+      "Edit(**/authorized_keys)",
       "mcp__supabase__execute_sql"
     ],
     "defaultMode": "auto"


### PR DESCRIPTION
## Summary

- Replace the four `Write(path)` permission deny rules with `Edit(path)` in `dot_claude/settings.json.tmpl`
- `Write(path)` rules are not matched by file permission checks (harness warning at session start); only `Edit(path)` rules are, and they cover all file-editing tools (Write/Edit/NotebookEdit)
- The secret-protection rules for `.env*`, `secrets/`, `.ssh/`, and `authorized_keys` were silently ineffective until now

## Verification

- `chezmoi execute-template < dot_claude/settings.json.tmpl | jq` renders valid JSON containing the four `Edit(...)` deny rules
- With the rule applied, an attempted Write to `.env.test` in the repo root is denied by the permission check

🤖 Generated with [Claude Code](https://claude.com/claude-code)