### PR TITLE
feat(git): machine-scoped commit signing — 1Password on work, on-disk key on personal (ADR 0004)

### DIFF
--- a/docs/adr/0004-env-aware-commit-signing.md
+++ b/docs/adr/0004-env-aware-commit-signing.md
@@ -1,0 +1,52 @@
+# 0004. Machine-scoped commit signing (1Password on work, on-disk key on personal)
+
+## Status
+
+Accepted — 2026-07-23. Closes issue #196.
+
+## Context
+
+Commit signing hardcoded the 1Password GUI signer, so it could not sign on a headless / SSH session (`dot_config/git/main.tmpl` set `gpg.ssh.program = op-ssh-sign` on all of macOS). `op-ssh-sign` needs the 1Password desktop app unlocked, and there is no headless unlock, so `git commit` failed with `error: 1Password: failed to fill whole buffer` or fell back to an Unverified signature.
+
+Two keys are already present:
+
+- `N4Wn` — held inside 1Password (private key never on disk). Maximum at-rest protection; requires the GUI to sign.
+- `Sl3q` — `~/.ssh/id_ed25519`, no passphrase, already registered on GitHub as an **auth** key. Signs headlessly, but is exposed at rest on disk.
+
+The repository already splits configuration by machine through the `.business_use` chezmoi variable.
+
+## Decision
+
+Choose the signer per machine at chezmoi-apply time (not at commit time), keyed on `.business_use`:
+
+- **business (+ macOS)** — `gpg.ssh.program = op-ssh-sign`, `signingkey = N4Wn`. The signing key never touches disk.
+- **personal** — no `gpg.ssh.program` (git's default `ssh-keygen` signer), `signingkey = ~/.ssh/id_ed25519.pub` (`Sl3q`). Signs on both headless and GUI sessions, so personal commits are always Verified.
+- Both — `gpg.ssh.allowedSignersFile = ~/.config/git/allowed_signers`, listing `Sl3q` and `N4Wn` under the personal and work emails, so `git log --show-signature` verifies locally regardless of which key signed.
+
+### Rejected alternatives
+
+- **Runtime env-aware dual-key on personal** (1Password on GUI, on-disk on headless): git passes a single `user.signingkey` to the signer, and the two signers need different keys (`N4Wn` vs `Sl3q`), so switching both program and key at commit time needs a wrapper that rewrites git's key argument — fragile for little gain. Moving the split to apply-time (per machine) is clean.
+- **On-disk key on business**: keeps the maximum-protection posture where it matters most; business commits stay 1Password-only.
+
+## Consequences
+
+### Positive
+
+- Personal commits are Verified everywhere, including headless/SSH — the original pain is gone.
+- Business keeps the private key off disk.
+- No wrapper script and no runtime detection; the split reuses the existing `.business_use` mechanism.
+- Local verification works: `ssh-keygen -Y verify` against the rendered `allowed_signers` returns `Good "git" signature` for the on-disk key.
+
+### Negative / accepted trade-offs
+
+- Personal GUI sessions no longer sign through 1Password. Accepted: the on-disk key already exists and is already GitHub-trusted, so this adds no new at-rest exposure.
+- The on-disk signing key has no passphrase (required for unattended headless signing); its at-rest exposure is the trade-off accepted on personal machines only.
+
+### Required follow-up (manual, outside chezmoi)
+
+- Register `Sl3q` as a GitHub **signing** key (it is currently an auth key only) so GitHub shows Verified for personal commits — web UI (Settings → SSH and GPG keys → New → "Signing Key") or `gh auth refresh -s admin:ssh_signing_key` then the API. `N4Wn` must likewise be registered as a signing key for business commits.
+
+### Verification
+
+- `chezmoi execute-template` renders the personal branch as `signingkey = ~/.ssh/id_ed25519.pub` with no `op-ssh-sign` program; the business branch mirrors it with `op-ssh-sign` + `N4Wn`.
+- End-to-end local verify passes (sign with the on-disk key → verify against `allowed_signers`).

--- a/dot_config/git/allowed_signers.tmpl
+++ b/dot_config/git/allowed_signers.tmpl
@@ -1,0 +1,10 @@
+{{ .email }} ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKKDPUz/WZBhkJsFEBQeUzU7s/O2tkddTScMWUBgSl3q
+{{- if .signing_key }}
+{{ .email }} {{ .signing_key }}
+{{- end }}
+{{- if .work_email }}
+{{ .work_email }} ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKKDPUz/WZBhkJsFEBQeUzU7s/O2tkddTScMWUBgSl3q
+{{- if .signing_key }}
+{{ .work_email }} {{ .signing_key }}
+{{- end }}
+{{- end }}

--- a/dot_config/git/main.tmpl
+++ b/dot_config/git/main.tmpl
@@ -1,7 +1,7 @@
 [user]
   name = {{ .name }}
   email = {{ .email }}
-{{- if .signing_key }}
+{{- if and .business_use .signing_key }}
   signingkey = {{ .signing_key }}
 {{- else }}
   signingkey = ~/.ssh/id_ed25519.pub
@@ -15,9 +15,10 @@
 
 [gpg]
   format = ssh
-{{- if eq .chezmoi.os "darwin" }}
 
 [gpg "ssh"]
+  allowedSignersFile = ~/.config/git/allowed_signers
+{{- if and .business_use (eq .chezmoi.os "darwin") }}
   program = /Applications/1Password.app/Contents/MacOS/op-ssh-sign
 {{- end }}
 


### PR DESCRIPTION
## Why

`op-ssh-sign` needs the 1Password GUI, so headless / SSH sessions could not sign — `git commit` failed with `failed to fill whole buffer` or produced Unverified commits (#196). The whole of this session's work was committed headless with a manual on-disk-key override; this makes that the deployed default on personal machines while keeping work machines on 1Password.

## What changed

`dot_config/git/main.tmpl` now splits the signer by `.business_use` at apply time:

- **business (+ macOS)** — `op-ssh-sign` + the 1Password key. Private key never on disk.
- **personal** — git's default `ssh-keygen` signer + on-disk `~/.ssh/id_ed25519`. Signs on headless and GUI alike, so personal commits stay Verified.
- **both** — `allowedSignersFile = ~/.config/git/allowed_signers` (new `allowed_signers.tmpl`, listing both keys under the personal and work emails) for local `git log --show-signature`.

Rationale and rejected alternatives (runtime dual-key wrapper; on-disk key on business) are in [ADR 0004](../docs/adr/0004-env-aware-commit-signing.md).

## Verified

- `chezmoi execute-template` renders personal as `signingkey = ~/.ssh/id_ed25519.pub` with no `op-ssh-sign` program.
- End-to-end local verify passes: signing with the on-disk key and verifying against the rendered `allowed_signers` returns `Good "git" signature for pavegy@gmail.com`.
- `just test` green.

## Required manual follow-up (outside chezmoi)

Register the on-disk key `Sl3q` as a GitHub **signing** key (it is currently an auth key only) so GitHub shows Verified for personal commits — Settings → SSH and GPG keys → New → "Signing Key", or `gh auth refresh -s admin:ssh_signing_key` then the API. Register the 1Password key as a signing key too for business commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
