### PR TITLE
feat(zsh): keks EKS cluster switcher and p10k AWS/kube prompt

### DIFF
--- a/dot_config/zsh/features/kube.zsh
+++ b/dot_config/zsh/features/kube.zsh
@@ -1,6 +1,6 @@
-# kube.zsh - switch kubernetes context/namespace with fzf
-# Provides:     kctx, kns, kinfo
-# Requires:     kubectl, fzf
+# kube.zsh - switch kubernetes context/namespace/EKS-cluster with fzf
+# Provides:     kctx, kns, kinfo, keks
+# Requires:     kubectl, fzf, aws, jq
 
 # Switch kube context with fzf
 kctx() {
@@ -37,4 +37,46 @@ kns() {
 kinfo() {
   echo "Context:   $(kubectl config current-context 2>/dev/null || echo 'none')"
   echo "Namespace: $(kubectl config view --minify -o jsonpath='{..namespace}' 2>/dev/null || echo 'default')"
+}
+
+# Switch kubeconfig to an EKS cluster in the current AWS profile with fzf, and
+# make it the current context. Needs an active AWS session first (awsp / s2a /
+# s2ak). Region precedence: KEKS_REGION override > the active profile's region
+# (aws configure get region) > ap-northeast-1.
+# The context is aliased "<profile>/<cluster>" so kctx stays readable across
+# many accounts that reuse cluster names (e.g. prod).
+keks() {
+  if [[ -z "$AWS_PROFILE" ]]; then
+    echo "keks: AWS_PROFILE is unset — run awsp or s2ak first" >&2
+    return 1
+  fi
+
+  local region="${KEKS_REGION:-$(aws configure get region 2>/dev/null)}"
+  region="${region:-ap-northeast-1}"
+
+  local out
+  if ! out=$(aws eks list-clusters --region "$region" --output json 2>&1); then
+    if grep -qiE 'expired|invalid.*token|sso session|load sso token|refresh failed' <<<"$out"; then
+      echo "keks: AWS session expired for $AWS_PROFILE — run awsp/s2ak to re-auth" >&2
+    elif grep -qiE 'not authorized|accessdenied|unauthorized' <<<"$out"; then
+      echo "keks: $AWS_PROFILE lacks eks:ListClusters in $region — pick a profile/role with EKS access (awsp/s2ak)" >&2
+    else
+      echo "keks: list-clusters failed in $region" >&2
+    fi
+    echo "$out" >&2
+    return 1
+  fi
+
+  local clusters
+  clusters=$(jq -r '.clusters[]' <<<"$out")
+  [[ -z "$clusters" ]] && { echo "keks: no EKS clusters in $AWS_PROFILE ($region)" >&2; return 1; }
+
+  local cluster
+  cluster=$(fzf --reverse --height=40% \
+      --header="EKS cluster in $AWS_PROFILE ($region)" <<<"$clusters") || return 1
+  [[ -z "$cluster" ]] && return 1
+
+  aws eks update-kubeconfig --region "$region" --name "$cluster" \
+      --alias "$AWS_PROFILE/$cluster" \
+    && echo "kube context: $AWS_PROFILE/$cluster"
 }

--- a/dot_p10k.zsh
+++ b/dot_p10k.zsh
@@ -1295,9 +1295,9 @@
   # typeset -g POWERLEVEL9K_TERRAFORM_VERSION_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
-  # Show kubecontext only when the command you are typing invokes one of these tools.
-  # Tip: Remove the next line to always show kubecontext.
-  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl|kogito|k9s|helmfile|flux|fluxctl|stern|kubeseal|skaffold|kubent|kubecolor|cmctl|sparkctl'
+  # Always show kubecontext (not only while typing kubectl/helm/etc.) so the
+  # current keks-set context <profile>/<cluster> is visible at a glance.
+  # typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl|kogito|k9s|helmfile|flux|fluxctl|stern|kubeseal|skaffold|kubent|kubecolor|cmctl|sparkctl'
 
   # Kubernetes context classes for the purpose of using different colors, icons and expansions with
   # different contexts.
@@ -1326,9 +1326,10 @@
   #   typeset -g POWERLEVEL9K_KUBECONTEXT_TEST_VISUAL_IDENTIFIER_EXPANSION='⭐'
   #   typeset -g POWERLEVEL9K_KUBECONTEXT_TEST_CONTENT_EXPANSION='> ${P9K_CONTENT} <'
   typeset -g POWERLEVEL9K_KUBECONTEXT_CLASSES=(
-      # '*prod*'  PROD    # These values are examples that are unlikely
-      # '*test*'  TEST    # to match your needs. Customize them as needed.
-      '*'       DEFAULT)
+      # keks aliases contexts as <profile>/<cluster>; prod clusters are named production-*.
+      '*production*'  PROD
+      '*'             DEFAULT)
+  typeset -g POWERLEVEL9K_KUBECONTEXT_PROD_FOREGROUND=196      # red: production danger
   typeset -g POWERLEVEL9K_KUBECONTEXT_DEFAULT_FOREGROUND=134
   # typeset -g POWERLEVEL9K_KUBECONTEXT_DEFAULT_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
@@ -1382,9 +1383,9 @@
   typeset -g POWERLEVEL9K_KUBECONTEXT_PREFIX='%250Fat '
 
   #[ aws: aws profile (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) ]#
-  # Show aws only when the command you are typing invokes one of these tools.
-  # Tip: Remove the next line to always show aws.
-  typeset -g POWERLEVEL9K_AWS_SHOW_ON_COMMAND='aws|awless|cdk|terraform|pulumi|terragrunt'
+  # Always show the aws segment (not only while typing aws/terraform/etc.) so the
+  # active AWS_PROFILE (SSO profile name) is visible at a glance.
+  # typeset -g POWERLEVEL9K_AWS_SHOW_ON_COMMAND='aws|awless|cdk|terraform|pulumi|terragrunt'
 
   # POWERLEVEL9K_AWS_CLASSES is an array with even number of elements. The first element
   # in each pair defines a pattern against which the current AWS profile gets matched.
@@ -1409,10 +1410,12 @@
   #   typeset -g POWERLEVEL9K_AWS_TEST_FOREGROUND=28
   #   typeset -g POWERLEVEL9K_AWS_TEST_VISUAL_IDENTIFIER_EXPANSION='⭐'
   #   typeset -g POWERLEVEL9K_AWS_TEST_CONTENT_EXPANSION='> ${P9K_CONTENT} <'
+  # Class is matched against P9K_AWS_PROFILE, so this reddens SSO prod profiles
+  # (e.g. data-infra-prod.*). saml sessions keep AWS_PROFILE=saml and won't match.
   typeset -g POWERLEVEL9K_AWS_CLASSES=(
-      # '*prod*'  PROD    # These values are examples that are unlikely
-      # '*test*'  TEST    # to match your needs. Customize them as needed.
+      '*prod*'  PROD
       '*'       DEFAULT)
+  typeset -g POWERLEVEL9K_AWS_PROD_FOREGROUND=196     # red: production danger
   typeset -g POWERLEVEL9K_AWS_DEFAULT_FOREGROUND=208
   # typeset -g POWERLEVEL9K_AWS_DEFAULT_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
@@ -1420,7 +1423,9 @@
   #
   # - P9K_AWS_PROFILE  The name of the current AWS profile.
   # - P9K_AWS_REGION   The region associated with the current AWS profile.
-  typeset -g POWERLEVEL9K_AWS_CONTENT_EXPANSION='${P9K_AWS_PROFILE//\%/%%}${P9K_AWS_REGION:+ ${P9K_AWS_REGION//\%/%%}}'
+  # AWS_LABEL (set by s2a) overrides the generic "saml" profile with the SSO
+  # profile name for the assumed account; SSO sessions leave it unset.
+  typeset -g POWERLEVEL9K_AWS_CONTENT_EXPANSION='${${AWS_LABEL:-$P9K_AWS_PROFILE}//\%/%%}${P9K_AWS_REGION:+ ${P9K_AWS_REGION//\%/%%}}'
 
   #[ aws_eb_env: aws elastic beanstalk environment (https://aws.amazon.com/elasticbeanstalk/) ]#
   # AWS Elastic Beanstalk environment color.


### PR DESCRIPTION
## 概要

AWS プロファイル認証後に手作業だった EKS クラスタへの kubeconfig 切替を 1 コマンド (`keks`) に集約する。あわせて p10k プロンプトで現在の AWS プロファイルと kube コンテキストを常時表示し、production を赤で警告する。

```mermaid
flowchart LR
  auth["s2ak / awsp"] --> keks["keks: fzf でクラスタ選択"]
  keks --> ctx["kube context = profile/cluster"]
  ctx --> p10k["p10k: aws + kubecontext を常時表示 / production は赤"]
```

## 変更点

### `keks` (dot_config/zsh/features/kube.zsh)

- 現在の `AWS_PROFILE` の EKS クラスタを fzf で選択し、`update-kubeconfig --alias <profile>/<cluster>` を実行して current context に設定する。
- リージョン優先順位は `KEKS_REGION` > プロファイルの region (`aws configure get region`) > ap-northeast-1。
- 失敗時は AWS の生エラーを分類する（トークン失効なら再認証、AccessDenied なら EKS 権限のあるプロファイル/ロールを選ぶよう案内）。
- context を `<profile>/<cluster>` エイリアスにするため、同名クラスタ (prod 等) を持つ多数のアカウント間でも `kctx` が読みやすい。

### p10k (dot_p10k.zsh)

- `aws` / `kubecontext` セグメントを常時表示にする（`SHOW_ON_COMMAND` をコメントアウト）。現在のプロファイルとクラスタが一目で分かる。
- `kubecontext` が `*production*`、`aws` が `*prod*` にマッチするとき前景色を赤 (196) にして危険表示する。
- `AWS_CONTENT_EXPANSION` が `$AWS_LABEL` を優先するようにする。saml セッションで generic な "saml" ではなく SSO アカウント名を表示するため。

## 補足（このリポジトリ外）

`keks` と p10k が前提とする入口・ラベル（`s2ak` / `awsp` / `AWS_LABEL` のエクスポート / fzf preview）は、マシン固有の `~/.zshrc.local`（chezmoi 管理外）側に実装している。p10k は `${AWS_LABEL:-$P9K_AWS_PROFILE}` でフォールバックするため、`AWS_LABEL` 未設定でも安全に動作する。

## 動作確認

- `zsh -n` の構文チェックと `just lint-headers` を通過。
- `keks` のガード（`AWS_PROFILE` 未設定時）・エラー分類・リージョン優先順位をユニット単位で確認。
- 実クラスタでの正常系（fzf 選択 → `update-kubeconfig` → context 反映）は対話操作が必要なため手元で確認する。


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [],
      "participants": [],
      "sha": "02723a138243f4fef4433db757242b7116e009c0",
      "status": "unmetered",
      "subject": "feat(zsh): add keks — fzf EKS cluster switcher for kubeconfig",
      "totals": {
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0,
        "input_tokens": 0,
        "output_tokens": 0,
        "total_context_tokens": 0
      }
    },
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 331372,
          "cache_creation_input_tokens": 331372,
          "cache_read_input_tokens": 22312203,
          "input_tokens": 186,
          "model": "claude-opus-4-8",
          "output_tokens": 176771,
          "total_context_tokens": 22820532,
          "turns": 94
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 331372,
          "cache_creation_input_tokens": 331372,
          "cache_read_input_tokens": 22312203,
          "input_tokens": 186,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 176771,
          "total_context_tokens": 22820532,
          "turns": 94
        }
      ],
      "recorded_at": "2026-07-23T04:10:05Z",
      "sha": "10a458c6f0625adf99b38be812a21822ef256b0e",
      "subject": "feat(p10k): always-show aws/kube segments, red on production, saml label",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 331372,
        "cache_creation_input_tokens": 331372,
        "cache_read_input_tokens": 22312203,
        "input_tokens": 186,
        "output_tokens": 176771,
        "total_context_tokens": 22820532,
        "turns": 94
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 1,
  "pr": {
    "base": "main",
    "head": "feat/keks-eks-switcher-p10k",
    "number": 203
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 2,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 331372,
    "cache_creation_input_tokens": 331372,
    "cache_read_input_tokens": 22312203,
    "input_tokens": 186,
    "output_tokens": 176771,
    "total_context_tokens": 22820532,
    "turns": 94
  },
  "totals_by_model": [
    {
      "cache_creation_ephemeral_1h_input_tokens": 331372,
      "cache_creation_input_tokens": 331372,
      "cache_read_input_tokens": 22312203,
      "input_tokens": 186,
      "model": "claude-opus-4-8",
      "output_tokens": 176771,
      "total_context_tokens": 22820532,
      "turns": 94
    }
  ],
  "updated_at": "2026-07-23T04:11:37Z"
}
```

</details>
<!-- code-flow-usage-json:end -->
