### PR TITLE
feat(herdr): adopt 0.7.4 popup url-open, tab-bar autohide, zsh completion

### DIFF
--- a/dot_config/herdr/config.toml
+++ b/dot_config/herdr/config.toml
@@ -18,11 +18,15 @@ prefix = "ctrl+a"
 split_vertical = "prefix+|"
 
 # prefix+u: extract URLs from the focused pane's scrollback, fzf-pick, open
-# (parity with tmux `bind u` in dot_tmux.conf)
+# (parity with tmux `bind u` in dot_tmux.conf). Popup keeps the tiled layout
+# intact; HERDR_ACTIVE_PANE_ID still points at the pane that had focus.
 [[keys.command]]
 key = "prefix+u"
-type = "pane"
+type = "popup"
 command = "herdr-url-open"
+description = "open URL from scrollback"
+width = "80%"
+height = "80%"
 
 [experimental]
 # macOS: switch to ASCII input source while prefix mode is active, so prefix
@@ -32,6 +36,7 @@ pane_history = true
 
 [ui]
 show_agent_labels_on_pane_borders = true
+hide_tab_bar_when_single_tab = true
 
 [ui.toast]
 delivery = "terminal"

--- a/dot_config/zsh/init/plugins.zsh
+++ b/dot_config/zsh/init/plugins.zsh
@@ -194,6 +194,13 @@ _zinit_setup_completions() {
     source "$_just_comp"
   fi
 
+  # herdr
+  if (( $+commands[herdr] )); then
+    local _herdr_comp="$cache_dir/_herdr"
+    [[ -f "$_herdr_comp" ]] || herdr completion zsh > "$_herdr_comp"
+    source "$_herdr_comp"
+  fi
+
   # mise
   if (( $+commands[mise] )); then
     local _mise_comp="$cache_dir/_mise"


### PR DESCRIPTION
## Summary

Reviewed herdr 0.7.2–0.7.4 release notes and adopted the config-relevant additions (herdr binary already upgraded to 0.7.4 via brew).

- `prefix+u` URL picker: `type = "pane"` → `type = "popup"` (80%×80%, plus `description` for the keybinding help). Same UX as tmux `display-popup` — fzf opens in a floating terminal without disturbing the tiled layout. The official docs state popups receive `HERDR_ACTIVE_PANE_ID` (not `HERDR_PANE_ID`); `herdr-url-open` already prefers the former, so no script change is needed.
- `ui.hide_tab_bar_when_single_tab = true` — reclaims one row when a workspace has a single tab (0.7.2).
- `herdr completion zsh` added to the cached completion block in `plugins.zsh`, following the existing gh/chezmoi/just pattern (0.7.2).

Considered and skipped: `ui.sidebar_collapsed_mode = "hidden"` (kept compact rail), `ui.copy_on_select` and sidebar `row_gap` overrides (defaults preferred).

## Deployment note

`herdr server reload-config` against a still-running 0.7.1 server rejects `type = "popup"` (`unknown variant`, `status: partial`) — the live server must be generation-switched with `herdr server live-handoff` after the binary upgrade. Config is applied; handoff is pending on this machine.

## Verification

- Config applied via chezmoi; `zsh -n` passes on the modified plugins.zsh
- New keys verified to exist in `herdr --default-config` (0.7.4) and the version-matched config reference at herdr.dev
- `herdr completion zsh` output confirmed to be a valid compdef script
- Runtime check of `prefix+u` popup pending the live-handoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)