### PR TITLE
feat(herdr): add prefix+m glowm Markdown/mermaid preview

### DIFF
--- a/dot_config/herdr/config.toml
+++ b/dot_config/herdr/config.toml
@@ -28,11 +28,27 @@ description = "open URL from scrollback"
 width = "80%"
 height = "80%"
 
+# prefix+m: fd-find a Markdown file under the focused pane's cwd, fzf-pick,
+# view in glowm (inline Mermaid via Kitty graphics). Uses type = "pane", not
+# "popup": popups are session-modal overlays that do not composite Kitty
+# graphics, so glowm's Mermaid images never paint there. A temporary pane
+# shares the normal pane render path where graphics work.
+[[keys.command]]
+key = "prefix+m"
+type = "pane"
+command = "herdr-md-open"
+description = "preview Markdown with glowm"
+
 [experimental]
 # macOS: switch to ASCII input source while prefix mode is active, so prefix
 # commands register even when the Japanese IME is on (best-effort)
 switch_ascii_input_source_in_prefix = true
 pane_history = true
+# Render Kitty graphics inside panes (mermaid images via glowm, snacks.image
+# in nvim, kitten icat). Requires a Kitty graphics-capable outer terminal
+# (Ghostty). Upstream still tracks Ghostty flicker/size-query bugs — if images
+# reload in a loop or render 0-sized, turn this back off.
+kitty_graphics = true
 
 [ui]
 show_agent_labels_on_pane_borders = true

--- a/dot_local/bin/executable_herdr-md-open
+++ b/dot_local/bin/executable_herdr-md-open
@@ -1,0 +1,25 @@
+#!/bin/zsh
+# fd-find Markdown files under the focused pane's cwd, pick one with fzf, view
+# it in glowm (inline Mermaid via Kitty graphics). Bound to prefix+m in
+# ~/.config/herdr/config.toml. Runs inside a temporary herdr command pane;
+# HERDR_ACTIVE_PANE_ID is the pane that had focus when the key fired.
+set -u
+
+pane_id="${HERDR_ACTIVE_PANE_ID:-${HERDR_PANE_ID:-}}"
+if [[ -z "$pane_id" ]]; then
+  print -u2 "herdr-md-open: no pane id (run from a herdr keybinding)"
+  exit 1
+fi
+
+# Prefer where the foreground process actually is; fall back to the shell cwd.
+cwd=$(herdr pane get "$pane_id" 2>/dev/null \
+  | jq -r '.result.pane | .foreground_cwd // .cwd // empty')
+if [[ -z "$cwd" || ! -d "$cwd" ]]; then
+  print -u2 "herdr-md-open: could not resolve pane cwd"
+  exit 1
+fi
+
+file=$(fd --type f --extension md --extension markdown --hidden \
+  --exclude .git . "$cwd" | fzf --reverse --prompt "glowm> ") || exit 0
+
+[[ -n "$file" ]] && glowm "$file"


### PR DESCRIPTION
## What

herdr で Markdown を glowm 表示し、Mermaid 図をインライン描画するための配線を追加する。

- `[experimental] kitty_graphics = true` — ペイン内で Kitty graphics を描画(glowm の Mermaid 画像、nvim の snacks.image、`kitten icat` などが有効化)。反映には `herdr server live-handoff` が必要（`reload-config` では効かない）
- `prefix+m` — フォーカスペインの cwd 以下を `fd` で `*.md` 列挙 → `fzf` 選択 → `glowm` 表示するカスタムコマンド（`herdr-md-open` スクリプト）

## 設計判断

- **`type = "pane"` を採用（`popup` ではない）**: popup は session-modal なオーバーレイで Kitty graphics を合成しないため、glowm の Mermaid 画像が描画されない。一時ペインなら通常ペインと同じ描画経路で graphics が効く。
- **パス取得は cwd+fd**（スクロールバック抽出ではない）: README/docs を見る頻度を優先。
- **fzf preview なし**: glowm preview は hover ごとに headless Chrome が起動して重いため意図的に省略。

## 既知の未解決点

- **glowm のスクロールが `more` 挙動になり、キー入力で末尾まで進むと一時ペインが閉じる。** glowm の native フル pager は端末サイズ/機能クエリの応答を要するが、herdr のペインが応答しない（CSI 14t/16t 未応答, herdr 側の制約）ため `internal/pager.pageMore` にフォールバックしている。glowm 側でも本設定でもなく herdr のペイン制約。native 強制の env は無い。

## Draft の理由 / TODO

- [ ] **glowm が会社の toolcheck 未通過**。通過後に personal `homebrew/Brewfile` へ `tap "atani/tap"` + `brew "atani/tap/glowm"` を追加する（本 PR には含めていない）。
- [ ] `prefix+m` の実機テスト（pane 描画は確認済み、fzf→glowm の一連動作は要確認）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
