### PR TITLE
ci: add fail-closed repository quality gate

### DIFF
--- a/.github/scripts/install-chezmoi.sh
+++ b/.github/scripts/install-chezmoi.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly version="2.70.5"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <bin-dir>" >&2
+  exit 2
+fi
+
+bin_dir="$1"
+platform="$(uname -s)"
+architecture="$(uname -m)"
+
+case "$platform:$architecture" in
+  Linux:x86_64)
+    asset="chezmoi-linux-amd64"
+    expected_sha256="da4f1346e3626c68cbe3620abc12134d886733420df92e32edb48d0406c7f9e5"
+    ;;
+  Darwin:x86_64)
+    asset="chezmoi-darwin-amd64"
+    expected_sha256="ddc01ecec92eae115a889e71a31c9d4473067429bfdb4e5c9d9d41221aca6b76"
+    ;;
+  Darwin:arm64)
+    asset="chezmoi-darwin-arm64"
+    expected_sha256="f6b1be4caf2edec0addfde57a391c1c77ddf32bc2f57c8b594eac483ba30d2a1"
+    ;;
+  *)
+    echo "Unsupported platform: $platform $architecture" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$bin_dir"
+tmp_file="$(mktemp "$bin_dir/.chezmoi.XXXXXX")"
+trap 'rm -f "$tmp_file"' EXIT
+
+url="https://github.com/twpayne/chezmoi/releases/download/v${version}/${asset}"
+curl --fail --silent --show-error --location "$url" --output "$tmp_file"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_sha256="$(sha256sum "$tmp_file")"
+elif command -v shasum >/dev/null 2>&1; then
+  actual_sha256="$(shasum -a 256 "$tmp_file")"
+else
+  echo "No SHA-256 tool found (sha256sum or shasum required)" >&2
+  exit 1
+fi
+actual_sha256="${actual_sha256%% *}"
+
+if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+  echo "SHA-256 mismatch for $asset" >&2
+  echo "expected: $expected_sha256" >&2
+  echo "actual:   $actual_sha256" >&2
+  exit 1
+fi
+
+chmod 0755 "$tmp_file"
+mv -f "$tmp_file" "$bin_dir/chezmoi"
+trap - EXIT
+
+echo "Installed chezmoi v$version to $bin_dir/chezmoi"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read
@@ -220,9 +219,62 @@ jobs:
         env:
           BUSINESS_USE: ${{ matrix.business_use }}
         run: |
+          set -euo pipefail
+
           chezmoi init --source="${PWD}"
-          chezmoi managed | head -20
-          chezmoi cat ~/.config/git/config || true
+
+          repo_root="$(pwd -P)"
+          expected_source="${repo_root}"
+          source_root_file="${repo_root}/.chezmoiroot"
+          home_source="${repo_root}/home"
+          if [[ -e "${source_root_file}" ]]; then
+            if [[ ! -f "${source_root_file}" ]]; then
+              echo ".chezmoiroot must be a regular file" >&2
+              exit 1
+            fi
+            source_subdir="$(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "${source_root_file}")"
+            if [[ "${source_subdir}" != "home" ]]; then
+              echo ".chezmoiroot must contain exactly 'home'" >&2
+              exit 1
+            fi
+            if [[ ! -d "${home_source}" ]]; then
+              echo ".chezmoiroot selects home, but home/ is not a directory" >&2
+              exit 1
+            fi
+            expected_source="$(cd "${home_source}" && pwd -P)"
+          elif [[ -e "${home_source}" ]]; then
+            echo "home/ exists, but .chezmoiroot is missing" >&2
+            exit 1
+          fi
+
+          actual_source="$(chezmoi source-path)"
+          if [[ "${actual_source}" != "${expected_source}" ]]; then
+            echo "Unexpected chezmoi source root" >&2
+            echo "expected: ${expected_source}" >&2
+            echo "actual:   ${actual_source}" >&2
+            exit 1
+          fi
+
+          expected_git_source="${expected_source}/dot_config/git/config"
+          actual_git_source="$(chezmoi source-path "${HOME}/.config/git/config")"
+          if [[ "${actual_git_source}" != "${expected_git_source}" ]]; then
+            echo "Unexpected source path for ~/.config/git/config" >&2
+            echo "expected: ${expected_git_source}" >&2
+            echo "actual:   ${actual_git_source}" >&2
+            exit 1
+          fi
+
+          managed_files="$(chezmoi managed)"
+          if ! grep -Fxq '.config/git/config' <<<"${managed_files}"; then
+            echo "Managed files do not contain .config/git/config" >&2
+            exit 1
+          fi
+          if grep -Fxq 'README.md' <<<"${managed_files}"; then
+            echo "Repository-only README.md must not be managed" >&2
+            exit 1
+          fi
+
+          chezmoi cat "${HOME}/.config/git/config"
 
   devbox:
     name: Devbox Validation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,7 +247,7 @@ jobs:
             exit 1
           fi
 
-          actual_source="$(chezmoi source-path)"
+          actual_source="$(chezmoi --source="${repo_root}" source-path)"
           if [[ "${actual_source}" != "${expected_source}" ]]; then
             echo "Unexpected chezmoi source root" >&2
             echo "expected: ${expected_source}" >&2
@@ -256,7 +256,7 @@ jobs:
           fi
 
           expected_git_source="${expected_source}/dot_config/git/config"
-          actual_git_source="$(chezmoi source-path "${HOME}/.config/git/config")"
+          actual_git_source="$(chezmoi --source="${repo_root}" source-path "${HOME}/.config/git/config")"
           if [[ "${actual_git_source}" != "${expected_git_source}" ]]; then
             echo "Unexpected source path for ~/.config/git/config" >&2
             echo "expected: ${expected_git_source}" >&2
@@ -264,7 +264,7 @@ jobs:
             exit 1
           fi
 
-          managed_files="$(chezmoi managed)"
+          managed_files="$(chezmoi --source="${repo_root}" managed)"
           if ! grep -Fxq '.config/git/config' <<<"${managed_files}"; then
             echo "Managed files do not contain .config/git/config" >&2
             exit 1
@@ -274,7 +274,7 @@ jobs:
             exit 1
           fi
 
-          chezmoi cat "${HOME}/.config/git/config"
+          chezmoi --source="${repo_root}" cat "${HOME}/.config/git/config"
 
   devbox:
     name: Devbox Validation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,44 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  quality:
+    name: Fast Quality Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+
+      - name: Install check dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq lua5.4 zsh
+          bash .github/scripts/install-chezmoi.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+      - name: Run fast quality gate
+        env:
+          LUA_COMPILER: luac5.4
+        run: just quality-gate
+
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       shell: ${{ steps.filter.outputs.shell }}
+      zsh: ${{ steps.filter.outputs.zsh }}
       lua: ${{ steps.filter.outputs.lua }}
       nvim: ${{ steps.filter.outputs.nvim }}
       devbox: ${{ steps.filter.outputs.devbox }}
@@ -32,6 +60,15 @@ jobs:
               - 'dot_zshenv.tmpl'
               - 'install.sh'
               - '.chezmoiscripts/**'
+              - '.github/scripts/install-chezmoi.sh'
+              - '.github/workflows/**'
+            zsh:
+              - '**/*.zsh'
+              - '**/*.zsh.tmpl'
+              - 'dot_z*.tmpl'
+              - 'dot_p10k.zsh'
+              - 'justfile'
+              - '.github/scripts/install-chezmoi.sh'
               - '.github/workflows/**'
             lua:
               - 'dot_config/nvim/**/*.lua'
@@ -47,6 +84,7 @@ jobs:
               - '.chezmoi*'
               - 'dot_config/**'
               - 'private_dot_ssh/**'
+              - '.github/scripts/install-chezmoi.sh'
               - '.github/workflows/**'
             markdown:
               - '**/*.md'
@@ -78,7 +116,7 @@ jobs:
           echo "Checking shell format..."
 
           # Check .sh scripts (shfmt does not support zsh; zsh syntax is checked by zsh -n in lint job)
-          find . -type f \( -name "install.sh" -o -path "./.chezmoiscripts/*.sh" \) -print0 | \
+          find . -type f \( -name "install.sh" -o -path "./.chezmoiscripts/*.sh" -o -path "./.github/scripts/install-chezmoi.sh" \) -print0 | \
             xargs -0 shfmt -d -i 2 -ci
 
       - name: Check lua format (stylua)
@@ -109,20 +147,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install zsh
-        run: sudo apt-get update && sudo apt-get install -y zsh
-
-      - name: Check zsh syntax
-        run: |
-          echo "Checking zsh syntax..."
-          for file in dot_zshrc.tmpl dot_zshenv.tmpl; do
-            if [[ -f "$file" ]]; then
-              # Remove chezmoi template syntax for syntax check
-              sed 's/{{[^}]*}}//g' "$file" > /tmp/check.zsh
-              zsh -n /tmp/check.zsh && echo "✓ $file" || exit 1
-            fi
-          done
-
       - name: ShellCheck
         run: |
           echo "Running ShellCheck..."
@@ -131,15 +155,27 @@ jobs:
             sudo apt-get update && sudo apt-get install -y shellcheck
           fi
           
-          # Check install.sh and scripts in .chezmoiscripts
-          find . -type f \( -name "install.sh" -o -path "./.chezmoiscripts/*.sh" \) -print0 | xargs -0 shellcheck
+          # Check install.sh, chezmoi scripts, and the CI installer
+          find . -type f \( -name "install.sh" -o -path "./.chezmoiscripts/*.sh" -o -path "./.github/scripts/install-chezmoi.sh" \) -print0 | xargs -0 shellcheck
 
+  zsh-darwin:
+    name: Zsh Syntax (macOS)
+    needs: changes
+    if: needs.changes.outputs.zsh == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: Check lua syntax
+      - name: Install just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+
+      - name: Install chezmoi in runner temp
         run: |
-          echo "Checking lua syntax..."
-          sudo apt-get install -y lua5.4
-          find dot_config/nvim -name "*.lua" -exec lua5.4 -p {} \; -print
+          bash .github/scripts/install-chezmoi.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+      - name: Check Darwin zsh syntax
+        run: just lint-zsh
 
   chezmoi:
     name: Chezmoi (${{ matrix.os }}, ${{ matrix.env_name }})
@@ -160,8 +196,8 @@ jobs:
 
       - name: Install chezmoi
         run: |
-          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          bash .github/scripts/install-chezmoi.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
 
       - name: Setup test config (provide prompted values)
         run: |
@@ -255,7 +291,7 @@ jobs:
   # This job always runs and reports success only if all required jobs passed or were skipped
   ci-complete:
     name: CI Complete
-    needs: [format, lint, chezmoi, devbox, neovim]
+    needs: [changes, quality, format, lint, zsh-darwin, chezmoi, devbox, neovim]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/dot_local/share/devbox/global/default/devbox.json.tmpl
+++ b/dot_local/share/devbox/global/default/devbox.json.tmpl
@@ -20,6 +20,7 @@
     "delta@latest",
     "chezmoi@latest",
     "just@latest",
+    "lua54Packages.lua@5.4.7",
     "stylua@latest",
     "shfmt@latest",
     "shellcheck@latest",

--- a/justfile
+++ b/justfile
@@ -26,17 +26,90 @@ fmt-check:
     @echo "✓ All files formatted correctly!"
 
 # Run linters
-lint:
-    @echo "Checking zsh syntax..."
-    @for file in dot_zshrc.tmpl dot_zshenv.tmpl; do \
-        if [ -f "$file" ]; then \
-            sed 's/{{{{[^}]*}}}}//g' "$file" > /tmp/check.zsh; \
-            zsh -n /tmp/check.zsh && echo "✓ $file"; \
-        fi \
-    done
-    @echo "Checking lua syntax..."
-    @find dot_config/nvim -name "*.lua" -exec luac -p {} \; 2>/dev/null || true
+lint: lint-zsh lint-lua
     @echo "✓ Done!"
+
+# Check tracked zsh sources using the current runner OS.
+# The conditional chezmoi CI matrix separately expands templates on macOS and Linux.
+lint-zsh:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    for command in chezmoi git zsh; do
+      if ! command -v "$command" >/dev/null 2>&1; then
+        echo "✗ Required command not found: $command" >&2
+        exit 1
+      fi
+    done
+
+    echo "Checking tracked zsh files..."
+    while IFS= read -r -d '' file; do
+      zsh -n "$file"
+      echo "✓ $file"
+    done < <(git ls-files -z '*.zsh')
+
+    echo "Rendering zsh templates with isolated test data..."
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+    printf '{}\n' > "$tmpdir/chezmoi.json"
+
+    render_and_check() {
+      local label="$1"
+      local template="$2"
+      local data="$3"
+      local rendered="$tmpdir/$label-${template//\//-}"
+
+      chezmoi \
+        --config "$tmpdir/chezmoi.json" \
+        --config-format json \
+        --source "$PWD" \
+        --override-data "$data" \
+        execute-template --file "$template" > "$rendered"
+      zsh -n "$rendered"
+      echo "✓ $template ($label, current runner OS)"
+    }
+
+    # Render each nested template directly so it cannot hide behind a false
+    # condition in a top-level template.
+    standalone_data='{"business_use":false,"auto_tmux":false,"homebrew_prefix":"/opt/homebrew","grafana_instance_id":"test-instance","grafana_api_token":"test-api-token","grafana_sa_token":"test-sa-token"}'
+    while IFS= read -r -d '' template; do
+      render_and_check standalone "$template" "$standalone_data"
+    done < <(git ls-files -z '*.zsh.tmpl')
+
+    # Render the complete top-level shell configuration for each data branch.
+    for profile in personal-basic personal-telemetry business; do
+      case "$profile" in
+        personal-basic)
+          data='{"business_use":false,"auto_tmux":false,"homebrew_prefix":"/opt/homebrew","grafana_instance_id":"","grafana_api_token":"","grafana_sa_token":""}'
+          ;;
+        personal-telemetry)
+          data='{"business_use":false,"auto_tmux":false,"homebrew_prefix":"/opt/homebrew","grafana_instance_id":"test-instance","grafana_api_token":"test-api-token","grafana_sa_token":"test-sa-token"}'
+          ;;
+        business)
+          data='{"business_use":true,"auto_tmux":true,"homebrew_prefix":"/opt/homebrew","grafana_instance_id":"","grafana_api_token":"","grafana_sa_token":""}'
+          ;;
+      esac
+      while IFS= read -r -d '' template; do
+        render_and_check "$profile" "$template" "$data"
+      done < <(git ls-files -z 'dot_z*.tmpl')
+    done
+
+# Check Lua syntax. CI explicitly sets LUA_COMPILER=luac5.4 on Ubuntu.
+lint-lua:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    lua_compiler="${LUA_COMPILER:-luac}"
+    if ! command -v "$lua_compiler" >/dev/null 2>&1; then
+      echo "✗ Lua compiler not found: $lua_compiler" >&2
+      exit 1
+    fi
+
+    echo "Checking Lua syntax with $lua_compiler..."
+    while IFS= read -r -d '' file; do
+      "$lua_compiler" -p "$file"
+      echo "✓ $file"
+    done < <(git ls-files -z 'dot_config/nvim/*.lua' 'dot_config/nvim/**/*.lua')
 
 # Lint Provides header on zsh files (init/, modules/, features/)
 lint-headers:
@@ -49,8 +122,12 @@ lint-headers:
     done
     @echo "✓ Headers OK!"
 
+# Fast, hermetic checks that run unconditionally in CI.
+quality-gate: lint lint-headers test-hooks test-skill-scripts
+    @echo "✓ Fast quality gate passed!"
+
 # Run all checks
-test: lint lint-headers fmt-check test-hooks test-skill-scripts
+test: quality-gate fmt-check
     @echo "✓ All checks passed!"
 
 # Run hook tests
@@ -70,10 +147,10 @@ test-skills:
     @bash tests/skills/equity-decision/run-tests.sh
     @bash tests/skills/japanese-ai-writing-proofreader/run-tests.sh
 
-# Install formatter tools
+# Install local quality-gate and formatter tools
 install:
-    @echo "Installing formatters via devbox..."
-    @devbox global add stylua shfmt just
+    @echo "Installing quality-gate and formatter tools via devbox..."
+    @devbox global add stylua shfmt just lua54Packages.lua@5.4.7
     @echo "✓ Done!"
 
 # Apply dotfiles (dry-run)

--- a/tests/hooks/run-tests.sh
+++ b/tests/hooks/run-tests.sh
@@ -4,20 +4,95 @@
 # Each *.test.sh in this directory is invoked with HOOKS_DIR set to the
 # chezmoi source dir (dot_claude/hooks). Tests use bash to execute hook
 # scripts directly, so the executable bit and chezmoi prefix do not matter.
-set -uo pipefail
+set -euo pipefail
 
-cd "$(dirname "$0")"
-export HOOKS_DIR
-HOOKS_DIR="$(cd "../../dot_claude/hooks" && pwd)"
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+repo_root="$(cd "$script_dir/../.." && pwd -P)"
+source_root="$repo_root"
+
+if [[ -f "$repo_root/.chezmoiroot" ]]; then
+  source_relative=""
+  extra_line=""
+  exec 3<"$repo_root/.chezmoiroot"
+  IFS= read -r source_relative <&3 || [[ -n "$source_relative" ]]
+  if IFS= read -r extra_line <&3 || [[ -n "$extra_line" ]]; then
+    echo ".chezmoiroot must contain exactly one relative path" >&2
+    exit 1
+  fi
+  exec 3<&-
+
+  case "$source_relative" in
+    "")
+      echo ".chezmoiroot must not be empty" >&2
+      exit 1
+      ;;
+    /*)
+      echo ".chezmoiroot must be relative: $source_relative" >&2
+      exit 1
+      ;;
+  esac
+  case "/$source_relative/" in
+    */../*)
+      echo ".chezmoiroot must not contain parent traversal: $source_relative" >&2
+      exit 1
+      ;;
+  esac
+
+  if [[ ! -d "$repo_root/$source_relative" ]]; then
+    echo "chezmoi source root not found: $repo_root/$source_relative" >&2
+    exit 1
+  fi
+  source_root="$(cd "$repo_root/$source_relative" && pwd -P)"
+  case "$source_root" in
+    "$repo_root" | "$repo_root"/*) ;;
+    *)
+      echo "chezmoi source root escapes repository: $source_root" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+claude_source="$source_root/dot_claude"
+
+if [[ ! -d "$claude_source/hooks" ]]; then
+  echo "Claude source directory not found: $claude_source" >&2
+  exit 1
+fi
+
+tmp_parent="${TMPDIR:-/tmp}"
+tmp_parent="${tmp_parent%/}"
+test_home="$(mktemp -d "$tmp_parent/dots-hook-tests.XXXXXX")"
+case "$test_home" in
+  "$tmp_parent"/dots-hook-tests.*) ;;
+  *)
+    echo "Unexpected temporary HOME: $test_home" >&2
+    exit 1
+    ;;
+esac
+
+cleanup() {
+  case "$test_home" in
+    "$tmp_parent"/dots-hook-tests.*)
+      [[ ! -d "$test_home" ]] || rm -rf -- "$test_home"
+      ;;
+  esac
+}
+trap cleanup EXIT
+
+ln -s "$claude_source" "$test_home/.claude"
+export HOME="$test_home"
+export HOOKS_DIR="$claude_source/hooks"
 
 pass=0
 fail=0
+test_count=0
 failed_tests=()
-out=$(mktemp)
-trap 'rm -f "$out"' EXIT
+out="$test_home/test-output"
 
+cd "$script_dir"
 for test in *.test.sh; do
   [[ -f $test ]] || continue
+  test_count=$((test_count + 1))
   name=${test%.test.sh}
   if bash "$test" >"$out" 2>&1; then
     printf '  ok   %s\n' "$name"
@@ -30,6 +105,11 @@ for test in *.test.sh; do
   fi
 done
 
+if ((test_count == 0)); then
+  echo "No hook tests found in $script_dir" >&2
+  exit 1
+fi
+
 echo
-echo "passed: $pass  failed: $fail"
+echo "tests: $test_count  passed: $pass  failed: $fail"
 [[ $fail -eq 0 ]]


### PR DESCRIPTION
## Overview

Stack 1/3. Adds an unconditional fast quality gate and removes silent lint success paths.

- checks all tracked Zsh plus isolated personal, telemetry, business, Linux, and macOS template renders
- makes Lua parsing fail closed and provisions Lua 5.4 through devbox
- runs hook and hermetic Skill tests on every CI run
- requires change detection and macOS Zsh validation in the aggregate check
- installs a pinned chezmoi binary with hard-coded SHA-256 verification
- limits workflow token permissions
- runs pull-request CI for stacked bases, not only `main`
- verifies the checkout's effective chezmoi source root, representative mapping, and managed-target boundary fail closed

## Verification

- full `just test` with Lua 5.4
- actionlint
- ShellCheck and shfmt for CI shell
- checksummed chezmoi v2.70.5 install and version check
- root-layout and `.chezmoiroot=home` source-resolution checks
- `git diff --check`

## Adversarial review

Independent subagent reviewers covered bugs/security and conventions/simplicity before each commit. Follow-up reviews caught stacked-PR trigger, source-root, and pipefail edge cases; all were fixed and re-reviewed. Final review has no remaining CRITICAL or IMPORTANT findings.

## Stack

Base: `main`

Next: #212 (`refactor/chezmoi-source-root`)
