### PR TITLE
docs(rules): default to no prose hard-wrap; never wrap GitHub bodies

### DIFF
--- a/dot_claude/rules/markdown-formatting.md
+++ b/dot_claude/rules/markdown-formatting.md
@@ -6,16 +6,15 @@ Language-independent formatting rules for Markdown output (responses, PR bodies,
   Markdown's ordered-list syntax (`1.` `2.`) render the numbering; don't type the numerals
   into the body text yourself.
 
-## Line breaks in prose: Semantic Line Breaks
+## Line breaks in prose
 
-Follow [Semantic Line Breaks](https://sembr.org/) for prose in Markdown files, both English and Japanese.
-Soft breaks don't affect rendering; they exist for diffs and editing, so place them at semantic boundaries.
+Default: **do not hard-wrap prose.** Write one paragraph per line and let the editor/renderer soft-wrap. Hard-wrapping gains nothing in rendered output (CommonMark collapses a soft break to a space) and is a footgun on hard-break surfaces (below).
 
-- One sentence per line (after 。．.！？!?) — this is the SemBr MUST level
-- A long sentence may break after a major clause (、 semicolon, em dash) — never mid-clause to satisfy a column limit
-- Multi-sentence list items: continuation lines also break per sentence
-- Japanese extra caution: a mid-sentence wrap can render as a bogus half-width space (CSS segment-break removal for CJK is spec'd but unevenly implemented across browsers), so the sentence boundary is the only safe break point
-- Where newlines are hard breaks, this rule does not apply: GitHub issue/PR comment bodies, tables, code blocks
+- **Never wrap hard-break surfaces**: GitHub issue / PR / comment bodies render every single newline as a `<br>`, so a wrapped paragraph shows as jagged forced breaks. Write them as long unwrapped lines with a blank line between paragraphs. (Tables and code blocks are not prose — leave them.)
+- **Follow the repo when it declares a convention**: an `.editorconfig` `max_line_length`, Prettier `proseWrap`, or an existing consistently-wrapped corpus (e.g. these rule files). Match it.
+- [Semantic Line Breaks](https://sembr.org/) (one sentence per line) is **opt-in** — worth it only where the repo wants sentence-granularity prose diffs, never the global default.
+- When you do wrap, break only at sentence boundaries (。．.！？!?), never mid-clause for a column limit. Japanese especially: a mid-sentence wrap can render as a bogus half-width space (CJK segment-break removal is unevenly implemented), so the sentence boundary is the only safe break.
+- **Code comments**: follow the repo's / language's formatter and line-length config.
 
 ## Diagrams: mermaid in artifacts, ASCII in chat
 

--- a/dot_claude/rules/markdown-formatting.md
+++ b/dot_claude/rules/markdown-formatting.md
@@ -8,13 +8,13 @@ Language-independent formatting rules for Markdown output (responses, PR bodies,
 
 ## Line breaks in prose
 
-Default: **do not hard-wrap prose.** Write one paragraph per line and let the editor/renderer soft-wrap. Hard-wrapping gains nothing in rendered output (CommonMark collapses a soft break to a space) and is a footgun on hard-break surfaces (below).
+Prose has **no column limit** and is **not hard-wrapped** by default. Write one paragraph per line and let the editor/renderer soft-wrap. A hard wrap gains nothing in rendered Markdown (CommonMark collapses a soft break to a space) and is a footgun on hard-break surfaces (below).
 
 - **Never wrap hard-break surfaces**: GitHub issue / PR / comment bodies render every single newline as a `<br>`, so a wrapped paragraph shows as jagged forced breaks. Write them as long unwrapped lines with a blank line between paragraphs. (Tables and code blocks are not prose — leave them.)
-- **Follow the repo when it declares a convention**: an `.editorconfig` `max_line_length`, Prettier `proseWrap`, or an existing consistently-wrapped corpus (e.g. these rule files). Match it.
-- [Semantic Line Breaks](https://sembr.org/) (one sentence per line) is **opt-in** — worth it only where the repo wants sentence-granularity prose diffs, never the global default.
-- When you do wrap, break only at sentence boundaries (。．.！？!?), never mid-clause for a column limit. Japanese especially: a mid-sentence wrap can render as a bogus half-width space (CJK segment-break removal is unevenly implemented), so the sentence boundary is the only safe break.
-- **Code comments**: follow the repo's / language's formatter and line-length config.
+- **Follow the repo's prose convention when it declares one**: Prettier `proseWrap`, or an existing consistently-wrapped corpus (e.g. these rule files). Match it.
+- [Semantic Line Breaks](https://sembr.org/) (one sentence per line) is **opt-in** — worth it only where the repo wants sentence-granularity prose diffs, never the global default. When wrapping, break only at sentence boundaries (。．.！？!?), never mid-clause. Japanese: a mid-sentence wrap can render as a bogus half-width space (CJK segment-break removal is unevenly implemented), so the sentence boundary is the only safe break.
+
+**Code line length** is not governed here — it follows each language's own formatter / linter (`.editorconfig`, `.stylua.toml`, Prettier, `shfmt`, etc.), never a Markdown-wide column rule.
 
 ## Diagrams: mermaid in artifacts, ASCII in chat
 


### PR DESCRIPTION
## Why

Hard-wrapping prose has no upside in rendered Markdown (CommonMark collapses a soft break to a space) and actively breaks GitHub issue/PR/comment bodies, which render every single newline as a `<br>` — a wrapped paragraph shows as jagged forced breaks. The old rule mandated Semantic Line Breaks as the global default and buried the GitHub-body exception in the last bullet, which is exactly how a wrapped, hard-to-read PR body slipped through.

## What changes

`dot_claude/rules/markdown-formatting.md`, "Line breaks in prose":

- **Prose has no column limit and no default hard-wrap.** One paragraph per line; let the editor/renderer soft-wrap.
- **The GitHub-body prohibition is now the first, prominent rule** — never wrap hard-break surfaces (single newlines render as `<br>`).
- **Follow the repo's prose convention when it declares one** (Prettier `proseWrap`, an existing wrapped corpus). No `max_line_length` for prose — that is a code concern.
- **Semantic Line Breaks becomes opt-in**, worth it only where the repo wants sentence-granularity prose diffs — no longer a global MUST.
- **Code line length is out of scope here** — it follows each language's own formatter/linter (`.editorconfig`, `.stylua.toml`, Prettier, `shfmt`), never a Markdown-wide column rule.

The Japanese CJK caution (a mid-sentence wrap can render as a bogus half-width space) is kept, scoped to the case where a repo opts into wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
