### PR TITLE
fix(db): remove generic destructive-command bypass

### DIFF
--- a/home/dot_claude/hooks/executable_block-destructive-db.sh
+++ b/home/dot_claude/hooks/executable_block-destructive-db.sh
@@ -7,12 +7,17 @@
 # DB. Recovery is hours; pausing is zero.
 #
 # Behavior:
-#   - Deny if the command matches a destructive DB pattern AND no explicit
-#     test-environment marker is present (RAILS_ENV=test, NODE_ENV=test,
-#     MIX_ENV=test).
+#   - Deny every known destructive database operation, even when the command
+#     contains a test-environment marker.
+#   - Inspect a conservative quote/backslash-normalized copy so simple shell
+#     token concatenation cannot hide a known destructive operation.
+#   - Runner-to-task matching may cross control operators. A command that only
+#     prints both strings can be paused; issue those diagnostics separately.
 #   - The deny is advisory: the user can override per-project via
 #     `.claude/settings.json` permissions.allow, or run the command in
 #     their own shell (the hook only sees tool-invoked Bash).
+#   - This is not a shell AST/dataflow evaluator. Agent rules prohibit
+#     dynamically constructing destructive DB commands.
 #
 # Reads Claude Code hook JSON from stdin; emits JSON on stdout when blocking.
 
@@ -21,49 +26,33 @@ set -euo pipefail
 cmd=$(jq -r '.tool_input.command // ""')
 [[ -n $cmd ]] || exit 0
 
-# Lowercase copy for case-insensitive matching via bash builtins (no subshells).
-# Avoids ${cmd,,} (bash 4+ only) and shopt -s nocasematch (version quirks).
-cmd_lc=$(printf '%s' "$cmd" | tr '[:upper:]' '[:lower:]')
-
-# Allowlist: if the command explicitly opts into a test environment, let it
-# through. Inheriting RAILS_ENV from the shell does not count — the marker
-# must be in the command itself.
-[[ $cmd_lc =~ (^|[[:space:]])(rails_env|node_env|mix_env|rack_env)=test([[:space:]]|$) ]] && exit 0
-[[ $cmd_lc =~ (^|[[:space:]])django_settings_module=[^[:space:]]*test ]]                  && exit 0
-
 # Destructive patterns across common stacks (written in lowercase ERE).
-# `\b` boundaries to avoid matching inside paths.
-# Tested with bash [[ =~ ]] — no subprocess per pattern.
+# Explicit non-identifier boundaries avoid substring matches. Runner-to-task
+# spans are intentionally broad so quoted/escaped shell separators inside CLI
+# option values cannot hide the destructive operation. This also crosses real
+# control operators by design; fail-closed review is safer than a shell parser.
+# \b is not supported in bash ERE; use ([^[:alnum:]_]|$) for word ends.
 patterns=(
-  # Rails / Rake / bin/rails (db:reset, db:drop, db:setup, db:schema:load)
-  # \b not supported in bash ERE; use ([^[:alnum:]_]|$) for end-of-word
-  '(rails|rake|bin/rails)[[:space:]]+db:(reset|drop|setup|schema:load|nuke)([^[:alnum:]_]|$)'
-  # Django
-  'manage\.py[[:space:]]+(flush|reset_db|sqlflush)([^[:alnum:]_]|$)'
-  # Prisma
-  'prisma[[:space:]]+migrate[[:space:]]+reset([^[:alnum:]_]|$)'
-  'prisma[[:space:]]+db[[:space:]]+push[^&|;]*--force-reset([^[:alnum:]_]|$)'
-  'prisma[[:space:]]+db[[:space:]]+seed[^&|;]*--reset([^[:alnum:]_]|$)'
-  # Sequelize CLI
-  'sequelize[[:space:]]+db:drop([^[:alnum:]_]|$)'
-  'sequelize[[:space:]]+db:migrate:undo:all([^[:alnum:]_]|$)'
-  # TypeORM
-  'typeorm[[:space:]]+schema:drop([^[:alnum:]_]|$)'
-  # Knex
-  'knex[[:space:]]+migrate:rollback[[:space:]]+--all([^[:alnum:]_]|$)'
-  # PostgreSQL — (^|[^[:alnum:]_]) for start-of-word too
+  '(rails|rake|bin/rails)[[:space:]]+.*db:(reset|drop|setup|schema:load|nuke)([^[:alnum:]_]|$)'
+  'manage\.py[[:space:]]+.*(flush|reset_db|sqlflush)([^[:alnum:]_]|$)'
+  'prisma[[:space:]]+.*migrate[[:space:]]+reset([^[:alnum:]_]|$)'
+  'prisma[[:space:]]+.*db[[:space:]]+push.*--force-reset([^[:alnum:]_]|$)'
+  'prisma[[:space:]]+.*db[[:space:]]+seed.*--reset([^[:alnum:]_]|$)'
+  'sequelize[[:space:]]+.*db:drop([^[:alnum:]_]|$)'
+  'sequelize[[:space:]]+.*db:migrate:undo:all([^[:alnum:]_]|$)'
+  'typeorm[[:space:]]+.*schema:drop([^[:alnum:]_]|$)'
+  'knex[[:space:]]+.*migrate:rollback[[:space:]]+.*--all([^[:alnum:]_]|$)'
   '(^|[^[:alnum:]_])dropdb([^[:alnum:]_]|$)'
-  # MySQL admin
-  'mysqladmin[[:space:]]+([^&|;]*[[:space:]])?drop([^[:alnum:]_]|$)'
-  # Raw SQL escaping into shell context
+  'mysqladmin[[:space:]]+(.*[[:space:]])?drop([^[:alnum:]_]|$)'
   'drop[[:space:]]+(database|schema)([^[:alnum:]_]|$)'
   'truncate([[:space:]]+table)?([^[:alnum:]_]|$)'
 )
 
-for p in "${patterns[@]}"; do
-  if [[ $cmd_lc =~ $p ]]; then
-    matched="$p"
-    reason="Destructive database operation blocked by the db-safety guard.
+deny_command() {
+  local matched=$1
+  local reason
+
+  reason="Destructive database operation blocked by the db-safety guard.
 
 Matched pattern: $matched
 Command: $cmd
@@ -76,23 +65,37 @@ them with a destructive reset.
 If a reset is genuinely needed:
   1. Run the command yourself in your shell (this guard only blocks
      tool-invoked Bash), or
-  2. Run with an explicit test-environment marker:
-       RAILS_ENV=test <command>     # or NODE_ENV=test / MIX_ENV=test
-  3. Add a per-project allow rule in .claude/settings.json:
+  2. Add a narrowly scoped per-project allow rule in .claude/settings.json:
        permissions.allow: [\"Bash(<the specific command>:*)\"]
+
+Test-environment markers are not an automatic exception: they do not prove
+which datasource a framework or raw database client will actually target.
 
 For sub-agents: do NOT escalate to a destructive command to clear a flaky
 test. Stop and report the failing command + error to the parent."
 
-    jq -n --arg reason "$reason" '{
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: $reason
-      }
-    }'
-    exit 0
-  fi
+  jq -n --arg reason "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+# Conservatively join every backslash-newline and remove quote/backslash
+# concatenation before deny matching. Over-normalization can only produce a
+# pause for review; there is no automatic allow path.
+cmd_scan=${cmd//$'\\\n'/}
+cmd_scan=${cmd_scan//\"/}
+cmd_scan=${cmd_scan//\'/}
+cmd_scan=${cmd_scan//\\/}
+cmd_scan_lc=$(printf '%s' "$cmd_scan" | tr '[:upper:]' '[:lower:]')
+
+for i in "${!patterns[@]}"; do
+  p=${patterns[$i]}
+  [[ $cmd_scan_lc =~ $p ]] && deny_command "$p"
 done
 
 exit 0

--- a/home/dot_claude/rules/db-safety.md
+++ b/home/dot_claude/rules/db-safety.md
@@ -1,8 +1,9 @@
 # Database Safety
 
-A PreToolUse Bash hook (`block-destructive-db.sh`) denies destructive database commands (`db:reset`, `prisma migrate reset`, `TRUNCATE`, `DROP DATABASE`, …) unless the command explicitly opts into a test environment. The rules below cover the judgment the hook cannot make.
+A PreToolUse Bash hook (`block-destructive-db.sh`) denies known destructive database commands (`db:reset`, `prisma migrate reset`, `TRUNCATE`, `DROP DATABASE`, …) regardless of test-environment markers. Generic markers such as `NODE_ENV=test` do not prove which datasource a framework or raw client will target. The rules below cover the judgment the hook cannot make.
 
 - Never wipe a database to recover from a transient error (concurrent-test schema noise, flaky migrations, stale fixtures). These are environment problems; a reset destroys dev data that lives in no seed or snapshot.
 - On schema/DDL errors: stop the destructive plan, capture the exact error and command, report with that evidence, and wait for instruction. Whether a reset is acceptable is the user's call — they know what dev data they have.
-- Set the test environment in the same command (`RAILS_ENV=test`, `NODE_ENV=test`, `MIX_ENV=test`, …) — inherited shell env is how "test cleanup" wipes development.
-- To run a destructive command deliberately: run it in your own shell (the hook only blocks tool-invoked commands), or add a per-project allow rule in `.claude/settings.json` for the specific pattern.
+- Never construct a destructive database command dynamically with parameter, brace, glob, or runtime data expansion. The hook recognizes known literal patterns and simple quote/backslash concatenation; it is an advisory guard, not a shell AST/dataflow evaluator.
+- The guard may conservatively match a database runner and destructive task text across shell control operators. If a diagnostic only needs to print or search those strings, issue it as a separate Bash call.
+- A test marker does not bypass the hook. To run a destructive command deliberately, run it in your own shell (the hook only blocks tool-invoked commands), or add a narrowly scoped per-project allow rule in `.claude/settings.json` for the specific command.

--- a/tests/hooks/block-destructive-db.test.sh
+++ b/tests/hooks/block-destructive-db.test.sh
@@ -1,20 +1,32 @@
 #!/usr/bin/env bash
 # Tests for executable_block-destructive-db.sh: PreToolUse(Bash) guard
-# that denies destructive database operations unless an explicit test-env
-# marker is present in the command itself.
-set -uo pipefail
+# that denies known destructive database operations regardless of
+# test-environment markers.
+set -euo pipefail
 
 hook="$HOOKS_DIR/executable_block-destructive-db.sh"
-[[ -f $hook ]] || { echo "hook not found: $hook"; exit 1; }
+[[ -f $hook ]] || {
+  echo "hook not found: $hook"
+  exit 1
+}
 
-# run "<json>" — pipe JSON to hook, capture stdout.
+# run "<json>" — pipe JSON to the hook, capture stdout.
 run() { printf '%s' "$1" | bash "$hook"; }
+
+run_command() {
+  local payload
+  payload=$(jq -nc --arg command "$1" '{tool_name:"Bash",tool_input:{command:$command}}')
+  run "$payload"
+}
 
 is_block() {
   echo "$1" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null
 }
 
-fail() { echo "FAIL: $1"; exit 1; }
+fail() {
+  echo "FAIL: $1"
+  exit 1
+}
 
 # ────────────────────────────────────────────────────────
 # DENY: Rails / Rake / bin/rails
@@ -61,17 +73,204 @@ out=$(run '{"tool_name":"Bash","tool_input":{"command":"mysql -e \"TRUNCATE TABL
 is_block "$out" || fail "should deny: mysql -e TRUNCATE TABLE — got: $out"
 
 # ────────────────────────────────────────────────────────
-# ALLOW: explicit test-env markers
+# DENY: test-env markers are not datasource proof
 # ────────────────────────────────────────────────────────
 
 out=$(run '{"tool_name":"Bash","tool_input":{"command":"RAILS_ENV=test bundle exec rails db:reset"}}')
-[[ -z $out ]] || fail "should allow: RAILS_ENV=test rails db:reset — got: $out"
+is_block "$out" || fail "should deny despite RAILS_ENV=test — got: $out"
 
-out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx prisma migrate reset"}}')
-[[ -z $out ]] || fail "should allow: NODE_ENV=test prisma migrate reset — got: $out"
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny despite NODE_ENV=test — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"CI=1 NODE_ENV=test npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny despite preceding env assignment — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"env NODE_ENV=test npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny env-prefixed NODE_ENV=test — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=production NODE_ENV=test npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny despite final NODE_ENV=test — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=\"test\" npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny quoted literal test value — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx knex migrate:rollback --all"}}')
+is_block "$out" || fail "should deny despite NODE_ENV=test knex rollback — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"RACK_ENV=test bundle exec rake db:drop"}}')
+is_block "$out" || fail "should deny despite RACK_ENV=test — got: $out"
 
 out=$(run '{"tool_name":"Bash","tool_input":{"command":"DJANGO_SETTINGS_MODULE=app.settings.test python manage.py flush"}}')
-[[ -z $out ]] || fail "should allow: DJANGO_SETTINGS_MODULE=*test manage.py flush — got: $out"
+is_block "$out" || fail "should deny despite test Django settings — got: $out"
+
+# Test markers never bypass any supported runner shape.
+marked_destructive_commands=(
+  'RAILS_ENV=test ./bin/rails db:drop'
+  'NODE_ENV=test sequelize db:drop'
+  'NODE_ENV=test ./node_modules/.bin/knex migrate:rollback --all'
+  'NODE_ENV=test bunx sequelize db:drop'
+  'NODE_ENV=test pnpm exec sequelize db:drop'
+  'NODE_ENV=test yarn knex migrate:rollback --all'
+  'NODE_ENV=test npm exec -- sequelize db:drop'
+  'DJANGO_SETTINGS_MODULE=app.settings.test ./manage.py flush'
+  'DJANGO_SETTINGS_MODULE=app.settings.test uv run python manage.py flush'
+  'DJANGO_SETTINGS_MODULE=app.settings.test poetry run python manage.py flush'
+  'DJANGO_SETTINGS_MODULE=app.settings.test pipenv run python manage.py flush'
+)
+
+for command in "${marked_destructive_commands[@]}"; do
+  out=$(run_command "$command")
+  is_block "$out" || fail "should deny marked destructive command: $command — got: $out"
+done
+
+# ────────────────────────────────────────────────────────
+# DENY: unrelated or incorrectly scoped test-env markers
+# ────────────────────────────────────────────────────────
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npm test && rails db:reset"}}')
+is_block "$out" || fail "should deny marker on an earlier command — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"echo NODE_ENV=test; npx prisma migrate reset"}}')
+is_block "$out" || fail "should deny marker used as an argument — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test rails db:reset"}}')
+is_block "$out" || fail "should deny Node marker for Rails — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"RAILS_ENV=test npx prisma migrate reset"}}')
+is_block "$out" || fail "should deny Rails marker for Prisma — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop && rails db:drop"}}')
+is_block "$out" || fail "should inspect every destructive command — got: $out"
+
+# shellcheck disable=SC2016 # command substitution must remain literal test input
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test echo \"$(npx sequelize db:drop)\""}}')
+is_block "$out" || fail "should deny destructive command substitution — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test cat <(npx sequelize db:drop)"}}')
+is_block "$out" || fail "should deny input process substitution — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test tee >(npx sequelize db:drop)"}}')
+is_block "$out" || fail "should deny output process substitution — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"DJANGO_SETTINGS_MODULE=app.settings.latest python manage.py flush"}}')
+is_block "$out" || fail "should deny non-test Django settings module — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"DJANGO_SETTINGS_MODULE=app.settings.production_test python manage.py flush"}}')
+is_block "$out" || fail "should deny Django test substring — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"DJANGO_SETTINGS_MODULE=app.test.production python manage.py flush"}}')
+is_block "$out" || fail "should deny non-final Django test component — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"node_env=test npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny lowercase node_env — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=TEST npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny uppercase TEST value — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test NODE_ENV=development npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny later NODE_ENV override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test env -u NODE_ENV npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny later env removal — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test sh -c \"NODE_ENV=production npx sequelize db:drop\""}}')
+is_block "$out" || fail "should deny nested shell override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test /bin/\"sh\" -c \"NODE_ENV=production npx sequelize db:drop\""}}')
+is_block "$out" || fail "should deny quote-concatenated nested shell — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test dash -c \"NODE_ENV=production npx sequelize db:drop\""}}')
+is_block "$out" || fail "should deny unlisted nested shell — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test e\"nv\" -u NODE_ENV npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny quote-concatenated env removal — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test DATABASE_URL=postgresql://localhost/app_development npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny explicit database connection override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop --env production"}}')
+is_block "$out" || fail "should deny Sequelize environment override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop --url postgresql://localhost/app_production"}}')
+is_block "$out" || fail "should deny Sequelize connection override — got: $out"
+
+# shellcheck disable=SC2016 # variable expansion must remain literal test input
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop $EXTRA_ARGS"}}')
+is_block "$out" || fail "should deny dynamic argument expansion — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop {--env,production}"}}')
+is_block "$out" || fail "should deny brace-expanded override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop *"}}')
+is_block "$out" || fail "should deny glob-expanded arguments — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx knex migrate:rollback --all --env production"}}')
+is_block "$out" || fail "should deny Knex environment override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"DJANGO_SETTINGS_MODULE=app.settings.test python manage.py flush --settings=app.settings.production"}}')
+is_block "$out" || fail "should deny Django settings override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize --env production db:drop"}}')
+is_block "$out" || fail "should deny Sequelize override before operation — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx knex --knexfile ./production.js migrate:rollback --all"}}')
+is_block "$out" || fail "should deny Knex override before operation — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"RAILS_ENV=test bundle exec rails --environment production db:drop"}}')
+is_block "$out" || fail "should deny Rails override before operation — got: $out"
+
+# Quoted or escaped separators inside option values stay in one shell command.
+out=$(run_command "NODE_ENV=test npx sequelize --config 'config;test.js' db:drop")
+is_block "$out" || fail "should deny Sequelize after quoted semicolon — got: $out"
+
+out=$(run_command 'NODE_ENV=test npx sequelize --config=config\;test.js db:drop')
+is_block "$out" || fail "should deny Sequelize after escaped semicolon — got: $out"
+
+out=$(run_command "NODE_ENV=test npx knex --knexfile 'knex|test.js' migrate:rollback --all")
+is_block "$out" || fail "should deny Knex after quoted pipe — got: $out"
+
+out=$(run_command "npx typeorm --dataSource 'foo;bar.ts' schema:drop")
+is_block "$out" || fail "should deny TypeORM after quoted semicolon — got: $out"
+
+# The deny-only scan intentionally crosses real control operators too. Split
+# diagnostics into separate Bash calls if they only print these strings.
+out=$(run_command "sequelize --help; echo 'db:drop'")
+is_block "$out" || fail "should conservatively deny cross-command task text — got: $out"
+
+# A backslash-newline is conservatively denied. Blindly removing it would
+# incorrectly join even-backslash newlines, which are real shell separators.
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test \\\nnpx sequelize db:drop"}}')
+is_block "$out" || fail "should deny ambiguous line continuation — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test echo \\\\\nnpx sequelize db:drop"}}')
+is_block "$out" || fail "should deny even-backslash newline separator — got: $out"
+
+# Deny detection canonicalizes shell token construction before matching.
+out=$(run_command 'NODE_ENV=production npx se"quelize" db:drop')
+is_block "$out" || fail "should deny quote-constructed runner — got: $out"
+
+out=$(run_command 'NODE_ENV=production npx sequelize db:"drop"')
+is_block "$out" || fail "should deny quote-constructed operation — got: $out"
+
+out=$(run_command 'NODE_ENV=production npx seque\lize db:drop')
+is_block "$out" || fail "should deny backslash-constructed runner — got: $out"
+
+out=$(run_command 'dr"opdb" app_production')
+is_block "$out" || fail "should deny quote-constructed raw client — got: $out"
+
+# NODE_ENV does not select the Prisma or TypeORM datasource.
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx prisma migrate reset"}}')
+is_block "$out" || fail "should deny Prisma despite NODE_ENV=test — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx typeorm schema:drop"}}')
+is_block "$out" || fail "should deny TypeORM despite NODE_ENV=test — got: $out"
+
+# Raw clients select their target independently of application env markers.
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test psql -c \"DROP DATABASE foo\""}}')
+is_block "$out" || fail "should deny raw SQL despite NODE_ENV=test — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"RAILS_ENV=test dropdb myapp_test"}}')
+is_block "$out" || fail "should deny dropdb despite RAILS_ENV=test — got: $out"
 
 # ────────────────────────────────────────────────────────
 # ALLOW: non-destructive commands
@@ -92,7 +291,7 @@ out=$(run '{"tool_name":"Read","tool_input":{"file_path":"db/schema.rb"}}')
 
 # ────────────────────────────────────────────────────────
 # DENY: case-insensitivity — mixed-case commands still blocked
-# (current hook uses grep -i, so DB:RESET must still be caught)
+# (the detection copy is lowercased before pattern matching)
 # ────────────────────────────────────────────────────────
 
 out=$(run '{"tool_name":"Bash","tool_input":{"command":"Rails DB:RESET"}}')


### PR DESCRIPTION
## Summary

- Deny every known destructive database operation regardless of RAILS_ENV, NODE_ENV, RACK_ENV, or Django test-settings markers.
- Match destructive operations even when CLI options precede the task or quote/backslash concatenation obscures tokens.
- Conservatively scan runner-to-task text across control operators so quoted or escaped separators cannot create a bypass.
- Document that dynamic shell dataflow is outside this advisory hook and prohibit agents from constructing destructive DB commands dynamically.

## Behavior change

A test-environment marker no longer authorizes tool-invoked database resets, drops, truncates, or equivalent operations. Run an intentional destructive command in a user-owned shell or configure a narrowly scoped project-specific exception.

## Verification

- Acceptance adversarial review: CRITICAL 0 / IMPORTANT 0 / MINOR 0.
- Security adversarial review: CRITICAL 0 / IMPORTANT 0 / MINOR 0.
- Simplicity adversarial review: CRITICAL 0 / IMPORTANT 0 / MINOR 0.
- macOS Bash 3.2 focused suite, Bash syntax, ShellCheck, shfmt, and diff checks passed.
- Full Nix-backed just test passed.