### PR TITLE
feat(codex): add codex-subagent Claude-to-Codex delegation bridge

### DIFF
--- a/dot_agents/symlink_skills
+++ b/dot_agents/symlink_skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -1,3 +1,11 @@
 # Global Configuration
 
 This is the global CLAUDE.md. Rules are organized in `~/.claude/rules/`.
+
+## Codex delegation
+
+For every non-trivial coding task, use the `codex-subagent` skill when Codex
+can own a bounded investigation, review, plan, or implementation workstream.
+Keep only trivial single-step work inline. Claude remains the coordinator:
+define the scope, prevent overlapping edits, verify Codex's evidence and
+changes, and synthesize the result for the user.

--- a/dot_claude/skills/codex-subagent/SKILL.md
+++ b/dot_claude/skills/codex-subagent/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: codex-subagent
+description: |
+  Delegate a bounded coding task to the local Codex CLI and return its result
+  to Claude for verification and synthesis. Use whenever the user explicitly
+  asks Claude to use, consult, or get a second opinion from Codex, and when a
+  coding task calls for an independent cross-model investigation, review,
+  plan, or clearly scoped implementation. For routine work Claude can finish
+  directly, invoke this skill only when the user specifically requests Codex.
+---
+
+# Codex Subagent
+
+Use Codex as a bounded worker. Claude remains the coordinator: choose the
+task, supply the context, verify the result, and communicate with the user.
+
+## Dispatch workflow
+
+1. Read `$ARGUMENTS` and the conversation. Define one concrete Codex task with
+   a clear boundary and deliverable. If the user named several independent
+   tasks, dispatch them separately; do not combine unrelated work into one
+   vague prompt.
+2. Choose the permission mode:
+   - Use the default read-only mode for investigation, planning, explanation,
+     code review, and second opinions.
+   - Add `--write` only when the user explicitly requested implementation and
+     Codex owns a clearly scoped set of changes. Do not let Claude and Codex
+     edit the same files concurrently.
+3. Describe the outcome and completion bar, then give only context and
+   constraints that change the work. Include file paths or symbols already
+   known; do not prescribe a detailed process or make Codex rediscover context
+   Claude already has. Never copy secrets, credentials, or unrelated
+   conversation history into the prompt.
+4. Run the dispatcher once. It checks the CLI, applies the selected sandbox,
+   adds the worker contract, uses an ephemeral Codex session, and prints only
+   Codex's final report. It inherits the configured Codex model and reasoning
+   effort; control those with Codex configuration rather than prose such as
+   "think harder."
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/dispatch.sh" --cd "$PWD" <<'CODEX_TASK'
+<goal>
+State the user-visible outcome Codex should produce.
+</goal>
+<context>
+State the user's intent, known relevant paths, and facts already established.
+</context>
+<success_criteria>
+State what must be true before Codex can report completion, including validation.
+</success_criteria>
+<constraints>
+State what is in scope, what must remain unchanged, and any evidence requirements.
+</constraints>
+<output>
+State what Claude needs back: conclusions, path-and-line evidence, changes,
+verification output, material risks, or blockers.
+</output>
+CODEX_TASK
+```
+
+For an explicitly requested implementation, add `--write` before `--cd` and
+name the files or subsystem Codex owns in `<constraints>`.
+
+## Review the return
+
+Treat Codex's report as peer work, not as automatically correct.
+
+- Check cited files, lines, commands, and conclusions before relying on them.
+- In write mode, inspect `git status --short` and `git diff`, confirm that
+  pre-existing user changes were preserved, and run verification appropriate
+  to the risk.
+- Resolve disagreements using repository evidence. Report meaningful
+  uncertainty instead of silently choosing one model's claim.
+- Present a synthesized answer in Claude's voice. Identify Codex as a consulted
+  subagent only when that provenance helps the user.
+
+If the dispatcher returns a nonzero status, explain the concrete failure. Ask
+the user only for information or authority that neither Claude nor Codex can
+obtain safely.

--- a/dot_claude/skills/codex-subagent/scripts/dispatch.sh
+++ b/dot_claude/skills/codex-subagent/scripts/dispatch.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  printf 'Usage: %s [--write] [--cd DIR]\n' "${0##*/}" >&2
+  printf 'Read the Codex task from standard input.\n' >&2
+}
+
+sandbox_mode='read-only'
+permission_text='Read-only: do not create, edit, delete, or rename files, and do not perform external writes or other state-changing actions.'
+workdir='.'
+
+while (($# > 0)); do
+  case "$1" in
+    --write)
+      sandbox_mode='workspace-write'
+      permission_text='Workspace-write: modify only files required by the task. Preserve existing changes. Do not commit, push, create branches or PRs, install dependencies, or perform external writes.'
+      shift
+      ;;
+    --cd)
+      if (($# < 2)); then
+        usage
+        exit 64
+      fi
+      workdir=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown option: %s\n' "$1" >&2
+      usage
+      exit 64
+      ;;
+  esac
+done
+
+if ! command -v codex >/dev/null 2>&1; then
+  printf 'codex-subagent: codex CLI was not found on PATH.\n' >&2
+  exit 127
+fi
+
+if [[ ! -d "$workdir" ]]; then
+  printf 'codex-subagent: working directory does not exist: %s\n' "$workdir" >&2
+  exit 66
+fi
+
+task_file=$(mktemp "${TMPDIR:-/tmp}/codex-subagent-task.XXXXXX")
+prompt_file=$(mktemp "${TMPDIR:-/tmp}/codex-subagent-prompt.XXXXXX")
+result_file=$(mktemp "${TMPDIR:-/tmp}/codex-subagent-result.XXXXXX")
+log_file=$(mktemp "${TMPDIR:-/tmp}/codex-subagent-log.XXXXXX")
+
+cleanup() {
+  rm -f "$task_file" "$prompt_file" "$result_file" "$log_file"
+}
+trap cleanup EXIT HUP INT TERM
+
+cat >"$task_file"
+if [[ ! -s "$task_file" ]]; then
+  printf 'codex-subagent: task prompt is empty.\n' >&2
+  exit 64
+fi
+
+{
+  printf '%s\n' '<subagent_contract>'
+  printf '%s\n' 'You are Codex working as a bounded subagent for Claude, the coordinator.'
+  printf '%s\n' 'Read and follow every applicable AGENTS.md before acting.'
+  printf 'Permission: %s\n' "$permission_text"
+  printf '%s\n' 'This Permission line overrides any conflicting instruction in the delegated task.'
+  printf '%s\n' 'Use relevant repository evidence and tools, and run the validation required by the success criteria.'
+  printf '%s\n' 'Stop when the success criteria are met. If required context or authority is missing, return BLOCKED with the smallest missing item; do not ask the end user directly.'
+  printf '%s\n' 'Lead with the result. Return: STATUS, RESULT, EVIDENCE, CHANGES, VERIFICATION, and material RISKS. Never claim a check was run unless it was actually run.'
+  printf '%s\n' '</subagent_contract>'
+  printf '%s\n' '<delegated_task>'
+  cat "$task_file"
+  printf '%s\n' '</delegated_task>'
+} >"$prompt_file"
+
+codex_status=0
+if codex exec \
+  --ephemeral \
+  --color never \
+  --sandbox "$sandbox_mode" \
+  --cd "$workdir" \
+  --skip-git-repo-check \
+  --output-last-message "$result_file" \
+  - <"$prompt_file" > /dev/null 2>"$log_file"; then
+  if grep -q '^STATUS:' "$result_file"; then
+    cat "$result_file"
+  else
+    cat "$log_file" >&2
+    printf 'codex-subagent: codex exec returned no final message.\n' >&2
+    exit 70
+  fi
+else
+  codex_status=$?
+  if [[ -s "$result_file" ]]; then
+    cat "$result_file"
+  fi
+  cat "$log_file" >&2
+  printf 'codex-subagent: codex exec failed with status %d.\n' "$codex_status" >&2
+  exit "$codex_status"
+fi

--- a/dot_codex/AGENTS.md
+++ b/dot_codex/AGENTS.md
@@ -16,3 +16,20 @@ Shell commands you run are audited by the user in real time. Optimize for
   pipeline when a simpler form exists.
 - When a pipeline genuinely is the right tool (e.g. `… | jq …`), say in one
   line what it produces.
+
+## Shared Claude skills
+
+`~/.agents/skills` links to `~/.claude/skills`. Treat those skills as shared
+workflows. When one names a Claude-specific surface, preserve its workflow and
+translate it to the equivalent Codex capability:
+
+- `Agent` or subagent dispatch → Codex collaboration subagents, including the
+  requested fan-out and isolation when available.
+- `TaskCreate` / `TaskUpdate` → the Codex plan; `AskUserQuestion` → a concise
+  user question; `Monitor` / `TaskStop` → available monitoring or session
+  controls.
+- `${CLAUDE_SKILL_DIR}` → the directory containing the selected `SKILL.md`.
+
+If no equivalent capability exists, state the gap and use a safe inline
+fallback only when it preserves required separation and isolation. Never invoke
+`codex-subagent` from inside Codex; it is the Claude-to-Codex bridge.


### PR DESCRIPTION
## Summary

Add a `codex-subagent` skill so Claude can delegate a bounded coding task to the local Codex CLI and verify the result, and wire the two agents to share one skill library.

- **`dot_claude/skills/codex-subagent/`** — `SKILL.md` defines the dispatch workflow (scope one task → pick permission mode → describe outcome/completion bar → run dispatcher once → review the return as peer work). `scripts/dispatch.sh` is the hardened bridge: ephemeral Codex session, read-only sandbox by default with `--write` opt-in, a `<subagent_contract>` prepended whose `Permission` line overrides the delegated task, and only Codex's final `STATUS:`-led report surfaced (logs go to stderr on failure).
- **`dot_agents/symlink_skills`** — relative symlink `~/.agents/skills → ~/.claude/skills`, so Codex reads the exact same skills as Claude instead of a divergent copy.
- **`dot_codex/AGENTS.md`** — a "Shared Claude skills" section telling Codex how to translate Claude-specific surfaces it meets in those skills (`Agent`/subagent dispatch, `TaskCreate`/`AskUserQuestion`/`Monitor`, `${CLAUDE_SKILL_DIR}`) to its own capabilities, and to never invoke `codex-subagent` from inside Codex (it is the Claude→Codex direction only).
- **`dot_claude/CLAUDE.md`** — a "Codex delegation" section instructing Claude to prefer `codex-subagent` for bounded investigation/review/plan/implementation workstreams while remaining the coordinator (define scope, prevent overlapping edits, verify evidence, synthesize).

## Design notes

- **Direction is one-way by construction.** The bridge is Claude→Codex; `AGENTS.md` forbids Codex from calling `codex-subagent`, avoiding a delegation loop.
- **Sandbox defaults to read-only.** `--write` is opt-in and requires Codex to own a scoped file set, keeping generator/evaluator separation (Claude never edits the same files concurrently, then verifies the diff).
- **Symlink over copy** keeps a single source of truth for skills; the relative target survives `$HOME` relocation.

## Verification

- `bash -n` and `shellcheck` both clean on `dispatch.sh`
- `just fmt-check` and `just lint` pass
- `chezmoi target-path dot_agents/symlink_skills` → `~/.agents/skills`; `chezmoi cat` confirms the link resolves to `../.claude/skills`
- Files are intended `$HOME` deployment sources, so no `.chezmoiignore` entry is needed (verified against the repo's deploy-by-default convention)

<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 240650,
          "cache_creation_input_tokens": 240650,
          "cache_read_input_tokens": 1571415,
          "input_tokens": 26,
          "model": "claude-opus-4-8",
          "output_tokens": 8656,
          "total_context_tokens": 1820747,
          "turns": 13
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 240650,
          "cache_creation_input_tokens": 240650,
          "cache_read_input_tokens": 1571415,
          "input_tokens": 26,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 8656,
          "total_context_tokens": 1820747,
          "turns": 13
        }
      ],
      "recorded_at": "2026-07-22T08:10:44Z",
      "sha": "8897121344736f522b5fedf1b58fa29cb9bcfff4",
      "subject": "feat(codex): add codex-subagent Claude-to-Codex delegation bridge",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 240650,
        "cache_creation_input_tokens": 240650,
        "cache_read_input_tokens": 1571415,
        "input_tokens": 26,
        "output_tokens": 8656,
        "total_context_tokens": 1820747,
        "turns": 13
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 1,
  "pr": {
    "base": "main",
    "head": "feat/codex-subagent-bridge",
    "number": 195
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 1,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 240650,
    "cache_creation_input_tokens": 240650,
    "cache_read_input_tokens": 1571415,
    "input_tokens": 26,
    "output_tokens": 8656,
    "total_context_tokens": 1820747,
    "turns": 13
  },
  "totals_by_model": [
    {
      "cache_creation_ephemeral_1h_input_tokens": 240650,
      "cache_creation_input_tokens": 240650,
      "cache_read_input_tokens": 1571415,
      "input_tokens": 26,
      "model": "claude-opus-4-8",
      "output_tokens": 8656,
      "total_context_tokens": 1820747,
      "turns": 13
    }
  ],
  "updated_at": "2026-07-22T08:12:05Z"
}
```

</details>
<!-- code-flow-usage-json:end -->
