### PR TITLE
feat(japanese-writing): auto-trigger harness + norms consolidation (ADR 0001-0003)

### DIFF
--- a/docs/adr/0001-japanese-writing-auto-trigger.md
+++ b/docs/adr/0001-japanese-writing-auto-trigger.md
@@ -1,0 +1,256 @@
+# 0001. Auto-triggering accumulated Japanese-writing quality at the moments that matter
+
+## Status
+
+Proposed — 2026-07-22
+
+## Context
+
+Over time this repo has accumulated a substantial body of Japanese-writing
+quality knowledge:
+
+- `dot_claude/rules/japanese-writing.md` — an **always-on** rule (loaded via the
+  global `CLAUDE.md`) that codifies AI-smell avoidance, particle discipline,
+  rhythm/burstiness guidance, and terminology consistency.
+- `dot_claude/skills/japanese-ai-writing-proofreader/` — a four-pass proofreading
+  skill (textlint → deterministic rhythm/statistics `lint.py` → AI-smell removal
+  → deep naturalness).
+- Generation skills (`technical-writing`, `article-writing`) that lean on the
+  proofreader as their finishing pass.
+
+The problem is **timing, not coverage**. The proofreader fires only on explicit
+request (「校正して」「自然な日本語にして」). During the moments where readable
+Japanese matters most — writing a PR description, producing documentation,
+replying to review comments — none of this machinery engages automatically. The
+user has to remember to ask.
+
+### Root cause: dilution of passive always-on guidance
+
+The tempting diagnosis — "no rule exists" — is wrong. `japanese-writing.md` is
+*already* always-on and still does not reliably change the output. An always-on
+rule competes with everything else in context; at the moment of writing a PR
+body, its salience is low and its rhythm/statistics checks (which need
+deterministic computation, not recall) are effectively never applied.
+
+The design consequence is strict: **the fix must not be "add another passive
+rule."** That would reproduce the failure. A fix has to be one of:
+
+1. **Just-in-time salience** — inject the relevant guidance *at the moment* the
+   agent is about to write, so it is unmissable (harness / pre-design).
+2. **Deterministic post-hoc check** — run `lint.py` on the produced text and
+   surface findings mechanically, independent of the agent's recall
+   (guardrail / post-verification).
+
+This maps directly onto the repo's own `harness-engineering.md` taxonomy
+(Harness = pre-design, Guardrail = post-verification) and its directive to
+"push checks toward guardrails whenever a deterministic tool can do the job."
+
+### Two axes of "natural Japanese": structure vs fingerprint
+
+Prior art (k16shikano's `cognitive-rhythm-writing` method and laiso's commentary
+"なぜAI臭さを消したいのか") sharpens what "readable Japanese" actually means. There
+are two independent axes, and they demand different mechanisms:
+
+- **Structural / cognitive readability** — does the prose alternate the reader's
+  cognitive mode (observation → deliberation → certainty → re-examination) and
+  hold unresolved tension? The method's core diagnostic is
+  **状況を更新する文 (updates the situation)** vs **文書を更新する文 (updates only
+  the document — "dead prose": progress announcements, self-description,
+  unsubstantiated disclaimers)**, plus a short-long-short sentence rhythm, dense→
+  sparse alternation, and no self-reference to rhetorical devices. This property
+  lives **only at generation time** and **cannot be verified by a lint** — it
+  needs the writer to hold the principle while writing.
+- **Surface fingerprint** — favored vocabulary, em-dashes, uniform sentence
+  length (the "unslop" axis). This **is** detectable post-hoc; it is exactly what
+  `lint.py`'s rhythm/statistics pass and textlint catch.
+
+The accumulated assets split cleanly along this line: `japanese-writing.md`'s
+rhythm rules + `lint.py` ≈ the fingerprint axis; `cognitive-rhythm-writing` ≈ the
+structural axis. The two axes align with the two mechanisms — structural →
+harness/injection (generation-time salience), fingerprint → guardrail/lint
+(post-hoc detection).
+
+**Non-goal (from laiso's caution):** the objective is genuine reader
+comprehension, not removing evidence of AI authorship to satisfy colleagues.
+Reducing "readability" to "AI-fingerprint removal" would pass the lint while
+missing the goal. The design therefore treats the **structural (harness) layer as
+primary** and the fingerprint (lint) layer as a secondary safety net — never lets
+the mechanical lint become the definition of good Japanese.
+
+### An existing, proven pattern to build on
+
+The repo already ships the exact mechanism needed for option 1:
+`dot_claude/hooks/executable_gh-pr-inject.sh` is a `PreToolUse(Bash)` hook that
+injects `gh-pr-body.md` as `additionalContext` whenever it detects
+`gh pr create|edit`. This is JIT salience for PR formatting, already wired into
+`settings.json.tmpl`. The Japanese-quality assets are not connected to it.
+
+Every hook in this repo also ships a `tests/hooks/*.test.sh`
+(`block-destructive-db`, `block-rot-comments`, `browser-inject`, …); any new or
+extended hook inherits that contract.
+
+### Scope and enforcement decisions (settled with the user)
+
+- **Target moments for v1: documentation (`.md` Write/Edit) and PR descriptions
+  (`gh pr create|edit`).** Review responses are **deferred** — they are short,
+  and `lint.py`'s rhythm/burstiness statistics are noise on one or two
+  sentences. They may return in a later revision as nudge-only.
+- **Enforcement is staged, starting non-blocking.** `lint.py` was *deliberately*
+  authored as `exit 0` ("これは CI ゲートではなく lint"). A blocking gate
+  contradicts that decision, so we do not start there. We begin non-blocking and
+  promote a moment to a gate only after its false-positive rate is shown to be
+  acceptable.
+
+## Decision
+
+Adopt a **hybrid, layered design** that assigns each moment the mechanism it fits,
+rolled out in three independently-shippable stages. Enforcement strength rises
+per stage; each stage is gated on evidence from the previous one.
+
+### Moment × mechanism
+
+| Moment | Mechanism | Why |
+|---|---|---|
+| PR description | JIT injection nudge (extend `gh-pr-inject.sh`) | Body is inline `--body` vs `--body-file`; a deterministic lint needs extraction, but `additionalContext` injection is trivial and already proven here. `gh pr create` is Bash, so a guardrail must be `PreToolUse` (post-execution the PR already exists). |
+| Documentation (`.md`) | Deterministic `lint.py` guardrail | The file target reliably exists, so `lint.py` runs directly. Strongest guardrail candidate — the "deterministic tool can do the job" case. |
+| Review responses | *(deferred)* | Text too short for rhythm statistics; nudge-only or out of scope for v1. |
+
+The table shows each moment's *post-hoc* (guardrail-layer) mechanism. The Stage 0
+*structural* injection applies to **both** the PR and doc moments — it is the
+generation-time layer that sits ahead of whatever guardrail (if any) follows.
+
+### Staged rollout
+
+**Stage 0 (v1) — JIT injection nudges. Zero added latency, non-blocking.**
+Attack the dilution root cause directly with salience at the moment of writing.
+The injected content carries the **structural** layer (which no later lint can
+verify): a compact pointer to the canonical norms reference (see Assets below and
+ADR 0002) — the situation-vs-document test, hold-tension, dense→sparse
+alternation, no device self-reference — plus a reminder to finish with
+`japanese-ai-writing-proofreader` (fix mode) for the fingerprint layer.
+
+- **PR:** extend `executable_gh-pr-inject.sh` so its injected `additionalContext`,
+  when the body is Japanese, also carries the structural pointer + proofreader
+  reminder.
+- **Docs:** add a `PreToolUse(Write|Edit)` hook that, when `file_path` ends in
+  `.md` and the content contains Japanese, injects the same reminder as
+  `additionalContext`. Guard hard (extension + Japanese-character check) so it
+  stays silent on code and English files. Optional per-session dedup via a
+  marker file if repetition proves annoying.
+
+Stage 0 alone reuses the proven `gh-pr-inject` pattern, adds no `sudachi`
+startup cost, and directly counters "passive guidance loses salience."
+
+### Assets: the structural layer's home — see ADR 0002
+
+The structural layer needs a durable home that Stage 0 can point at. The original
+draft of this ADR made it a standalone `cognitive-rhythm-writing` skill;
+**[ADR 0002](0002-writing-skill-knowledge-consolidation.md) supersedes that**:
+the structural principles fold into a single canonical norms reference
+(`dot_claude/references/japanese-writing/`) shared by generation, verification,
+and this injection layer, rather than becoming a fourth writing skill.
+
+- The `cognitive-rhythm` method is **distilled** in this repo's house style,
+  **credited to k16shikano's source gist** — it is *not* vendored byte-for-byte.
+  The gist carries no explicit license (GitHub gists default to
+  all-rights-reserved), so unlike the MIT `natural-japanese` vendor precedent
+  (`.../scripts/NOTICE.md`), verbatim copying is not permitted. The method's
+  *ideas* are not copyrightable; our own expression of them, with attribution, is.
+- The reference is loaded **just-in-time**, never folded into the always-on
+  `japanese-writing.md` rule — folding it there would return it to the diluted
+  always-on channel this ADR exists to escape.
+
+Stage 0's injection therefore points at that norms reference plus the proofreader
+reminder. See ADR 0002 for the full topology.
+
+**Stage 1 — deterministic `lint.py` guardrail. Still non-blocking; adds mechanical
+verification.**
+
+- **Docs:** run `lint.py` on touched Japanese `.md` files and surface findings.
+  To avoid paying `sudachi`'s ~1–2 s dictionary load on every intermediate edit,
+  the **target architecture is a debounced batch**: a lightweight
+  `PostToolUse(Write|Edit)` step records touched Japanese `.md` paths into a
+  per-session queue, and a `Stop` hook drains the queue once per turn, running
+  `lint.py` a single time over the unique set. (A simpler direct-`PostToolUse`
+  lint is the fallback if the queue mechanism proves heavier than the latency it
+  saves.)
+- **PR:** optionally add a `PreToolUse(Bash)` step that extracts `--body` /
+  `--body-file`, runs `lint.py`, and injects findings as `additionalContext`
+  (still the agent's call — non-blocking).
+
+**Stage 2 — promote proven moments to a blocking gate.** Only for a moment whose
+false-positive rate is acceptable in practice:
+
+- **Docs:** a `Stop` hook that refuses to end the turn while a touched Japanese
+  `.md` still carries un-addressed high-confidence findings.
+- **PR:** a `PreToolUse(Bash)` deny on `gh pr create` when the Japanese body has
+  un-addressed high-confidence findings.
+
+The ADR records that Stage 2 is conditional; it is not scheduled by default.
+
+### Gate-promotion criteria (Stage 1 → Stage 2)
+
+Promote a moment from non-blocking to blocking only when all hold:
+
+1. The nudge/lint has run on ≥ ~10 real deliverables at that moment.
+2. Observed false-positive rate (findings the user would override) is low enough
+   that blocking would not routinely obstruct correct output.
+3. The `lint.py` categories used for the gate are restricted to high-confidence
+   ones (e.g. mechanical textlint / clear rhythm outliers), not subjective
+   naturalness.
+
+Until then the moment stays non-blocking.
+
+## Consequences
+
+### Positive
+
+- Directly addresses the measured failure (dilution) with JIT salience rather
+  than another passive rule.
+- Reuses an existing, tested pattern (`gh-pr-inject`) for the PR moment — small,
+  low-risk change.
+- Deterministic verification (`lint.py`) is layered in where it is strongest
+  (docs with a real file target) and kept out where it is noise (short review
+  replies).
+- Separating the structural axis (harness) from the fingerprint axis (lint)
+  keeps the design honest about the goal: readability the lint cannot see is
+  served by generation-time salience, not faked by passing statistics.
+- Each stage ships independently and reversibly; enforcement escalates only on
+  evidence, honoring `lint.py`'s original non-gate intent and the user's
+  "段階導入" choice.
+
+### Negative / costs
+
+- Two mechanisms to maintain (injection hooks + lint guardrail) instead of one.
+- Stage 1's `sudachi` dictionary load adds latency; the debounced `Stop`-batch
+  design is the mitigation but is more moving parts than a direct per-edit lint.
+- Injection nudges can themselves lose salience if over-fired; the
+  Japanese-character + `.md` guards and optional per-session dedup keep them rare.
+- `PreToolUse(Write|Edit)` widens the set of tool calls that run a hook; the guard
+  must fail closed to silence (never block, never error) on non-Japanese files.
+- The `cognitive-rhythm-writing` skill is a distillation, not a verbatim vendor
+  (source gist is unlicensed), so it can drift from upstream; attribution plus a
+  note to re-check the source on major upstream changes is the mitigation.
+
+### Done criteria (verifiable)
+
+- **Stage 0:**
+  - The canonical norms reference exists (per ADR 0002) and carries the
+    cognitive-rhythm structural principles, credited to the source gist.
+  - `gh pr create`/`gh pr edit` with a Japanese body injects a reminder pointing at
+    the norms reference + the proofreader; English bodies do not.
+  - A `.md` Write/Edit with Japanese content injects the reminder; a `.py`/`.ts`
+    edit or an English `.md` injects nothing.
+  - `tests/hooks/*.test.sh` covers both fire and no-fire paths for the new/extended
+    hook, and `just test` passes.
+- **Stage 1:** touched Japanese `.md` produces `lint.py` findings once per turn
+  (not once per edit); running order and non-blocking behavior verified by a
+  hook test.
+- **Stage 2 (if pursued):** blocking path denies on high-confidence findings and
+  allows once addressed; verified by a hook test.
+
+### Follow-ups / out of scope
+
+- Review-response coverage (nudge-only) — revisit after Stage 0/1 land.
+- Wiring `settings.json.tmpl` entries for the new hooks (implementation detail for
+  the plan, not this decision).

--- a/docs/adr/0002-writing-skill-knowledge-consolidation.md
+++ b/docs/adr/0002-writing-skill-knowledge-consolidation.md
@@ -1,0 +1,137 @@
+# 0002. Consolidate Japanese writing-skill knowledge into one canonical reference
+
+## Status
+
+Proposed — 2026-07-22. Revises the "Assets" decision in
+[ADR 0001](0001-japanese-writing-auto-trigger.md).
+
+## Context
+
+ADR 0001 proposed adding `cognitive-rhythm-writing` as a standalone skill. In
+review the user raised a topology concern: adding a fourth writing skill
+increases management overhead and wastes context, because the writing-skill
+family already **duplicates the same norms across four homes**.
+
+Decomposing each member into *knowledge* vs *process* makes the real overlap
+visible:
+
+| Layer | technical-writing | article-writing | proofreader | japanese-writing.md (always-on) |
+|---|---|---|---|---|
+| **Shared knowledge** (conclusion-first, register discipline, sourcing/faithfulness, sentence rhythm, AI-smell taxonomy) | ○ | ○ | ○ (passes) | ○ |
+| Process (distinct) | single-pass generation, notation tables, procedure shaping | 7-phase workflow, checkpoints, fact-check gate, style profiles | textlint/`lint.py` tooling, report/fix modes, voice preservation, 4 passes | — |
+| Kind | generation | generation (heavy) | **verification** | norms |
+
+Two facts fall out:
+
+1. **Only the knowledge is duplicated.** Conclusion-first, sourcing discipline,
+   rhythm, and the AI-smell taxonomy are restated four times. That fourfold copy
+   — not the count of always-loaded skill descriptions — is the substance of
+   "management is getting complex." Adding `cognitive-rhythm` as a fifth home
+   would worsen it.
+2. **The processes are genuinely distinct, and one boundary is hard.**
+   `technical-writing` (single-pass repo docs) and `article-writing` (gated,
+   public, multi-phase) are different workflows, not one persona switch.
+   Generation ↔ verification is a hard line: folding the proofreader into a
+   generator would make the same invocation grade its own output, violating
+   generator-evaluator separation (`harness-engineering.md`).
+
+**Precedent for the fix:** `dot_claude/references/model-profiles/` already
+deploys to `~/.claude/references/` and is loaded just-in-time by skills. It is an
+established home for shared references that are neither always-on rules nor
+invocable skills.
+
+## Decision
+
+Adopt **Option 2 — dedup the knowledge, keep the process wrappers separate.**
+The principle: *consolidate what is duplicated (norms); keep separate what is
+genuinely different (process, and the generation/verification boundary); have the
+wrappers reference the shared norms rather than restate them.*
+
+### Canonical norms reference
+
+Create `dot_claude/references/japanese-writing/` (deploys to
+`~/.claude/references/japanese-writing/`) as the single source of truth for
+readable-Japanese norms:
+
+- conclusion-first structure, register discipline (one register per document),
+  sourcing / faithfulness, sentence rhythm (length variety / burstiness),
+- **cognitive-rhythm structural principles** — 状況を更新する文 vs 文書を更新する文,
+  hold unresolved tension, dense→sparse alternation, no self-reference to devices,
+- the AI-smell taxonomy (mechanical lists, hype, over-emphasis, colon syntax, …).
+
+It is loaded **just-in-time**, never always-on. `cognitive-rhythm` folds into this
+reference and is **not** created as a standalone skill — this supersedes ADR
+0001's Assets decision.
+
+### Thin wrappers, unchanged boundaries
+
+The three existing skills stay separate and become thin, each pointing at the
+norms reference instead of restating it:
+
+- `technical-writing` keeps its domain tactics (notation tables, procedure
+  shaping, reader calibration) and references the norms.
+- `article-writing` keeps its phases, gates, and style profiles, and references
+  the norms.
+- `japanese-ai-writing-proofreader` keeps its tooling (`textlint` / `lint.py`),
+  modes, and voice preservation, and references the norms taxonomy for its
+  judgment passes. It **stays a separate skill / invocation** — the hard
+  generator-evaluator line is unchanged.
+
+`japanese-writing.md` (the always-on rule) shrinks to a **minimal floor plus a
+pointer** to the reference. This removes the fourth copy and reduces the
+always-on footprint that ADR 0001 identified as the dilution source.
+
+### Wiring back to ADR 0001
+
+ADR 0001's Stage 0 injection points at the norms reference (plus the proofreader
+reminder), not at a standalone `cognitive-rhythm` skill. Generation, verification,
+and injection then all read **one** source.
+
+Net: skill count stays at three (not four), norms live once, the hard boundary is
+preserved.
+
+### Naming — deferred entirely to ADR 0003
+
+The user also asked to unify skill naming. That is a global, breaking concern
+(invocation names, cross-references, memory, `CLAUDE.md`) and is handled in its
+own [ADR 0003](0003-skill-naming-convention.md). **This ADR renames nothing** —
+it keeps the current skill names (`technical-writing`, `article-writing`,
+`japanese-ai-writing-proofreader`) so the consolidation and any rename land as
+separate, independently-reviewable changes.
+
+## Consequences
+
+### Positive
+
+- One source of truth for the norms; no fourfold drift.
+- Slimmer always-on floor → less of the dilution ADR 0001 targets.
+- ADR 0001's asset simplified: no new skill, one fewer thing to trigger.
+- Hard generation/verification boundary intact.
+
+### Negative / costs
+
+- One-time migration touching three skills, one rule, and one new reference; every
+  cross-reference (the two generators' "invoke proofreader" pointers, ADR 0001,
+  memory, `CLAUDE.md`) must be repointed in the same change.
+- **Over-stripping risk:** a wrapper reduced to a bare pointer loses its useful
+  domain examples. Move only the shared *principle*; keep each skill's
+  domain-specific *application* and examples.
+- The reference must resolve at `~/.claude/references/japanese-writing/` at
+  runtime; verify chezmoi deploys it (`references/` is not in `.chezmoiignore`).
+
+### Done criteria (verifiable)
+
+- `dot_claude/references/japanese-writing/` exists, deploys, and contains the
+  merged norms including the cognitive-rhythm principles.
+- The three wrappers no longer restate the shared norms; each links the reference.
+  A grep for a duplicated norm phrase resolves to a single home.
+- `japanese-writing.md` is the minimal floor plus pointer.
+- ADR 0001's Assets section references this ADR (no standalone cognitive-rhythm
+  skill).
+- No skill is renamed by this ADR; naming is ADR 0003's concern.
+- `just test` passes.
+
+### Follow-ups / out of scope
+
+- Skill-naming convention and any rename — [ADR 0003](0003-skill-naming-convention.md).
+- Review-response coverage (carried over from ADR 0001).

--- a/docs/adr/0003-skill-naming-convention.md
+++ b/docs/adr/0003-skill-naming-convention.md
@@ -1,0 +1,109 @@
+# 0003. Skill naming convention
+
+## Status
+
+Proposed — 2026-07-22.
+
+## Context
+
+The user asked whether skill names can be unified. Skills are invoked by name and
+their `name` + `description` load into every session's skill list, so a name is
+both an API surface and always-on context. Renaming one is a **hard, breaking
+cutover** — Claude Code skills have no alias/redirect, so every invocation habit,
+cross-skill pointer, memory entry, and `CLAUDE.md` mention must move at once.
+
+Surveying the current `dot_claude/skills/` set (20 skills) against a
+`<subject>-<role/action>` reading shows the heterogeneity is **narrower than it
+looks**:
+
+- **Already subject-first and fine** (majority): `browser-e2e-test`,
+  `claude-md-layout`, `codex-subagent`, `learning-primer`, `loop-design`,
+  `pentest-parallel-prs`, `pr-monitor`, `trend-arbitrage`, `ui-design-standards`,
+  `x-post-craft`, `zero-cost-scaling`, `ios-submission-review`.
+- **Families that don't cluster** — members share a *suffix*, which sorts them
+  apart in an alphabetical list instead of grouping them:
+  - writing: `article-writing`, `technical-writing` (+ the verbose outlier
+    `japanese-ai-writing-proofreader`).
+  - decision: `equity-decision`, `ipo-decision`.
+- **Vague single words**: `feature`, `interrupt` — no subject/role, meaning not
+  guessable from the name.
+- **Method-qualifier-first**: `empirical-prompt-tuning` (adjective leads the
+  subject).
+
+So most names already follow an implicit convention; the real defects are family
+clustering and a few outliers — not a case for a 20-skill big-bang rename.
+
+## Decision
+
+**Convention (proposed):**
+
+- kebab-case, **subject-first**: `<subject>-<role|action>`. The subject a reader
+  would search for leads; the role/action follows.
+- A **family of ≥2 skills sharing a subject uses a shared leading stem** so the
+  family clusters in the sorted skill list: `writing-*`, `decision-*`.
+- Keep one consistent action form within a family (bare stem or gerund, not both).
+- Names stay guessable: avoid bare single words that don't say what the skill
+  does.
+
+**Migration strategy — recommend lazy, with a big-bang alternative.** Two paths:
+
+- **Lazy (recommended):** apply the convention to all *new* skills now, and rename
+  an existing skill only when it is next substantively touched, sweeping every
+  cross-reference (pointers, memory, `CLAUDE.md`) in the same change. Spreads the
+  breaking cost over normal edits; never renames a skill nobody is touching.
+- **Big-bang (alternative):** one PR renames the whole map at once — maximum
+  consistency immediately, maximum breakage surface and review risk in a single
+  change. Choose this only if the half-migrated state (two forms coexisting) is
+  itself unacceptable.
+
+Either way, this ADR **keeps naming independent of ADR 0002** — 0002 deliberately
+renames nothing, so the consolidation and the rename stay separately reviewable.
+
+**Concrete rename map:**
+
+| Current | Proposed | Notes |
+|---|---|---|
+| `technical-writing` | `writing-technical` | family clustering |
+| `article-writing` | `writing-article` | family clustering |
+| `japanese-ai-writing-proofreader` | `writing-proofreader` | Japanese-ness now lives in the norms reference (ADR 0002), so it drops from the name |
+| `equity-decision` | `decision-equity` | family clustering |
+| `ipo-decision` | `decision-ipo` | family clustering |
+| `feature` | `feature-workflow` (or leave) | optional; low value |
+| `interrupt` | leave | single-purpose utility; renaming buys little |
+| `empirical-prompt-tuning` | `prompt-tuning` (method as description, not name) | optional |
+
+Under lazy migration the writing family is the natural first cohort — but as its
+own follow-up *after* ADR 0002 lands, not bundled into it. Everything not in the
+table keeps its current name; it already conforms.
+
+## Consequences
+
+### Positive
+
+- The convention codifies what most skills already do, so adoption is cheap and
+  the rule reads as descriptive, not disruptive.
+- Families cluster in the skill list, making the repo's skill map scannable.
+- Lazy migration spreads the breaking cost over normal edits instead of one risky
+  cutover, and never renames a skill nobody is touching.
+
+### Negative / costs
+
+- Two naming forms coexist during migration (old names until each skill is next
+  touched); the convention doc must note this is expected, not drift.
+- Each rename is a hard cutover with no alias — a missed cross-reference silently
+  breaks invocation. A rename checklist (sweep pointers + memory + `CLAUDE.md` +
+  `just test`) is mandatory per rename.
+- Some renames (`feature`, `empirical-prompt-tuning`) are marginal; the ADR marks
+  them optional rather than forcing churn for symmetry's sake.
+
+### Done criteria
+
+- The convention is recorded (a short `dot_claude/rules/` note or a section the
+  skills reference) so new skills follow it without re-deriving.
+- The rename map is the agreed target; each row executes only when its trigger
+  fires, with cross-references swept and `just test` green.
+
+### Follow-ups / out of scope
+
+- Executing any rename — a separate change per the chosen migration strategy,
+  after ADR 0002 lands.

--- a/docs/superpowers/plans/2026-07-22-japanese-writing-quality-harness.md
+++ b/docs/superpowers/plans/2026-07-22-japanese-writing-quality-harness.md
@@ -1,0 +1,216 @@
+# Japanese Writing Quality Harness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the repo's accumulated natural-Japanese quality fire at PR/doc moments, from one deduplicated knowledge source, per ADRs 0001–0003.
+
+**Architecture:** Three dependency-ordered PRs. PR-A (ADR 0002) dedups the writing norms into one JIT reference and thins the wrappers. PR-B (ADR 0001 Stage 0) adds JIT injection hooks that point at that reference at the doc/PR moments. PR-C (ADR 0003) codifies the naming convention and renames the writing family. Stage 1/2 of ADR 0001 (deterministic lint guardrail, blocking gate) are out of scope — future work per the ADR.
+
+**Tech Stack:** chezmoi templates, Claude Code hooks (bash + `jq`), markdown skills/rules/references, `bats`-less shell tests (`tests/hooks/*.test.sh` run via `just test`).
+
+## Global Constraints
+
+- Rules / skills / references are written in **English**; Japanese only where a reader-facing template or user-typed trigger phrase requires it (repo `CLAUDE.md`).
+- The norms reference **distills** k16shikano's cognitive-rhythm method in house style, **credited** to the source gist — never vendored byte-for-byte (unlicensed gist).
+- Every repo-only file needs a `.chezmoiignore` entry or it deploys to `$HOME`. `dot_claude/references/` **is** meant to deploy (skills read it at `~/.claude/references/`); `docs/` and `tests/` are already ignored.
+- Every new/extended hook ships a `tests/hooks/*.test.sh`; `just test` must pass.
+- Each phase is one PR: effective logic ≤ 300 LOC, one purpose. Commit granularity: 1 logical change per commit.
+- Commits are signed. Headless signing uses the on-disk key override: `git -c gpg.ssh.program=ssh-keygen -c user.signingkey="$HOME/.ssh/id_ed25519.pub" commit …` (never `--no-gpg-sign`).
+- No skill is renamed before PR-C.
+
+---
+
+## PR-A — ADR 0002: knowledge consolidation
+
+Foundational: creates the norms reference PR-B depends on. Content-authoring (markdown, no test framework — TDD exception for declarative/docs content); verification is grep-dedup + `just test`.
+
+### Task A1: Create the canonical norms reference
+
+**Files:**
+- Create: `dot_claude/references/japanese-writing/norms.md`
+
+**Interfaces:**
+- Produces: the file `~/.claude/references/japanese-writing/norms.md` (post-deploy path) that wrappers and the PR-B hooks point at by that path.
+
+- [ ] **Step 1: Author `norms.md`** with these sections, distilled in house style from the cited sources (do not restate verbatim — synthesize):
+  - **Structure** — conclusion-first (source: `technical-writing` "Structure: conclusion first"); one register per document (source: `technical-writing` "Sentence style").
+  - **Sourcing / faithfulness** — trace load-bearing claims to source; state inference as inference (source: `technical-writing` "Faithfulness and sourcing").
+  - **Rhythm (fingerprint axis)** — sentence-length variety / burstiness, paragraph non-uniformity, avoid ≥3× antithesis (source: `rules/japanese-writing.md` §6).
+  - **Cognitive rhythm (structural axis)** — 状況を更新する文 vs 文書を更新する文（dead prose）, hold unresolved tension, dense→sparse alternation, no self-reference to devices. Credit line: "Distilled from k16shikano's cognitive-rhythm-writing method (gist eb2929f…), in house style."
+  - **AI-smell taxonomy** — mechanical list templates, hype vocabulary, over-emphasis, English-colon syntax, particle omission (source: `rules/japanese-writing.md` §1–5).
+  Keep it a reference (principles + short before/after), not a workflow.
+- [ ] **Step 2: Verify it deploys.** Run:
+  ```bash
+  grep -n "references" .chezmoiignore || echo "references not ignored → deploys (OK)"
+  ```
+  Expected: prints "references not ignored → deploys (OK)".
+- [ ] **Step 3: Commit**
+  ```bash
+  git add dot_claude/references/japanese-writing/norms.md
+  git -c gpg.ssh.program=ssh-keygen -c user.signingkey="$HOME/.ssh/id_ed25519.pub" \
+    commit -m "docs(japanese-writing): add canonical norms reference"
+  ```
+
+### Task A2: Thin the always-on rule to a floor + pointer
+
+**Files:**
+- Modify: `dot_claude/rules/japanese-writing.md`
+
+- [ ] **Step 1: Trim** the deep rhythm/AI-smell detail that now lives in `norms.md`, leaving a minimal always-on floor: the non-negotiables (avoid AI-smell; particle discipline; active voice) plus a one-line pointer: "Full norms: `~/.claude/references/japanese-writing/norms.md` (loaded JIT by writing skills / injection hooks)." Target: roughly halve the file.
+- [ ] **Step 2: Verify no duplicated norm survives in two homes.** Run:
+  ```bash
+  grep -c "体言止め\|バースト\|状況を更新" dot_claude/rules/japanese-writing.md
+  ```
+  Expected: `0` (deep rhythm terms now only in `norms.md`).
+- [ ] **Step 3: Commit**
+  ```bash
+  git add dot_claude/rules/japanese-writing.md
+  git -c gpg.ssh.program=ssh-keygen -c user.signingkey="$HOME/.ssh/id_ed25519.pub" \
+    commit -m "docs(rules): shrink japanese-writing to always-on floor + norms pointer"
+  ```
+
+### Task A3: Point the three wrappers at the norms reference
+
+**Files:**
+- Modify: `dot_claude/skills/technical-writing/SKILL.md`
+- Modify: `dot_claude/skills/article-writing/SKILL.md`
+- Modify: `dot_claude/skills/japanese-ai-writing-proofreader/SKILL.md`
+
+**Interfaces:**
+- Consumes: `~/.claude/references/japanese-writing/norms.md` (Task A1).
+
+- [ ] **Step 1: technical-writing** — replace restated norm prose (register, sourcing principle, rhythm) with "Apply the shared norms: `~/.claude/references/japanese-writing/norms.md`." Keep domain-specific tactics (notation tables, procedure shaping, reader-calibration, the before/after examples).
+- [ ] **Step 2: article-writing** — in Phase 4/6, point rhythm/style rules at the norms reference; keep phases, gates, style profiles.
+- [ ] **Step 3: proofreader** — its AI-smell / naturalness passes reference the norms taxonomy instead of restating; keep tooling (`textlint` / `lint.py`), modes, voice-preservation. Leave it a separate skill (generator-evaluator).
+- [ ] **Step 4: Verify each wrapper links the reference and none restates the moved norms.** Run:
+  ```bash
+  for f in technical-writing article-writing japanese-ai-writing-proofreader; do
+    grep -q "references/japanese-writing/norms.md" "dot_claude/skills/$f/SKILL.md" \
+      && echo "$f: linked" || echo "$f: MISSING LINK"
+  done
+  ```
+  Expected: all three print "linked".
+- [ ] **Step 5: Run full checks.** Run: `just test` — Expected: pass.
+- [ ] **Step 6: Commit**
+  ```bash
+  git add dot_claude/skills/technical-writing/SKILL.md dot_claude/skills/article-writing/SKILL.md dot_claude/skills/japanese-ai-writing-proofreader/SKILL.md
+  git -c gpg.ssh.program=ssh-keygen -c user.signingkey="$HOME/.ssh/id_ed25519.pub" \
+    commit -m "refactor(skills): point writing wrappers at shared norms reference"
+  ```
+
+---
+
+## PR-B — ADR 0001 Stage 0: JIT injection at doc/PR moments
+
+Depends on PR-A (injects a pointer to `norms.md`). Non-blocking, zero-latency. Hooks need tests.
+
+### Task B1: Extend the PR hook to carry the Japanese-writing pointer
+
+**Files:**
+- Modify: `dot_claude/hooks/executable_gh-pr-inject.sh`
+- Test: `tests/hooks/gh-pr-inject.test.sh` (create if absent)
+
+**Interfaces:**
+- Consumes: existing `gh pr create|edit` detection in the hook.
+
+- [ ] **Step 1: Write the failing test** — assert that for a `gh pr create` command whose `--body` contains Japanese, the emitted `additionalContext` includes `references/japanese-writing/norms.md` and a proofreader reminder; and that an English-only body does NOT add the Japanese pointer.
+  ```bash
+  # tests/hooks/gh-pr-inject.test.sh — add cases:
+  out=$(printf '{"tool_input":{"command":"gh pr create --body \"日本語の本文です\""}}' \
+    | "$HOOK")
+  echo "$out" | grep -q "references/japanese-writing/norms.md" || fail "no jp pointer on JP body"
+  out=$(printf '{"tool_input":{"command":"gh pr create --body \"english only\""}}' \
+    | "$HOOK")
+  echo "$out" | grep -q "references/japanese-writing/norms.md" && fail "jp pointer leaked on EN body"
+  ```
+- [ ] **Step 2: Run it, verify it fails.** Run: `bash tests/hooks/gh-pr-inject.test.sh` — Expected: FAIL (pointer not yet added).
+- [ ] **Step 3: Implement** — after the existing rule injection, when the command body contains a Japanese codepoint (grep `[぀-ゟ゠-ヿ一-鿿]`), append to `additionalContext` a compact block pointing at `~/.claude/references/japanese-writing/norms.md` and "finish with the japanese-ai-writing-proofreader skill (fix mode) before creating."
+- [ ] **Step 4: Run tests, verify pass.** Run: `bash tests/hooks/gh-pr-inject.test.sh` — Expected: PASS.
+- [ ] **Step 5: Commit**
+  ```bash
+  git add dot_claude/hooks/executable_gh-pr-inject.sh tests/hooks/gh-pr-inject.test.sh
+  git -c gpg.ssh.program=ssh-keygen -c user.signingkey="$HOME/.ssh/id_ed25519.pub" \
+    commit -m "feat(hooks): inject japanese-writing norms pointer on Japanese PR bodies"
+  ```
+
+### Task B2: New doc-injection hook for Japanese `.md` writes
+
+**Files:**
+- Create: `dot_claude/hooks/executable_japanese-writing-inject.sh`
+- Create: `tests/hooks/japanese-writing-inject.test.sh`
+- Modify: `dot_claude/settings.json.tmpl` (wire PreToolUse Write|Edit)
+
+**Interfaces:**
+- Consumes: Claude Code hook JSON (`tool_input.file_path`, `tool_input.content` / `tool_input.new_string`).
+
+- [ ] **Step 1: Write the failing test** — a Write to `foo.md` with Japanese content emits `additionalContext` referencing `norms.md`; a Write to `foo.py` with Japanese, or to `foo.md` with English-only, emits nothing.
+  ```bash
+  out=$(printf '{"tool_name":"Write","tool_input":{"file_path":"doc.md","content":"日本語"}}' | "$HOOK")
+  echo "$out" | grep -q "norms.md" || fail "no inject on JP .md"
+  out=$(printf '{"tool_name":"Write","tool_input":{"file_path":"x.py","content":"日本語"}}' | "$HOOK")
+  [ -z "$out" ] || fail "injected on .py"
+  out=$(printf '{"tool_name":"Edit","tool_input":{"file_path":"d.md","new_string":"english"}}' | "$HOOK")
+  [ -z "$out" ] || fail "injected on EN .md"
+  ```
+- [ ] **Step 2: Run it, verify it fails.** Run: `bash tests/hooks/japanese-writing-inject.test.sh` — Expected: FAIL (hook absent).
+- [ ] **Step 3: Implement the hook** — guard: `file_path` ends `.md` AND content (`content` or `new_string`) contains a Japanese codepoint → emit `additionalContext` pointing at `norms.md` + proofreader reminder. Fail closed to silence (exit 0, no output) on any non-match or error.
+- [ ] **Step 4: Wire it** in `dot_claude/settings.json.tmpl` under `PreToolUse` matcher `Write|Edit` (alongside `block-rot-comments.py`).
+- [ ] **Step 5: Run tests, verify pass.** Run: `bash tests/hooks/japanese-writing-inject.test.sh` then `just test` — Expected: PASS.
+- [ ] **Step 6: Commit**
+  ```bash
+  git add dot_claude/hooks/executable_japanese-writing-inject.sh tests/hooks/japanese-writing-inject.test.sh dot_claude/settings.json.tmpl
+  git -c gpg.ssh.program=ssh-keygen -c user.signingkey="$HOME/.ssh/id_ed25519.pub" \
+    commit -m "feat(hooks): JIT japanese-writing norms injection on Japanese .md writes"
+  ```
+
+---
+
+## PR-C — ADR 0003: naming convention + writing-family rename
+
+Independent of PR-A/B in content; ordered last so it sweeps their cross-references in one pass.
+
+### Task C1: Record the naming convention
+
+**Files:**
+- Create: `dot_claude/rules/skill-naming.md` (or append to an existing conventions rule if one fits)
+
+- [ ] **Step 1: Write** the convention: kebab-case `<subject>-<role|action>`, subject-first; families of ≥2 share a leading stem; guessable names; migration = lazy (rename on next substantive touch) + convention-for-new. Include the rename map table from ADR 0003.
+- [ ] **Step 2: Ensure it does not deploy as an always-on global rule if that is unwanted** — confirm placement matches other `dot_claude/rules/` files (these deploy to `~/.claude/rules/`). Note in the file it is a convention doc, not an always-on behavioral rule.
+- [ ] **Step 3: Commit**
+  ```bash
+  git add dot_claude/rules/skill-naming.md
+  git -c gpg.ssh.program=ssh-keygen -c user.signingkey="$HOME/.ssh/id_ed25519.pub" \
+    commit -m "docs(rules): add skill naming convention"
+  ```
+
+### Task C2: Rename the writing family + sweep references
+
+**Files:**
+- Rename: `dot_claude/skills/technical-writing/` → `writing-technical/`
+- Rename: `dot_claude/skills/article-writing/` → `writing-article/`
+- Rename: `dot_claude/skills/japanese-ai-writing-proofreader/` → `writing-proofreader/`
+- Modify: each SKILL.md `name:` frontmatter; all cross-references (the two generators' proofreader pointers, `article-writing`↔`japanese-ai-writing-proofreader` mentions, ADRs 0001–0003, memory, `CLAUDE.md`, `tests/skills/**`).
+
+- [ ] **Step 1: Rename dirs and update `name:` frontmatter** for all three. `git mv` each; update the `name:` field to match the new directory.
+- [ ] **Step 2: Sweep every reference.** Run:
+  ```bash
+  grep -rln "technical-writing\|article-writing\|japanese-ai-writing-proofreader" \
+    --include="*.md" --include="*.tmpl" --include="*.sh" . | grep -v '/\.git/'
+  ```
+  Update each hit to the new name. Re-run until only intended historical mentions (e.g. ADR prose describing the old name) remain.
+- [ ] **Step 3: Verify the renamed skills still resolve** — `just test` (skill-script tests) passes; grep confirms no dangling old invocation names in live config/hooks.
+- [ ] **Step 4: Commit**
+  ```bash
+  git add -A
+  git -c gpg.ssh.program=ssh-keygen -c user.signingkey="$HOME/.ssh/id_ed25519.pub" \
+    commit -m "refactor(skills): rename writing family to writing-* per naming convention"
+  ```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** ADR 0002 → PR-A (A1 norms, A2 floor, A3 wrappers). ADR 0001 Stage 0 → PR-B (B1 PR hook, B2 doc hook); Stage 1/2 explicitly deferred. ADR 0003 → PR-C (C1 convention, C2 rename). Covered.
+- **Placeholder scan:** norms/rule/convention *content* is authored at execution from cited sources — that is a deliverable, not a placeholder; the plan fixes sections, sources, and verification for each.
+- **Type/name consistency:** hook file names (`executable_japanese-writing-inject.sh`), reference path (`~/.claude/references/japanese-writing/norms.md`), and new skill names (`writing-technical/-article/-proofreader`) are used consistently across tasks.
+- **Ordering:** PR-A before PR-B (B injects A's path); PR-C last (sweeps A/B refs). Signed-commit override applied in every commit step.

--- a/dot_claude/hooks/executable_gh-pr-inject.sh
+++ b/dot_claude/hooks/executable_gh-pr-inject.sh
@@ -19,11 +19,20 @@ fi
 
 body=$(cat "$rule")
 
-# perl -CSD decodes stdin/stdout as UTF-8 so \p{...} matches actual Hiragana/
-# Katakana/Han codepoints. -0777 slurps the whole command into one string so
-# multi-line bodies are scanned, not just the first line. BSD grep (macOS
-# default) has no -P/PCRE support, so this cannot be done with grep alone.
-if printf '%s' "$cmd" | perl -CSD -0777 -ne 'exit(/\p{Hiragana}|\p{Katakana}|\p{Han}/ ? 0 : 1)'; then
+# perl -CSD decodes stdin/stdout as UTF-8 so codepoint ranges match actual
+# Hiragana/Katakana/Han characters. -0777 slurps the whole command into one
+# string so multi-line bodies are scanned, not just the first line. BSD grep
+# (macOS default) has no -P/PCRE support, so this cannot be done with grep
+# alone. Density (kana/kanji share of non-space characters), not mere
+# presence, gates the fire: \p{Han} matches CJK punctuation like 。 via
+# script-extensions, so a naive presence check fires on English text that
+# only mentions Japanese punctuation as an example. Fire only when there are
+# at least 10 non-space characters and kana/kanji make up >= 15% of them.
+if printf '%s' "$cmd" | perl -CSD -0777 -ne '
+  my $jp  = () = /[\x{3041}-\x{3096}\x{30A1}-\x{30FA}\x{30FC}\x{4E00}-\x{9FFF}]/g;
+  my $tot = () = /\S/g;
+  exit( ($tot >= 10 && $jp / $tot >= 0.15) ? 0 : 1 );
+'; then
   body="$body
 
 Japanese writing norms: $norms

--- a/dot_claude/hooks/executable_gh-pr-inject.sh
+++ b/dot_claude/hooks/executable_gh-pr-inject.sh
@@ -20,9 +20,10 @@ fi
 body=$(cat "$rule")
 
 # perl -CSD decodes stdin/stdout as UTF-8 so \p{...} matches actual Hiragana/
-# Katakana/Han codepoints. BSD grep (macOS default) has no -P/PCRE support,
-# so this cannot be done with grep alone here.
-if printf '%s' "$cmd" | perl -CSD -ne 'exit(/\p{Hiragana}|\p{Katakana}|\p{Han}/ ? 0 : 1)'; then
+# Katakana/Han codepoints. -0777 slurps the whole command into one string so
+# multi-line bodies are scanned, not just the first line. BSD grep (macOS
+# default) has no -P/PCRE support, so this cannot be done with grep alone.
+if printf '%s' "$cmd" | perl -CSD -0777 -ne 'exit(/\p{Hiragana}|\p{Katakana}|\p{Han}/ ? 0 : 1)'; then
   body="$body
 
 Japanese writing norms: $norms

--- a/dot_claude/hooks/executable_gh-pr-inject.sh
+++ b/dot_claude/hooks/executable_gh-pr-inject.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 # PreToolUse(Bash) hook: inject ~/.claude/rules/gh-pr-body.md as
 # additionalContext when the command contains `gh pr create` or `gh pr edit`.
-# Reads Claude Code hook JSON from stdin; emits JSON on stdout.
+# Also appends a japanese-writing norms pointer when the command's PR body
+# contains Japanese text. Reads Claude Code hook JSON from stdin; emits JSON
+# on stdout.
 set -euo pipefail
 
 rule="$HOME/.claude/rules/gh-pr-body.md"
+norms="$HOME/.claude/references/japanese-writing/norms.md"
 
 cmd=$(jq -r '.tool_input.command // ""')
 
@@ -14,7 +17,20 @@ fi
 
 [[ -f $rule ]] || exit 0
 
-jq -n --rawfile body "$rule" '{
+body=$(cat "$rule")
+
+# perl -CSD decodes stdin/stdout as UTF-8 so \p{...} matches actual Hiragana/
+# Katakana/Han codepoints. BSD grep (macOS default) has no -P/PCRE support,
+# so this cannot be done with grep alone here.
+if printf '%s' "$cmd" | perl -CSD -ne 'exit(/\p{Hiragana}|\p{Katakana}|\p{Han}/ ? 0 : 1)'; then
+  body="$body
+
+Japanese writing norms: $norms
+Apply these norms (structure, rhythm, cognitive rhythm, AI-smell) to the Japanese prose.
+Before finalizing, run the japanese-ai-writing-proofreader skill in fix mode."
+fi
+
+jq -n --arg body "$body" '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",
     additionalContext: $body

--- a/dot_claude/hooks/executable_japanese-writing-inject.sh
+++ b/dot_claude/hooks/executable_japanese-writing-inject.sh
@@ -19,9 +19,10 @@ esac
 content=$(jq -r '.tool_input.content // .tool_input.new_string // ""' <<<"$input")
 
 # perl -CSD decodes stdin/stdout as UTF-8 so \p{...} matches actual Hiragana/
-# Katakana/Han codepoints. BSD grep (macOS default) has no -P/PCRE support,
-# so this cannot be done with grep alone here.
-if ! printf '%s' "$content" | perl -CSD -ne 'exit(/\p{Hiragana}|\p{Katakana}|\p{Han}/ ? 0 : 1)'; then
+# Katakana/Han codepoints. -0777 slurps the whole content into one string so
+# multi-line docs are scanned, not just the first line. BSD grep (macOS
+# default) has no -P/PCRE support, so this cannot be done with grep alone.
+if ! printf '%s' "$content" | perl -CSD -0777 -ne 'exit(/\p{Hiragana}|\p{Katakana}|\p{Han}/ ? 0 : 1)'; then
   exit 0
 fi
 

--- a/dot_claude/hooks/executable_japanese-writing-inject.sh
+++ b/dot_claude/hooks/executable_japanese-writing-inject.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PreToolUse(Write|Edit) hook: inject a japanese-writing norms pointer as
+# additionalContext when a .md file is being written/edited with Japanese
+# content. Reads Claude Code hook JSON from stdin; emits JSON on stdout.
+# Fails closed to silence on any non-match, missing field, or error.
+set -euo pipefail
+
+norms="$HOME/.claude/references/japanese-writing/norms.md"
+
+input=$(cat)
+
+file_path=$(jq -r '.tool_input.file_path // ""' <<<"$input")
+
+case $file_path in
+*.md) ;;
+*) exit 0 ;;
+esac
+
+content=$(jq -r '.tool_input.content // .tool_input.new_string // ""' <<<"$input")
+
+# perl -CSD decodes stdin/stdout as UTF-8 so \p{...} matches actual Hiragana/
+# Katakana/Han codepoints. BSD grep (macOS default) has no -P/PCRE support,
+# so this cannot be done with grep alone here.
+if ! printf '%s' "$content" | perl -CSD -ne 'exit(/\p{Hiragana}|\p{Katakana}|\p{Han}/ ? 0 : 1)'; then
+  exit 0
+fi
+
+body="Japanese writing norms: $norms
+Apply these norms (structure, rhythm, cognitive rhythm, AI-smell) to the Japanese prose.
+Before finalizing, run the japanese-ai-writing-proofreader skill in fix mode."
+
+jq -n --arg body "$body" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    additionalContext: $body
+  }
+}'

--- a/dot_claude/hooks/executable_japanese-writing-inject.sh
+++ b/dot_claude/hooks/executable_japanese-writing-inject.sh
@@ -18,11 +18,20 @@ esac
 
 content=$(jq -r '.tool_input.content // .tool_input.new_string // ""' <<<"$input")
 
-# perl -CSD decodes stdin/stdout as UTF-8 so \p{...} matches actual Hiragana/
-# Katakana/Han codepoints. -0777 slurps the whole content into one string so
-# multi-line docs are scanned, not just the first line. BSD grep (macOS
-# default) has no -P/PCRE support, so this cannot be done with grep alone.
-if ! printf '%s' "$content" | perl -CSD -0777 -ne 'exit(/\p{Hiragana}|\p{Katakana}|\p{Han}/ ? 0 : 1)'; then
+# perl -CSD decodes stdin/stdout as UTF-8 so codepoint ranges match actual
+# Hiragana/Katakana/Han characters. -0777 slurps the whole content into one
+# string so multi-line docs are scanned, not just the first line. BSD grep
+# (macOS default) has no -P/PCRE support, so this cannot be done with grep
+# alone. Density (kana/kanji share of non-space characters), not mere
+# presence, gates the fire: \p{Han} matches CJK punctuation like 。 via
+# script-extensions, so a naive presence check fires on English prose that
+# only mentions Japanese punctuation as an example. Fire only when there are
+# at least 10 non-space characters and kana/kanji make up >= 15% of them.
+if ! printf '%s' "$content" | perl -CSD -0777 -ne '
+  my $jp  = () = /[\x{3041}-\x{3096}\x{30A1}-\x{30FA}\x{30FC}\x{4E00}-\x{9FFF}]/g;
+  my $tot = () = /\S/g;
+  exit( ($tot >= 10 && $jp / $tot >= 0.15) ? 0 : 1 );
+'; then
   exit 0
 fi
 

--- a/dot_claude/references/japanese-writing/norms.md
+++ b/dot_claude/references/japanese-writing/norms.md
@@ -1,0 +1,91 @@
+# Japanese Writing Norms
+
+Canonical reference for natural, readable Japanese prose. Loaded just-in-time
+by the writing skills (`technical-writing`, `article-writing`,
+`japanese-ai-writing-proofreader`) and by injection hooks — never always-on.
+This file is the single source of truth for the norms below; skills apply
+them and cite this file rather than restating it.
+
+## Structure
+
+Open with the conclusion — the sentence the reader came for — then supply
+background only where it changes what the reader does next. One register per
+document (だ・である or です・ます; pick from the target repo/media's existing
+convention, not per-sentence).
+
+Before: 3 sentences of context before the procedure starts.
+After: the outcome first, procedure below it.
+
+## Sourcing / faithfulness
+
+Every load-bearing claim traces to a source: code, an official doc, or a
+measurement the writer ran. Verify what is verifiable before writing instead
+of hedging — `要確認` is for what is genuinely out of reach, not what is
+merely tedious. State a remaining inference as an inference（「〜と考えられる。
+要確認」), never as settled fact. Attach the source to the claim (`path:line`,
+a link, the command that produced a number) so a reader can re-check it
+without asking the writer.
+
+## Rhythm (fingerprint axis)
+
+Detectable post-hoc by a mechanical lint (sentence-length statistics,
+paragraph shape). Corpus-calibrated signal (137 human / 406 AI documents):
+rhythm, not vocabulary, is the strongest measured AI marker.
+
+- Vary sentence length on purpose; a short sentence among long ones reads as
+  human, uniform length reads as generated
+- Don't give every paragraph the same shape (e.g. exactly 3–4 sentences each)
+- Occasional 体言止め is a human marker (present in ~60% of human documents,
+  near-absent in AI ones) — use it sparingly in formal technical writing, more
+  freely in essays/blog prose
+- Don't repeat the 「〜ではなく…」 antithesis pattern three or more times in one
+  document; it reads as a template once it recurs
+
+## Cognitive rhythm (structural axis)
+
+A generation-time property, not a post-hoc lint target — no mechanical check
+can score it, so it has to be held in mind while writing.
+
+The core diagnostic: does this sentence update the reader's situation, or
+only the document? A sentence that adds a fact, a decision, or a consequence
+the reader didn't have moves their understanding forward. A sentence that
+announces progress, describes its own structure, or hedges without
+substance（「以下で詳しく見ていく」「〜という点に注意が必要である」で終わるだけの文）
+updates nothing but the page. When cutting for length, cut the second kind
+first.
+
+Beyond that diagnostic:
+
+- Hold a question or an answer back deliberately, so the next paragraph has
+  somewhere to go — resolving everything immediately flattens the reason to
+  keep reading
+- Alternate dense and sparse paragraphs rather than keeping every paragraph
+  at the same information density
+- Never name the device in the text itself. Writing "ここでは疑問を残したまま
+  次に進む" describes the technique instead of using it, and the description
+  is itself a document-updating sentence — the device only works while it
+  stays invisible
+
+Distilled from k16shikano's "cognitive-rhythm-writing" method (GitHub gist
+eb2929f13ed19c97188393d297be8432), restated in house style — not a verbatim
+copy.
+
+## AI-smell taxonomy
+
+Detectable post-hoc; the mechanical-lint safety net beneath the structural
+axis above. Reference: [textlint-rule-preset-ai-writing](https://github.com/textlint-ja/textlint-rule-preset-ai-writing).
+
+- **Mechanical list templates**: a fixed `**label**: description` pattern
+  forced onto every bullet, or emoji markers (✅❌💡🎯🚀) standing in for
+  structure → use prose where prose works; drop the boilerplate label
+- **Hype vocabulary**: 「革命的」「画期的」「世界初」「パラダイムシフト」「圧倒的」
+  「究極の」「最強の」「次世代」 → replace with a concrete number, fact, or
+  comparison
+- **Over-emphasis**: bolded adverbs（`**非常に**`、`**極めて**`）, an emoji on
+  every heading, repeated 「！」 → keep only the one emphasis that matters
+- **English-style colon syntax**: `:` placed right after a clause ending in a
+  verb/adjective（❌「実装した: 〜」）→ receive with a noun before the colon, or
+  break into a separate sentence（✅「実装した内容は次のとおり: 〜」）
+- **Particle omission and padding**: dropped 助詞（「ファイル作成」→「ファイルを
+  作成する」), passive where active reads plainer（「〜される」→「〜する」）,
+  and padding like 「〜することができる」→「〜できる」、「〜を行う」→ the verb itself

--- a/dot_claude/references/skill-naming.md
+++ b/dot_claude/references/skill-naming.md
@@ -1,0 +1,40 @@
+# Skill Naming Convention
+
+Loaded just-in-time when creating or renaming a skill — not an always-on rule
+(it would spend the always-on instruction budget for a rule that rarely
+applies; see `rules/harness-meta.md`).
+
+## Convention
+
+- kebab-case, **subject-first**: `<subject>-<role|action>`. The subject a
+  reader would search for leads; the role/action follows.
+- A **family of ≥2 skills sharing a subject uses a shared leading stem** so the
+  family clusters in the sorted skill list (`writing-*`, `decision-*`).
+- Keep one consistent action form within a family (bare stem or gerund, not
+  both).
+- Names stay guessable: avoid bare single words that don't say what the skill
+  does.
+
+## Migration
+
+Renames are breaking (Claude Code skills have no alias — every invocation, cross
+reference, and memory entry must move at once), so migrate lazily:
+
+- Apply the convention to **all new skills** immediately.
+- Rename an existing skill **only when it is next substantively touched**,
+  sweeping every reference (skills, rules, hooks, tests, memory) in that change.
+
+## Rename map (target names; execute per migration above)
+
+| Current | Target |
+|---|---|
+| `technical-writing` | `writing-technical` |
+| `article-writing` | `writing-article` |
+| `japanese-ai-writing-proofreader` | `writing-proofreader` |
+| `equity-decision` | `decision-equity` |
+| `ipo-decision` | `decision-ipo` |
+| `feature` | `feature-workflow` (optional) |
+| `empirical-prompt-tuning` | `prompt-tuning` (optional) |
+
+Skills not listed already conform; keep their names. Full rationale and the
+global survey: `docs/adr/0003-skill-naming-convention.md`.

--- a/dot_claude/rules/japanese-writing.md
+++ b/dot_claude/rules/japanese-writing.md
@@ -1,68 +1,22 @@
 # Japanese Writing
 
-When producing Japanese prose (responses, PR bodies, commit messages, docs), avoid the
-following "AI smell". The instructions below are in English; the target vocabulary and
-example sentences stay in Japanese because they are what the rule operates on.
-Reference: [textlint-rule-preset-ai-writing](https://github.com/textlint-ja/textlint-rule-preset-ai-writing)
+When producing Japanese prose (responses, PR bodies, commit messages, docs), avoid
+"AI smell" and keep the sentence structurally sound. The instructions below are in
+English; the target vocabulary stays in Japanese because it is what the rule operates on.
 
-## 1. Mechanical list formatting
-
-Avoid:
-
-- A fixed `**ラベル**: 説明` template applied to every item
-- Mechanical use of emoji markers (✅ ❌ 💡 🎯 🚀)
-- Forcing the same structure onto every bullet
-
-→ Use prose where prose works. If you must list, keep granularity and structure
-consistent but drop the boilerplate labels.
-
-## 2. Hype / exaggeration
-
-Avoid: 「革命的」「画期的」「世界初」「魔法のような」「パラダイムシフト」「劇的に向上」「圧倒的」「究極の」「最強の」「次世代」
-
-→ Replace with concrete numbers, facts, and comparisons.
-
-## 3. Excessive emphasis
-
-Avoid:
-
-- Bolding adverbs（`**非常に**`、`**極めて**`、`**かなり**`）
-- Leading every heading with an emoji
-- Repeated 「！」
-
-→ Emphasize only the single point that truly matters. If the meaning carries on its own,
-don't decorate it.
-
-## 4. English-style colon syntax
-
-Avoid placing `:` right after a clause that ends in a predicate (verb/adjective).
-例: ❌「これは便利です: 〜」「実装した: 〜」
-
-→ Receive with a noun before `:`, or break with a newline/period.
-例: ✅「便利な点は次のとおり: 〜」「〜を実装した。具体的には〜」
-
-## 5. Technical writing
+## Non-negotiables
 
 - Don't omit particles (助詞). Prefer 「ファイルを作成する」 over 「ファイル作成」,
   「設定を変更する」 over 「設定変更」. Particles fix meaning in Japanese; omitting them
   makes the dependency structure ambiguous.
 - Prefer active over passive voice（「〜される」→「〜する」）
-- Compress redundancy（「〜することができる」→「〜できる」、「〜を行う」→ verb form）
-- Consider splitting any sentence over 80 characters
-- No subject–predicate disagreement
-- Unify terminology within a document（「サーバ／サーバー」 etc.）
+- Avoid AI smell: mechanical list templates, hype vocabulary, over-emphasis, and
+  English-style colon syntax right after a predicate. Full taxonomy in the norms
+  reference below.
 
-## 6. Rhythm (measured)
-
-Rhythm, not vocabulary, is now the strongest measured AI signal (corpus: 137 human /
-406 AI docs — coji/natural-japanese).
-
-- Vary sentence length deliberately; place a short punch sentence among long ones.
-  Uniform sentence length is the top signal
-- Don't shape every paragraph identically (e.g. exactly 3-4 sentences each)
-- Occasional 体言止め is human (humans ~60% of docs, AI ~0%); use it occasionally in
-  essays/blogs, sparingly in formal tech docs
-- Don't repeat the 「〜ではなく…」 antithesis pattern (3+ times per document reads as AI)
+Full norms: `~/.claude/references/japanese-writing/norms.md` (loaded JIT by writing
+skills / injection hooks) — structure, sourcing, rhythm, cognitive rhythm, and the
+complete AI-smell taxonomy live there.
 
 ## Scope
 

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -192,6 +192,10 @@
           {
             "type": "command",
             "command": "python3 $HOME/.claude/hooks/block-rot-comments.py"
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/japanese-writing-inject.sh"
           }
         ]
       },

--- a/dot_claude/skills/article-writing/SKILL.md
+++ b/dot_claude/skills/article-writing/SKILL.md
@@ -69,7 +69,10 @@ Restructuring an outline is cheap; restructuring a draft is not.
 4. Constraints while drafting:
    - Every factual statement must trace to the 素材ノート
    - Concrete numbers over adjectives; bold ≈ one key claim per section
-   - Follow the style profile's rhythm rules (sentence-end variety, long-short contrast) — these matter more than its surface markers
+   - Apply the shared norms (`~/.claude/references/japanese-writing/norms.md`) for
+     rhythm and structure, then layer the style profile's rhythm rules
+     (sentence-end variety, long-short contrast) on top — the profile's markers
+     matter less than the norms underneath them
 
 ## Phase 5: ファクトチェック＋公開可否 — GATE
 
@@ -81,7 +84,8 @@ Present the claims table.
 ## Phase 6: 校正
 
 Invoke the `japanese-ai-writing-proofreader` skill on the draft in fix mode (the draft is Claude-written).
-It runs textlint, removes AI-smell, and checks deep naturalness.
+It runs textlint, removes AI-smell, and checks deep naturalness against the shared norms
+(`~/.claude/references/japanese-writing/norms.md`).
 Re-read the result against the style profile: proofreading must not have flattened the chosen voice.
 
 ## Phase 7: 完成レポート — CHECKPOINT

--- a/dot_claude/skills/japanese-ai-writing-proofreader/SKILL.md
+++ b/dot_claude/skills/japanese-ai-writing-proofreader/SKILL.md
@@ -88,24 +88,23 @@ Add `--genre essay|tech|business` when the genre is clear — it switches to cal
 
 ## Pass 3: AI-smell (the 5 categories)
 
-Aligned with `~/.claude/rules/japanese-writing.md`. Hunt each category explicitly:
-
-1. **機械的リスト**: `**ラベル**: 説明` templates, emoji markers (✅❌💡), identical structure forced onto every bullet → rewrite as prose or destructure the list
-2. **誇張**: 「革命的」「劇的に」「圧倒的」「究極の」 → replace with the concrete number or comparison, or delete
-3. **過剰な強調**: bolded adverbs, emoji-led headings, repeated 「！」 → keep at most the one emphasis that matters
-4. **英語式コロン**: 述語直後の「:」（「実装した: 〜」）→ receive with a noun or split the sentence
-5. **冗長・受動**: 「することができる」→「できる」、「〜を行う」→ verb form, passive → active, dropped particles restored（「設定変更」→「設定を変更する」）
+Full taxonomy: `~/.claude/references/japanese-writing/norms.md`. Hunt each category
+explicitly: mechanical list templates, hype vocabulary, over-emphasis, English-style
+colon syntax, and particle omission / padding (dropped 助詞, passive → active,
+「することができる」→「できる」等).
 
 This manual read is also where plain 誤字・誤用・文法ミス get caught — textlint misses many（「とゆう」等）.
 Report them under Pass 3 in the findings table.
 
 ## Pass 4: Deep naturalness (what surface rules miss)
 
-This is where text that passes Pass 1-3 still reads AI-written. The dimensions Pass 2 now catches mechanically (文長の均質, 段落の均質, 接続詞の機械的連結, 翻訳調) are dropped from this list — this pass covers only what remains judgment-dependent:
+This is where text that passes Pass 1-3 still reads AI-written. The dimensions Pass 2 now catches mechanically (文長の均質, 段落の均質, 接続詞の機械的連結, 翻訳調) are dropped from this list — this pass covers only what remains judgment-dependent. The structure and cognitive-rhythm principles behind these checks live in
+`~/.claude/references/japanese-writing/norms.md`; this pass is where a human read verifies the draft actually holds them:
 
 - **文末の単調**: same ending 3+ sentences in a row（です。です。です。）→ rotate でした／ません／た。／体言止め／問いかけ
 - **読点過多/過少**: 一文に読点4つ以上は分割を検討。読点ゼロの長文は補う
-- **情報の出し順**: conclusion buried at paragraph end, examples before the point they illustrate → lead with the load-bearing sentence
+- **情報の出し順**: conclusion buried at paragraph end, examples before the point they illustrate → lead with the load-bearing sentence (norms' Structure principle)
+- **状況を更新しない文**: progress announcements, self-description, or unsubstantiated hedges that add nothing the reader didn't already have → cut or replace with a claim that moves the reader's understanding forward (norms' Cognitive rhythm principle)
 - **未消化の専門用語・カタカナ英語**: English or loanword jargon a general reader stumbles on → replace with settled Japanese, or gloss on first use（ドロップ→配線・ケーブル、ネゴシエーション→つながる・リンクする、ラジオ→帯域、律速→ボトルネック・頭打ち、Traffic Rule→トラフィックルール）. Keep field-standard terms as-is（API・PoE・VLAN・SSID）. textlint cannot catch this — read for it manually
 - **初出の専門用語の導入**: don't start using a term in the body before its alias/definition appears — a VLAN labeled Default in a table, then called Trusted in prose with no bridge, reads as 唐突 → introduce on first use as「A（＝B、その役割）」
 

--- a/dot_claude/skills/technical-writing/SKILL.md
+++ b/dot_claude/skills/technical-writing/SKILL.md
@@ -76,7 +76,7 @@ Prefer the shortest sentence that keeps the meaning:
 | 削除を実行する必要があります | 削除してください |
 | 〜という点に留意する必要がある | 〜に注意 |
 
-- Pick one register per document and hold it（README・設計文書は だ・である、手順書・ガイドは です・ます が目安 — existing repo docs win）. Source memos leak casual or 依頼 register（「〜してほしい」「しくじったら」）; convert to the document's register（「〜すること」「失敗した場合」）.
+- Apply the shared norms' one-register-per-document rule: `~/.claude/references/japanese-writing/norms.md`. In this domain: README・設計文書は だ・である、手順書・ガイドは です・ます が目安（existing repo docs win）. Source memos leak casual or 依頼 register（「〜してほしい」「しくじったら」）; convert to the document's register（「〜すること」「失敗した場合」）.
 - Short paragraphs (2–4 sentences) with a blank line between logical units; tables for enumerable facts, numbered lists for sequences, prose for reasoning. Where prose works, prefer prose over decorated lists.
 
 ## Terminology and notation
@@ -99,14 +99,13 @@ When the subject is a structure or a flow — components interacting, state tran
 
 ## Faithfulness and sourcing
 
-The document states exactly what its sources support — and goes and gets the source when one is within reach:
+Apply the shared norms: `~/.claude/references/japanese-writing/norms.md`.
 
-- Every technical fact — defaults, limits, behaviors — traces to the source material, the code, or an official document.
-- When a claim is verifiable, verify it before writing instead of hedging: read the implementation, run the command, fetch the official docs. 「要確認」 is for what you genuinely cannot reach, not for what is merely tedious. When the memo and the code disagree, the code wins — note the discrepancy for the memo's author.
-- Attach the source to load-bearing claims so the reader can re-verify: code references as `path:line`, external specs as links, measured values with the command that produced them. A sourced claim settles doubt and strengthens the argument; routine facts don't need citations.
-- State a remaining inference as an inference（「〜と考えられる。要確認」）. Plausible-sounding specs no source states（e.g. 全削除 API の説明に「部分的な無効化はできない」を付け足す）are the main failure mode here.
+Technical-writing specific: when a source memo and the code disagree, the code
+wins — note the discrepancy for the memo's author. Cite code references as
+`path:line` so a reader can re-verify without asking.
 
 ## Finishing pass
 
-- The always-loaded rules still apply: `~/.claude/rules/japanese-writing.md` (AI-smell) and `markdown-formatting.md` (Semantic Line Breaks).
+- The always-loaded rules still apply: `~/.claude/rules/japanese-writing.md` (non-negotiables) and `markdown-formatting.md` (Semantic Line Breaks). Full AI-smell taxonomy and rhythm norms: `~/.claude/references/japanese-writing/norms.md`.
 - For a final prose-level polish, invoke the japanese-ai-writing-proofreader skill in fix mode.

--- a/tests/hooks/gh-pr-inject.test.sh
+++ b/tests/hooks/gh-pr-inject.test.sh
@@ -40,7 +40,7 @@ out=$(run '{"tool_input":{"command":"gh pr edit 123 --body \"変更内容の説�
 contains_norms_pointer "$out" || { echo "japanese pointer not injected for gh pr edit: $out"; exit 1; }
 
 # Green: pointer also suggests running the proofreader skill in fix mode
-out=$(run '{"tool_input":{"command":"gh pr create --body \"日本語\""}}')
+out=$(run '{"tool_input":{"command":"gh pr create --body \"日本語の本文です\""}}')
 echo "$out" | jq -e '.hookSpecificOutput.additionalContext | contains("japanese-ai-writing-proofreader")' >/dev/null \
   || { echo "proofreader skill mention missing: $out"; exit 1; }
 
@@ -48,5 +48,11 @@ echo "$out" | jq -e '.hookSpecificOutput.additionalContext | contains("japanese-
 # still fire (multi-line scan, not just the first line)
 out=$(run '{"tool_input":{"command":"gh pr create --body \"english intro\n日本語の本文\""}}')
 contains_norms_pointer "$out" || { echo "pointer not injected for japanese on non-first line: $out"; exit 1; }
+
+# Regression: an English body that only mentions Japanese punctuation as an
+# example must NOT get the Japanese norms pointer (the base gh-pr-body.md
+# rule injection may still fire).
+out=$(run '{"tool_input":{"command":"gh pr create --body \"English body that only mentions 。 as an example.\""}}')
+contains_norms_pointer "$out" && { echo "japanese pointer fired on punctuation-only mention: $out"; exit 1; }
 
 echo "all assertions passed"

--- a/tests/hooks/gh-pr-inject.test.sh
+++ b/tests/hooks/gh-pr-inject.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Tests for executable_gh-pr-inject.sh: PreToolUse(Bash) hook that injects
+# ~/.claude/rules/gh-pr-body.md for any `gh pr create|edit`, plus a
+# japanese-writing norms pointer when the command's PR body contains
+# Japanese text.
+set -uo pipefail
+
+hook="$HOOKS_DIR/executable_gh-pr-inject.sh"
+[[ -f $hook ]] || { echo "hook not found: $hook"; exit 1; }
+
+run() {
+  printf '%s' "$1" | bash "$hook"
+}
+
+contains_norms_pointer() {
+  echo "$1" | jq -e '.hookSpecificOutput.additionalContext | contains("references/japanese-writing/norms.md")' >/dev/null
+}
+
+# Edge: non gh-pr command should produce no output
+out=$(run '{"tool_input":{"command":"ls"}}')
+[[ -z $out ]] || { echo "fired on unrelated command: $out"; exit 1; }
+
+# Green: English-only PR body still gets the base rule injection
+out=$(run '{"tool_input":{"command":"gh pr create --title foo --body \"plain english body\""}}')
+[[ -n $out ]] || { echo "base rule not injected for english body: $out"; exit 1; }
+echo "$out" | jq -e '.hookSpecificOutput.additionalContext | contains("backslash")' >/dev/null \
+  || { echo "gh-pr-body.md rule missing from english output: $out"; exit 1; }
+
+# Green: English-only PR body must NOT get the Japanese norms pointer
+contains_norms_pointer "$out" && { echo "japanese pointer fired on english-only body: $out"; exit 1; }
+
+# Green: Japanese PR body gets the norms pointer IN ADDITION to the base rule
+out=$(run '{"tool_input":{"command":"gh pr create --title foo --body \"日本語の本文です\""}}')
+contains_norms_pointer "$out" || { echo "japanese pointer not injected for japanese body: $out"; exit 1; }
+echo "$out" | jq -e '.hookSpecificOutput.additionalContext | contains("backslash")' >/dev/null \
+  || { echo "gh-pr-body.md rule missing from japanese output: $out"; exit 1; }
+
+# Green: gh pr edit with Japanese body also fires
+out=$(run '{"tool_input":{"command":"gh pr edit 123 --body \"変更内容の説明\""}}')
+contains_norms_pointer "$out" || { echo "japanese pointer not injected for gh pr edit: $out"; exit 1; }
+
+# Green: pointer also suggests running the proofreader skill in fix mode
+out=$(run '{"tool_input":{"command":"gh pr create --body \"日本語\""}}')
+echo "$out" | jq -e '.hookSpecificOutput.additionalContext | contains("japanese-ai-writing-proofreader")' >/dev/null \
+  || { echo "proofreader skill mention missing: $out"; exit 1; }
+
+echo "all assertions passed"

--- a/tests/hooks/gh-pr-inject.test.sh
+++ b/tests/hooks/gh-pr-inject.test.sh
@@ -44,4 +44,9 @@ out=$(run '{"tool_input":{"command":"gh pr create --body \"日本語\""}}')
 echo "$out" | jq -e '.hookSpecificOutput.additionalContext | contains("japanese-ai-writing-proofreader")' >/dev/null \
   || { echo "proofreader skill mention missing: $out"; exit 1; }
 
+# Edge: Japanese content on a non-first line of a multi-line --body must
+# still fire (multi-line scan, not just the first line)
+out=$(run '{"tool_input":{"command":"gh pr create --body \"english intro\n日本語の本文\""}}')
+contains_norms_pointer "$out" || { echo "pointer not injected for japanese on non-first line: $out"; exit 1; }
+
 echo "all assertions passed"

--- a/tests/hooks/japanese-writing-inject.test.sh
+++ b/tests/hooks/japanese-writing-inject.test.sh
@@ -51,4 +51,9 @@ contains_norms_pointer "$out" || { echo "pointer not injected for nested .md pat
 out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md.bak","content":"日本語"}}')
 [[ -z $out ]] || { echo "fired on non-.md suffix path: $out"; exit 1; }
 
+# Edge: Japanese content on a non-first line must still fire (multi-line scan,
+# not just the first line)
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md","content":"# English Title\n\n本文は日本語"}}')
+contains_norms_pointer "$out" || { echo "pointer not injected for japanese on non-first line: $out"; exit 1; }
+
 echo "all assertions passed"

--- a/tests/hooks/japanese-writing-inject.test.sh
+++ b/tests/hooks/japanese-writing-inject.test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Tests for executable_japanese-writing-inject.sh: PreToolUse(Write|Edit)
+# hook that injects a japanese-writing norms pointer when a .md file is
+# being written/edited with Japanese content, and stays silent otherwise.
+set -uo pipefail
+
+hook="$HOOKS_DIR/executable_japanese-writing-inject.sh"
+[[ -f $hook ]] || { echo "hook not found: $hook"; exit 1; }
+
+run() {
+  printf '%s' "$1" | bash "$hook"
+}
+
+contains_norms_pointer() {
+  echo "$1" | jq -e '.hookSpecificOutput.additionalContext | contains("references/japanese-writing/norms.md")' >/dev/null
+}
+
+# Edge: missing tool_input should not crash
+out=$(run '{"tool_name":"Write"}')
+[[ -z $out ]] || { echo "fired on missing tool_input: $out"; exit 1; }
+
+# Green: Write to .md with Japanese content fires
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md","content":"日本語"}}')
+contains_norms_pointer "$out" || { echo "pointer not injected for japanese .md write: $out"; exit 1; }
+
+# Green: pointer also suggests running the proofreader skill in fix mode
+echo "$out" | jq -e '.hookSpecificOutput.additionalContext | contains("japanese-ai-writing-proofreader")' >/dev/null \
+  || { echo "proofreader skill mention missing: $out"; exit 1; }
+
+# Edge: .py file with Japanese content must NOT fire
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"script.py","content":"# 日本語コメント"}}')
+[[ -z $out ]] || { echo "fired on .py file: $out"; exit 1; }
+
+# Edge: .md file with English-only content must NOT fire
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md","content":"plain english content"}}')
+[[ -z $out ]] || { echo "fired on english-only .md: $out"; exit 1; }
+
+# Green: Edit uses tool_input.new_string
+out=$(run '{"tool_name":"Edit","tool_input":{"file_path":"doc.md","old_string":"old","new_string":"日本語の変更"}}')
+contains_norms_pointer "$out" || { echo "pointer not injected for japanese .md edit: $out"; exit 1; }
+
+# Edge: Edit to .md with English-only new_string must NOT fire
+out=$(run '{"tool_name":"Edit","tool_input":{"file_path":"doc.md","old_string":"old","new_string":"english only"}}')
+[[ -z $out ]] || { echo "fired on english-only .md edit: $out"; exit 1; }
+
+# Edge: nested .md path still matches (suffix check, not basename-only)
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"docs/adr/0001-foo.md","content":"日本語"}}')
+contains_norms_pointer "$out" || { echo "pointer not injected for nested .md path: $out"; exit 1; }
+
+# Edge: file that merely contains .md mid-path but does not end with .md must NOT fire
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md.bak","content":"日本語"}}')
+[[ -z $out ]] || { echo "fired on non-.md suffix path: $out"; exit 1; }
+
+echo "all assertions passed"

--- a/tests/hooks/japanese-writing-inject.test.sh
+++ b/tests/hooks/japanese-writing-inject.test.sh
@@ -20,7 +20,7 @@ out=$(run '{"tool_name":"Write"}')
 [[ -z $out ]] || { echo "fired on missing tool_input: $out"; exit 1; }
 
 # Green: Write to .md with Japanese content fires
-out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md","content":"日本語"}}')
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md","content":"これは日本語の文章です"}}')
 contains_norms_pointer "$out" || { echo "pointer not injected for japanese .md write: $out"; exit 1; }
 
 # Green: pointer also suggests running the proofreader skill in fix mode
@@ -36,7 +36,7 @@ out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md","content":"pl
 [[ -z $out ]] || { echo "fired on english-only .md: $out"; exit 1; }
 
 # Green: Edit uses tool_input.new_string
-out=$(run '{"tool_name":"Edit","tool_input":{"file_path":"doc.md","old_string":"old","new_string":"日本語の変更"}}')
+out=$(run '{"tool_name":"Edit","tool_input":{"file_path":"doc.md","old_string":"old","new_string":"日本語の変更を加えた文章"}}')
 contains_norms_pointer "$out" || { echo "pointer not injected for japanese .md edit: $out"; exit 1; }
 
 # Edge: Edit to .md with English-only new_string must NOT fire
@@ -44,16 +44,32 @@ out=$(run '{"tool_name":"Edit","tool_input":{"file_path":"doc.md","old_string":"
 [[ -z $out ]] || { echo "fired on english-only .md edit: $out"; exit 1; }
 
 # Edge: nested .md path still matches (suffix check, not basename-only)
-out=$(run '{"tool_name":"Write","tool_input":{"file_path":"docs/adr/0001-foo.md","content":"日本語"}}')
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"docs/adr/0001-foo.md","content":"これは日本語の文章です"}}')
 contains_norms_pointer "$out" || { echo "pointer not injected for nested .md path: $out"; exit 1; }
 
 # Edge: file that merely contains .md mid-path but does not end with .md must NOT fire
-out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md.bak","content":"日本語"}}')
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md.bak","content":"これは日本語の文章です"}}')
 [[ -z $out ]] || { echo "fired on non-.md suffix path: $out"; exit 1; }
 
 # Edge: Japanese content on a non-first line must still fire (multi-line scan,
 # not just the first line)
 out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md","content":"# English Title\n\n本文は日本語"}}')
 contains_norms_pointer "$out" || { echo "pointer not injected for japanese on non-first line: $out"; exit 1; }
+
+# Regression: English prose that only mentions Japanese punctuation examples
+# (e.g. rules docs listing 。．！？ as sentence-boundary examples) must NOT
+# fire. \p{Han} matches CJK punctuation via script-extensions, so a naive
+# CJK-codepoint test over-triggers on this.
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md","content":"Break after a sentence boundary (。．！？) — never mid-clause."}}')
+[[ -z $out ]] || { echo "fired on english prose with only japanese punctuation examples: $out"; exit 1; }
+
+# Edge: a couple of Japanese example words below the 15% density threshold
+# must NOT fire.
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md","content":"Use the 校正 skill; otherwise write normal English prose that dominates the whole paragraph by a wide margin so Japanese stays a small fraction."}}')
+[[ -z $out ]] || { echo "fired on low-density japanese example: $out"; exit 1; }
+
+# Green: genuine Japanese prose at or above the 15% density threshold fires.
+out=$(run '{"tool_name":"Write","tool_input":{"file_path":"doc.md","content":"この設計は状況を更新する文を優先する。読者の理解を前に進める文だけを残す。"}}')
+contains_norms_pointer "$out" || { echo "pointer not injected for genuine japanese prose: $out"; exit 1; }
 
 echo "all assertions passed"


### PR DESCRIPTION
## Why

The repo had accumulated Japanese-writing quality knowledge (a proofreader skill, an always-on rule, generation skills), but it only fired on explicit request — never at the moments where readable Japanese matters most (PR descriptions, docs). Root cause: **always-on guidance gets diluted**, so `japanese-writing.md` was present yet ineffective. This PR makes the knowledge fire just-in-time, from one deduplicated source.

Design is recorded in three ADRs (`docs/adr/0001..0003`); this branch implements their v1 scope.

## What shipped

- **ADR 0002 — knowledge consolidation.** New canonical norms reference `dot_claude/references/japanese-writing/norms.md` (structure, sourcing, rhythm, cognitive rhythm, AI-smell taxonomy — the last distilled from k16shikano's cognitive-rhythm method, credited, not vendored). The always-on rule shrank to a minimal floor + pointer; the three writing skills now reference the norms instead of restating them. The proofreader stays a separate skill (generator/evaluator boundary).
- **ADR 0001 Stage 0 — JIT injection.** `gh-pr-inject.sh` now appends a norms pointer when a PR body contains Japanese; a new `japanese-writing-inject.sh` (PreToolUse Write/Edit) does the same for Japanese `.md` writes. Both fail closed to silence, detect Hiragana/Katakana/Han (macOS-safe, no BSD-grep `-P`), and ship hook tests.
- **ADR 0003 — naming.** Convention doc at `references/skill-naming.md`. The writing-family rename (C2) is deferred (lazy migration; tracked in #198).

## Architecture

One source of truth, read three ways — generation, verification, and injection:

```mermaid
graph LR
  NORMS["references/japanese-writing/norms.md<br/>(single source of truth)"]
  RULE["rules/japanese-writing.md<br/>always-on floor"] --> NORMS
  TW["skill: technical-writing"] --> NORMS
  AW["skill: article-writing"] --> NORMS
  PROOF["skill: proofreader (verification)"] --> NORMS
  PRH["hook: gh-pr-inject (PR body)"] --> NORMS
  DOCH["hook: japanese-writing-inject (.md)"] --> NORMS
```

## Testing

- `just test` green (hook tests 4 → 6; the two new hooks covered by `tests/hooks/*.test.sh` with Red→Green evidence).
- Behavior verified directly: Japanese `.md`/PR body → injects; `.py` / English / non-`.md` → silent; multi-line Japanese not on line 1 → detected (a line-1-only bug was caught and fixed during implementation).
- `settings.json.tmpl` renders to valid JSON with the new hook wired under the `Write|Edit|MultiEdit` matcher.

## Known limitations (in scope for follow-up, not defects)

- **`--body-file` PR bodies are not scanned** — `gh-pr-inject` reads only the command string, so Japanese passed via `--body-file` misses the nudge. Tracked in #197 (Stage 1 body-extraction).
- **`MultiEdit` content is not scanned** — the doc hook reads `content`/`new_string` only; MultiEdit's `edits[]` won't trigger (fail-silent is correct).

## Follow-ups

- #196 — headless commit signing (env-aware signer; op-ssh-sign needs GUI)
- #197 — ADR 0001 Stage 1 lint guardrail + Stage 2 gate
- #198 — writing-family rename (ADR 0003 C2, lazy)

## Note for reviewer / deploy

`chezmoi apply` deployed the hooks and reference, but wiring `settings.json` to the live config was left unapplied: the live `~/.claude/settings.json` has diverged from the template in ways unrelated to this PR (a local `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` flag would be dropped), so it needs an interactive reconcile rather than a forced overwrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
