### PR TITLE
fix(pr-monitor): paginate review threads safely

### DIFF
--- a/home/dot_claude/hooks/executable_block-destructive-db.sh
+++ b/home/dot_claude/hooks/executable_block-destructive-db.sh
@@ -7,12 +7,17 @@
 # DB. Recovery is hours; pausing is zero.
 #
 # Behavior:
-#   - Deny if the command matches a destructive DB pattern AND no explicit
-#     test-environment marker is present (RAILS_ENV=test, NODE_ENV=test,
-#     MIX_ENV=test).
+#   - Deny every known destructive database operation, even when the command
+#     contains a test-environment marker.
+#   - Inspect a conservative quote/backslash-normalized copy so simple shell
+#     token concatenation cannot hide a known destructive operation.
+#   - Runner-to-task matching may cross control operators. A command that only
+#     prints both strings can be paused; issue those diagnostics separately.
 #   - The deny is advisory: the user can override per-project via
 #     `.claude/settings.json` permissions.allow, or run the command in
 #     their own shell (the hook only sees tool-invoked Bash).
+#   - This is not a shell AST/dataflow evaluator. Agent rules prohibit
+#     dynamically constructing destructive DB commands.
 #
 # Reads Claude Code hook JSON from stdin; emits JSON on stdout when blocking.
 
@@ -21,49 +26,33 @@ set -euo pipefail
 cmd=$(jq -r '.tool_input.command // ""')
 [[ -n $cmd ]] || exit 0
 
-# Lowercase copy for case-insensitive matching via bash builtins (no subshells).
-# Avoids ${cmd,,} (bash 4+ only) and shopt -s nocasematch (version quirks).
-cmd_lc=$(printf '%s' "$cmd" | tr '[:upper:]' '[:lower:]')
-
-# Allowlist: if the command explicitly opts into a test environment, let it
-# through. Inheriting RAILS_ENV from the shell does not count — the marker
-# must be in the command itself.
-[[ $cmd_lc =~ (^|[[:space:]])(rails_env|node_env|mix_env|rack_env)=test([[:space:]]|$) ]] && exit 0
-[[ $cmd_lc =~ (^|[[:space:]])django_settings_module=[^[:space:]]*test ]]                  && exit 0
-
 # Destructive patterns across common stacks (written in lowercase ERE).
-# `\b` boundaries to avoid matching inside paths.
-# Tested with bash [[ =~ ]] — no subprocess per pattern.
+# Explicit non-identifier boundaries avoid substring matches. Runner-to-task
+# spans are intentionally broad so quoted/escaped shell separators inside CLI
+# option values cannot hide the destructive operation. This also crosses real
+# control operators by design; fail-closed review is safer than a shell parser.
+# \b is not supported in bash ERE; use ([^[:alnum:]_]|$) for word ends.
 patterns=(
-  # Rails / Rake / bin/rails (db:reset, db:drop, db:setup, db:schema:load)
-  # \b not supported in bash ERE; use ([^[:alnum:]_]|$) for end-of-word
-  '(rails|rake|bin/rails)[[:space:]]+db:(reset|drop|setup|schema:load|nuke)([^[:alnum:]_]|$)'
-  # Django
-  'manage\.py[[:space:]]+(flush|reset_db|sqlflush)([^[:alnum:]_]|$)'
-  # Prisma
-  'prisma[[:space:]]+migrate[[:space:]]+reset([^[:alnum:]_]|$)'
-  'prisma[[:space:]]+db[[:space:]]+push[^&|;]*--force-reset([^[:alnum:]_]|$)'
-  'prisma[[:space:]]+db[[:space:]]+seed[^&|;]*--reset([^[:alnum:]_]|$)'
-  # Sequelize CLI
-  'sequelize[[:space:]]+db:drop([^[:alnum:]_]|$)'
-  'sequelize[[:space:]]+db:migrate:undo:all([^[:alnum:]_]|$)'
-  # TypeORM
-  'typeorm[[:space:]]+schema:drop([^[:alnum:]_]|$)'
-  # Knex
-  'knex[[:space:]]+migrate:rollback[[:space:]]+--all([^[:alnum:]_]|$)'
-  # PostgreSQL — (^|[^[:alnum:]_]) for start-of-word too
+  '(rails|rake|bin/rails)[[:space:]]+.*db:(reset|drop|setup|schema:load|nuke)([^[:alnum:]_]|$)'
+  'manage\.py[[:space:]]+.*(flush|reset_db|sqlflush)([^[:alnum:]_]|$)'
+  'prisma[[:space:]]+.*migrate[[:space:]]+reset([^[:alnum:]_]|$)'
+  'prisma[[:space:]]+.*db[[:space:]]+push.*--force-reset([^[:alnum:]_]|$)'
+  'prisma[[:space:]]+.*db[[:space:]]+seed.*--reset([^[:alnum:]_]|$)'
+  'sequelize[[:space:]]+.*db:drop([^[:alnum:]_]|$)'
+  'sequelize[[:space:]]+.*db:migrate:undo:all([^[:alnum:]_]|$)'
+  'typeorm[[:space:]]+.*schema:drop([^[:alnum:]_]|$)'
+  'knex[[:space:]]+.*migrate:rollback[[:space:]]+.*--all([^[:alnum:]_]|$)'
   '(^|[^[:alnum:]_])dropdb([^[:alnum:]_]|$)'
-  # MySQL admin
-  'mysqladmin[[:space:]]+([^&|;]*[[:space:]])?drop([^[:alnum:]_]|$)'
-  # Raw SQL escaping into shell context
+  'mysqladmin[[:space:]]+(.*[[:space:]])?drop([^[:alnum:]_]|$)'
   'drop[[:space:]]+(database|schema)([^[:alnum:]_]|$)'
   'truncate([[:space:]]+table)?([^[:alnum:]_]|$)'
 )
 
-for p in "${patterns[@]}"; do
-  if [[ $cmd_lc =~ $p ]]; then
-    matched="$p"
-    reason="Destructive database operation blocked by the db-safety guard.
+deny_command() {
+  local matched=$1
+  local reason
+
+  reason="Destructive database operation blocked by the db-safety guard.
 
 Matched pattern: $matched
 Command: $cmd
@@ -76,23 +65,37 @@ them with a destructive reset.
 If a reset is genuinely needed:
   1. Run the command yourself in your shell (this guard only blocks
      tool-invoked Bash), or
-  2. Run with an explicit test-environment marker:
-       RAILS_ENV=test <command>     # or NODE_ENV=test / MIX_ENV=test
-  3. Add a per-project allow rule in .claude/settings.json:
+  2. Add a narrowly scoped per-project allow rule in .claude/settings.json:
        permissions.allow: [\"Bash(<the specific command>:*)\"]
+
+Test-environment markers are not an automatic exception: they do not prove
+which datasource a framework or raw database client will actually target.
 
 For sub-agents: do NOT escalate to a destructive command to clear a flaky
 test. Stop and report the failing command + error to the parent."
 
-    jq -n --arg reason "$reason" '{
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: $reason
-      }
-    }'
-    exit 0
-  fi
+  jq -n --arg reason "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+# Conservatively join every backslash-newline and remove quote/backslash
+# concatenation before deny matching. Over-normalization can only produce a
+# pause for review; there is no automatic allow path.
+cmd_scan=${cmd//$'\\\n'/}
+cmd_scan=${cmd_scan//\"/}
+cmd_scan=${cmd_scan//\'/}
+cmd_scan=${cmd_scan//\\/}
+cmd_scan_lc=$(printf '%s' "$cmd_scan" | tr '[:upper:]' '[:lower:]')
+
+for i in "${!patterns[@]}"; do
+  p=${patterns[$i]}
+  [[ $cmd_scan_lc =~ $p ]] && deny_command "$p"
 done
 
 exit 0

--- a/home/dot_claude/rules/db-safety.md
+++ b/home/dot_claude/rules/db-safety.md
@@ -1,8 +1,9 @@
 # Database Safety
 
-A PreToolUse Bash hook (`block-destructive-db.sh`) denies destructive database commands (`db:reset`, `prisma migrate reset`, `TRUNCATE`, `DROP DATABASE`, …) unless the command explicitly opts into a test environment. The rules below cover the judgment the hook cannot make.
+A PreToolUse Bash hook (`block-destructive-db.sh`) denies known destructive database commands (`db:reset`, `prisma migrate reset`, `TRUNCATE`, `DROP DATABASE`, …) regardless of test-environment markers. Generic markers such as `NODE_ENV=test` do not prove which datasource a framework or raw client will target. The rules below cover the judgment the hook cannot make.
 
 - Never wipe a database to recover from a transient error (concurrent-test schema noise, flaky migrations, stale fixtures). These are environment problems; a reset destroys dev data that lives in no seed or snapshot.
 - On schema/DDL errors: stop the destructive plan, capture the exact error and command, report with that evidence, and wait for instruction. Whether a reset is acceptable is the user's call — they know what dev data they have.
-- Set the test environment in the same command (`RAILS_ENV=test`, `NODE_ENV=test`, `MIX_ENV=test`, …) — inherited shell env is how "test cleanup" wipes development.
-- To run a destructive command deliberately: run it in your own shell (the hook only blocks tool-invoked commands), or add a per-project allow rule in `.claude/settings.json` for the specific pattern.
+- Never construct a destructive database command dynamically with parameter, brace, glob, or runtime data expansion. The hook recognizes known literal patterns and simple quote/backslash concatenation; it is an advisory guard, not a shell AST/dataflow evaluator.
+- The guard may conservatively match a database runner and destructive task text across shell control operators. If a diagnostic only needs to print or search those strings, issue it as a separate Bash call.
+- A test marker does not bypass the hook. To run a destructive command deliberately, run it in your own shell (the hook only blocks tool-invoked commands), or add a narrowly scoped per-project allow rule in `.claude/settings.json` for the specific command.

--- a/home/dot_claude/skills/pr-monitor/scripts/pr-monitor.sh
+++ b/home/dot_claude/skills/pr-monitor/scripts/pr-monitor.sh
@@ -22,25 +22,75 @@ UNTIL=${5:-green}
 INTERVAL=${PR_MONITOR_INTERVAL:-30}
 MAX_POLLS=${PR_MONITOR_MAX_POLLS:-0}
 
-THREADS_QUERY='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{isResolved}}}}}'
+THREADS_QUERY="query(\$o:String!,\$r:String!,\$n:Int!,\$after:String){repository(owner:\$o,name:\$r){pullRequest(number:\$n){reviewThreads(first:100,after:\$after){nodes{isResolved}pageInfo{hasNextPage endCursor}}}}}"
 
 last_state=""
 polls=0
 errors=0
 
+fetch_threads() {
+  local after=""
+  local seen=$'\n'
+  local page stats has_next next page_total page_unresolved
+  local pages=0
+  local total=0
+  local unresolved=0
+  local -a args
+
+  while true; do
+    # Bound each poll even if the API returns an endless sequence of cursors.
+    ((pages >= 100)) && return 1
+    pages=$((pages + 1))
+
+    args=(api graphql -f query="$THREADS_QUERY" -f o="$OWNER" -f r="$REPO" -F n="$PR")
+    [[ -n $after ]] && args+=(-f after="$after")
+    page=$(gh "${args[@]}" 2>/dev/null) || return 1
+
+    stats=$(jq -ec '
+      select(
+        (.errors == null)
+        or ((.errors | type) == "array" and (.errors | length) == 0)
+      )
+      | .data.repository.pullRequest.reviewThreads
+      | select((.nodes | type) == "array")
+      | select(all(.nodes[]; (.isResolved | type) == "boolean"))
+      | select((.pageInfo.hasNextPage | type) == "boolean")
+      | { total: (.nodes | length),
+          unresolved: ([.nodes[] | select(.isResolved == false)] | length),
+          hasNextPage: .pageInfo.hasNextPage,
+          endCursor: .pageInfo.endCursor }' <<<"$page") || return 1
+
+    page_total=$(jq -r '.total' <<<"$stats")
+    page_unresolved=$(jq -r '.unresolved' <<<"$stats")
+    total=$((total + page_total))
+    unresolved=$((unresolved + page_unresolved))
+
+    has_next=$(jq -r '.hasNextPage' <<<"$stats")
+    [[ $has_next == true ]] || break
+
+    next=$(jq -er '.endCursor | select(type == "string" and length > 0)' <<<"$stats") || return 1
+    [[ $seen == *$'\n'"$next"$'\n'* ]] && return 1
+    seen+="$next"$'\n'
+    after=$next
+  done
+
+  jq -cn --argjson total "$total" --argjson unresolved "$unresolved" \
+    '{total: $total, unresolved: $unresolved}'
+}
+
 while true; do
   polls=$((polls + 1))
-  if (( MAX_POLLS > 0 && polls > MAX_POLLS )); then
+  if ((MAX_POLLS > 0 && polls > MAX_POLLS)); then
     echo "[TIMEOUT] max polls reached"
     exit 1
   fi
 
   if pr_json=$(gh pr view "$PR" --repo "$OWNER/$REPO" --json state,statusCheckRollup 2>/dev/null) &&
-     th_json=$(gh api graphql -f query="$THREADS_QUERY" -F o="$OWNER" -F r="$REPO" -F n="$PR" 2>/dev/null); then
+    threads=$(fetch_threads); then
     errors=0
   else
     errors=$((errors + 1))
-    if (( errors % 3 == 0 )); then
+    if ((errors % 3 == 0)); then
       echo "[POLL_ERROR] $errors consecutive fetch failures — check gh auth / network"
     fi
     sleep "$INTERVAL"
@@ -59,10 +109,6 @@ while true; do
         pending: (.total - .ok - (.failures | length)),
         failed: (.failures | length),
         failures }' <<<"$pr_json")
-  threads=$(jq -c '
-    [.data.repository.pullRequest.reviewThreads.nodes[]?.isResolved]
-    | {total: length, unresolved: ([.[] | select(. == false)] | length)}' <<<"$th_json")
-
   state="CI $ci | Reviews $threads | PR $pr_state"
   if [[ $state != "$last_state" ]]; then
     echo "$state"
@@ -70,15 +116,21 @@ while true; do
   fi
 
   case $pr_state in
-    MERGED) echo "DONE: merged"; exit 0 ;;
-    CLOSED) echo "DONE: closed without merge"; exit 0 ;;
+    MERGED)
+      echo "DONE: merged"
+      exit 0
+      ;;
+    CLOSED)
+      echo "DONE: closed without merge"
+      exit 0
+      ;;
   esac
 
   if [[ $UNTIL == green ]]; then
     pending=$(jq -r '.pending' <<<"$ci")
     failed=$(jq -r '.failed' <<<"$ci")
     unresolved=$(jq -r '.unresolved' <<<"$threads")
-    if (( pending == 0 && failed == 0 && unresolved == 0 )); then
+    if ((pending == 0 && failed == 0 && unresolved == 0)); then
       echo "DONE: all checks green and threads resolved"
       exit 0
     fi

--- a/tests/hooks/block-destructive-db.test.sh
+++ b/tests/hooks/block-destructive-db.test.sh
@@ -1,20 +1,32 @@
 #!/usr/bin/env bash
 # Tests for executable_block-destructive-db.sh: PreToolUse(Bash) guard
-# that denies destructive database operations unless an explicit test-env
-# marker is present in the command itself.
-set -uo pipefail
+# that denies known destructive database operations regardless of
+# test-environment markers.
+set -euo pipefail
 
 hook="$HOOKS_DIR/executable_block-destructive-db.sh"
-[[ -f $hook ]] || { echo "hook not found: $hook"; exit 1; }
+[[ -f $hook ]] || {
+  echo "hook not found: $hook"
+  exit 1
+}
 
-# run "<json>" — pipe JSON to hook, capture stdout.
+# run "<json>" — pipe JSON to the hook, capture stdout.
 run() { printf '%s' "$1" | bash "$hook"; }
+
+run_command() {
+  local payload
+  payload=$(jq -nc --arg command "$1" '{tool_name:"Bash",tool_input:{command:$command}}')
+  run "$payload"
+}
 
 is_block() {
   echo "$1" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null
 }
 
-fail() { echo "FAIL: $1"; exit 1; }
+fail() {
+  echo "FAIL: $1"
+  exit 1
+}
 
 # ────────────────────────────────────────────────────────
 # DENY: Rails / Rake / bin/rails
@@ -61,17 +73,204 @@ out=$(run '{"tool_name":"Bash","tool_input":{"command":"mysql -e \"TRUNCATE TABL
 is_block "$out" || fail "should deny: mysql -e TRUNCATE TABLE — got: $out"
 
 # ────────────────────────────────────────────────────────
-# ALLOW: explicit test-env markers
+# DENY: test-env markers are not datasource proof
 # ────────────────────────────────────────────────────────
 
 out=$(run '{"tool_name":"Bash","tool_input":{"command":"RAILS_ENV=test bundle exec rails db:reset"}}')
-[[ -z $out ]] || fail "should allow: RAILS_ENV=test rails db:reset — got: $out"
+is_block "$out" || fail "should deny despite RAILS_ENV=test — got: $out"
 
-out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx prisma migrate reset"}}')
-[[ -z $out ]] || fail "should allow: NODE_ENV=test prisma migrate reset — got: $out"
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny despite NODE_ENV=test — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"CI=1 NODE_ENV=test npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny despite preceding env assignment — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"env NODE_ENV=test npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny env-prefixed NODE_ENV=test — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=production NODE_ENV=test npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny despite final NODE_ENV=test — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=\"test\" npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny quoted literal test value — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx knex migrate:rollback --all"}}')
+is_block "$out" || fail "should deny despite NODE_ENV=test knex rollback — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"RACK_ENV=test bundle exec rake db:drop"}}')
+is_block "$out" || fail "should deny despite RACK_ENV=test — got: $out"
 
 out=$(run '{"tool_name":"Bash","tool_input":{"command":"DJANGO_SETTINGS_MODULE=app.settings.test python manage.py flush"}}')
-[[ -z $out ]] || fail "should allow: DJANGO_SETTINGS_MODULE=*test manage.py flush — got: $out"
+is_block "$out" || fail "should deny despite test Django settings — got: $out"
+
+# Test markers never bypass any supported runner shape.
+marked_destructive_commands=(
+  'RAILS_ENV=test ./bin/rails db:drop'
+  'NODE_ENV=test sequelize db:drop'
+  'NODE_ENV=test ./node_modules/.bin/knex migrate:rollback --all'
+  'NODE_ENV=test bunx sequelize db:drop'
+  'NODE_ENV=test pnpm exec sequelize db:drop'
+  'NODE_ENV=test yarn knex migrate:rollback --all'
+  'NODE_ENV=test npm exec -- sequelize db:drop'
+  'DJANGO_SETTINGS_MODULE=app.settings.test ./manage.py flush'
+  'DJANGO_SETTINGS_MODULE=app.settings.test uv run python manage.py flush'
+  'DJANGO_SETTINGS_MODULE=app.settings.test poetry run python manage.py flush'
+  'DJANGO_SETTINGS_MODULE=app.settings.test pipenv run python manage.py flush'
+)
+
+for command in "${marked_destructive_commands[@]}"; do
+  out=$(run_command "$command")
+  is_block "$out" || fail "should deny marked destructive command: $command — got: $out"
+done
+
+# ────────────────────────────────────────────────────────
+# DENY: unrelated or incorrectly scoped test-env markers
+# ────────────────────────────────────────────────────────
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npm test && rails db:reset"}}')
+is_block "$out" || fail "should deny marker on an earlier command — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"echo NODE_ENV=test; npx prisma migrate reset"}}')
+is_block "$out" || fail "should deny marker used as an argument — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test rails db:reset"}}')
+is_block "$out" || fail "should deny Node marker for Rails — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"RAILS_ENV=test npx prisma migrate reset"}}')
+is_block "$out" || fail "should deny Rails marker for Prisma — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop && rails db:drop"}}')
+is_block "$out" || fail "should inspect every destructive command — got: $out"
+
+# shellcheck disable=SC2016 # command substitution must remain literal test input
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test echo \"$(npx sequelize db:drop)\""}}')
+is_block "$out" || fail "should deny destructive command substitution — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test cat <(npx sequelize db:drop)"}}')
+is_block "$out" || fail "should deny input process substitution — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test tee >(npx sequelize db:drop)"}}')
+is_block "$out" || fail "should deny output process substitution — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"DJANGO_SETTINGS_MODULE=app.settings.latest python manage.py flush"}}')
+is_block "$out" || fail "should deny non-test Django settings module — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"DJANGO_SETTINGS_MODULE=app.settings.production_test python manage.py flush"}}')
+is_block "$out" || fail "should deny Django test substring — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"DJANGO_SETTINGS_MODULE=app.test.production python manage.py flush"}}')
+is_block "$out" || fail "should deny non-final Django test component — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"node_env=test npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny lowercase node_env — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=TEST npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny uppercase TEST value — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test NODE_ENV=development npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny later NODE_ENV override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test env -u NODE_ENV npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny later env removal — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test sh -c \"NODE_ENV=production npx sequelize db:drop\""}}')
+is_block "$out" || fail "should deny nested shell override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test /bin/\"sh\" -c \"NODE_ENV=production npx sequelize db:drop\""}}')
+is_block "$out" || fail "should deny quote-concatenated nested shell — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test dash -c \"NODE_ENV=production npx sequelize db:drop\""}}')
+is_block "$out" || fail "should deny unlisted nested shell — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test e\"nv\" -u NODE_ENV npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny quote-concatenated env removal — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test DATABASE_URL=postgresql://localhost/app_development npx sequelize db:drop"}}')
+is_block "$out" || fail "should deny explicit database connection override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop --env production"}}')
+is_block "$out" || fail "should deny Sequelize environment override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop --url postgresql://localhost/app_production"}}')
+is_block "$out" || fail "should deny Sequelize connection override — got: $out"
+
+# shellcheck disable=SC2016 # variable expansion must remain literal test input
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop $EXTRA_ARGS"}}')
+is_block "$out" || fail "should deny dynamic argument expansion — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop {--env,production}"}}')
+is_block "$out" || fail "should deny brace-expanded override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize db:drop *"}}')
+is_block "$out" || fail "should deny glob-expanded arguments — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx knex migrate:rollback --all --env production"}}')
+is_block "$out" || fail "should deny Knex environment override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"DJANGO_SETTINGS_MODULE=app.settings.test python manage.py flush --settings=app.settings.production"}}')
+is_block "$out" || fail "should deny Django settings override — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx sequelize --env production db:drop"}}')
+is_block "$out" || fail "should deny Sequelize override before operation — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx knex --knexfile ./production.js migrate:rollback --all"}}')
+is_block "$out" || fail "should deny Knex override before operation — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"RAILS_ENV=test bundle exec rails --environment production db:drop"}}')
+is_block "$out" || fail "should deny Rails override before operation — got: $out"
+
+# Quoted or escaped separators inside option values stay in one shell command.
+out=$(run_command "NODE_ENV=test npx sequelize --config 'config;test.js' db:drop")
+is_block "$out" || fail "should deny Sequelize after quoted semicolon — got: $out"
+
+out=$(run_command 'NODE_ENV=test npx sequelize --config=config\;test.js db:drop')
+is_block "$out" || fail "should deny Sequelize after escaped semicolon — got: $out"
+
+out=$(run_command "NODE_ENV=test npx knex --knexfile 'knex|test.js' migrate:rollback --all")
+is_block "$out" || fail "should deny Knex after quoted pipe — got: $out"
+
+out=$(run_command "npx typeorm --dataSource 'foo;bar.ts' schema:drop")
+is_block "$out" || fail "should deny TypeORM after quoted semicolon — got: $out"
+
+# The deny-only scan intentionally crosses real control operators too. Split
+# diagnostics into separate Bash calls if they only print these strings.
+out=$(run_command "sequelize --help; echo 'db:drop'")
+is_block "$out" || fail "should conservatively deny cross-command task text — got: $out"
+
+# A backslash-newline is conservatively denied. Blindly removing it would
+# incorrectly join even-backslash newlines, which are real shell separators.
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test \\\nnpx sequelize db:drop"}}')
+is_block "$out" || fail "should deny ambiguous line continuation — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test echo \\\\\nnpx sequelize db:drop"}}')
+is_block "$out" || fail "should deny even-backslash newline separator — got: $out"
+
+# Deny detection canonicalizes shell token construction before matching.
+out=$(run_command 'NODE_ENV=production npx se"quelize" db:drop')
+is_block "$out" || fail "should deny quote-constructed runner — got: $out"
+
+out=$(run_command 'NODE_ENV=production npx sequelize db:"drop"')
+is_block "$out" || fail "should deny quote-constructed operation — got: $out"
+
+out=$(run_command 'NODE_ENV=production npx seque\lize db:drop')
+is_block "$out" || fail "should deny backslash-constructed runner — got: $out"
+
+out=$(run_command 'dr"opdb" app_production')
+is_block "$out" || fail "should deny quote-constructed raw client — got: $out"
+
+# NODE_ENV does not select the Prisma or TypeORM datasource.
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx prisma migrate reset"}}')
+is_block "$out" || fail "should deny Prisma despite NODE_ENV=test — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test npx typeorm schema:drop"}}')
+is_block "$out" || fail "should deny TypeORM despite NODE_ENV=test — got: $out"
+
+# Raw clients select their target independently of application env markers.
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"NODE_ENV=test psql -c \"DROP DATABASE foo\""}}')
+is_block "$out" || fail "should deny raw SQL despite NODE_ENV=test — got: $out"
+
+out=$(run '{"tool_name":"Bash","tool_input":{"command":"RAILS_ENV=test dropdb myapp_test"}}')
+is_block "$out" || fail "should deny dropdb despite RAILS_ENV=test — got: $out"
 
 # ────────────────────────────────────────────────────────
 # ALLOW: non-destructive commands
@@ -92,7 +291,7 @@ out=$(run '{"tool_name":"Read","tool_input":{"file_path":"db/schema.rb"}}')
 
 # ────────────────────────────────────────────────────────
 # DENY: case-insensitivity — mixed-case commands still blocked
-# (current hook uses grep -i, so DB:RESET must still be caught)
+# (the detection copy is lowercased before pattern matching)
 # ────────────────────────────────────────────────────────
 
 out=$(run '{"tool_name":"Bash","tool_input":{"command":"Rails DB:RESET"}}')

--- a/tests/skills/pr-monitor/run-tests.sh
+++ b/tests/skills/pr-monitor/run-tests.sh
@@ -5,26 +5,71 @@
 # clamped at the last) so the loop can be driven through state transitions
 # without network access.
 set -uo pipefail
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit 1
 SCRIPT="$(cd ../../.. && pwd)/home/dot_claude/skills/pr-monitor/scripts/pr-monitor.sh"
 
 workdir=$(mktemp -d)
 trap 'rm -rf "$workdir"' EXIT
 mkdir -p "$workdir/bin"
 
-cat > "$workdir/bin/gh" <<'FAKE'
+cat >"$workdir/bin/gh" <<'FAKE'
 #!/usr/bin/env bash
 case "$1" in
-  pr)  prefix=pr ;;
-  api) prefix=th ;;
-  *)   exit 1 ;;
+  pr)
+    n=$(cat "$FIXDIR/pr.count" 2>/dev/null || echo 0)
+    n=$((n + 1))
+    echo "$n" > "$FIXDIR/pr.count"
+    last=$(find "$FIXDIR" -name 'pr-*.json' | wc -l | tr -d ' ')
+    ((n > last)) && n=$last
+    cat "$FIXDIR/pr-$n.json"
+    ;;
+  api)
+    query=""
+    after=""
+    previous=""
+    for arg in "$@"; do
+      case $arg in
+        query=*) query=${arg#query=} ;;
+        after=*)
+          [[ $previous == -f ]] || exit 1
+          after=${arg#after=}
+          ;;
+      esac
+      previous=$arg
+    done
+    [[ $query == *'after:$after'* ]] || exit 1
+    [[ $query == *'pageInfo{hasNextPage endCursor}'* ]] || exit 1
+
+    if [[ -z $after ]]; then
+      n=$(cat "$FIXDIR/th.count" 2>/dev/null || echo 0)
+      n=$((n + 1))
+      echo "$n" > "$FIXDIR/th.count"
+      page=1
+      echo "$page" > "$FIXDIR/th.page"
+    else
+      n=$(cat "$FIXDIR/th.count")
+      page=$(cat "$FIXDIR/th.page")
+      previous_fixture="$FIXDIR/th-$n-$page.json"
+      expected_after=$(jq -er \
+        '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor
+         | select(type == "string" and length > 0)' \
+        "$previous_fixture") || exit 1
+      [[ $after == "$expected_after" ]] || exit 1
+      printf '%s\n' "$after" >>"$FIXDIR/after.log"
+      page=$((page + 1))
+      echo "$page" > "$FIXDIR/th.page"
+    fi
+
+    fixture="$FIXDIR/th-$n-$page.json"
+    if [[ $page -eq 1 && ! -f $fixture ]]; then
+      fixture="$FIXDIR/th-$n.json"
+    fi
+    cat "$fixture"
+    ;;
+  *)
+    exit 1
+    ;;
 esac
-n=$(cat "$FIXDIR/$prefix.count" 2>/dev/null || echo 0)
-n=$((n + 1))
-echo "$n" > "$FIXDIR/$prefix.count"
-last=$(find "$FIXDIR" -name "$prefix-*.json" | wc -l | tr -d ' ')
-(( n > last )) && n=$last
-cat "$FIXDIR/$prefix-$n.json"
 FAKE
 chmod +x "$workdir/bin/gh"
 export PATH="$workdir/bin:$PATH"
@@ -37,6 +82,7 @@ expect() { # expect <label> <needle> <haystack>
     echo "  ok   $1"
   else
     echo "  FAIL $1 — expected to find: $2"
+    # shellcheck disable=SC2001 # Prefix every line of multi-line diagnostics.
     echo "$3" | sed 's/^/       /'
     fail=1
   fi
@@ -48,6 +94,7 @@ expect_count() { # expect_count <label> <n> <pattern> <haystack>
     echo "  ok   $1"
   else
     echo "  FAIL $1 — expected $2 lines matching '$3', got $got"
+    # shellcheck disable=SC2001 # Prefix every line of multi-line diagnostics.
     echo "$4" | sed 's/^/       /'
     fail=1
   fi
@@ -58,7 +105,7 @@ export FIXDIR="$workdir/fix1"
 mkdir -p "$FIXDIR"
 # polls 1-2: one pending CheckRun, one success, one pending StatusContext,
 # plus an excluded approval gate (must not count toward total)
-cat > "$FIXDIR/pr-1.json" <<'J'
+cat >"$FIXDIR/pr-1.json" <<'J'
 {"state":"OPEN","statusCheckRollup":[
   {"name":"test","status":"IN_PROGRESS","conclusion":""},
   {"name":"lint","status":"COMPLETED","conclusion":"SUCCESS"},
@@ -67,7 +114,7 @@ cat > "$FIXDIR/pr-1.json" <<'J'
 J
 cp "$FIXDIR/pr-1.json" "$FIXDIR/pr-2.json"
 # poll 3: CANCELLED must be classified as a failure (not only FAILURE)
-cat > "$FIXDIR/pr-3.json" <<'J'
+cat >"$FIXDIR/pr-3.json" <<'J'
 {"state":"OPEN","statusCheckRollup":[
   {"name":"test","status":"COMPLETED","conclusion":"CANCELLED"},
   {"name":"lint","status":"COMPLETED","conclusion":"SUCCESS"},
@@ -75,7 +122,7 @@ cat > "$FIXDIR/pr-3.json" <<'J'
   {"name":"require-approval","status":"IN_PROGRESS","conclusion":""}]}
 J
 # poll 4: all green
-cat > "$FIXDIR/pr-4.json" <<'J'
+cat >"$FIXDIR/pr-4.json" <<'J'
 {"state":"OPEN","statusCheckRollup":[
   {"name":"test","status":"COMPLETED","conclusion":"SUCCESS"},
   {"name":"lint","status":"COMPLETED","conclusion":"SUCCESS"},
@@ -83,43 +130,194 @@ cat > "$FIXDIR/pr-4.json" <<'J'
   {"name":"require-approval","status":"IN_PROGRESS","conclusion":""}]}
 J
 # threads: one unresolved until poll 4
-cat > "$FIXDIR/th-1.json" <<'J'
-{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false}]}}}}}
+cat >"$FIXDIR/th-1.json" <<'J'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
 J
 cp "$FIXDIR/th-1.json" "$FIXDIR/th-2.json"
 cp "$FIXDIR/th-1.json" "$FIXDIR/th-3.json"
-cat > "$FIXDIR/th-4.json" <<'J'
-{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true}]}}}}}
+cat >"$FIXDIR/th-4.json" <<'J'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
 J
 
 out=$(bash "$SCRIPT" 1 owner repo 2>&1)
 rc=$?
-if [[ $rc -eq 0 ]]; then echo "  ok   green: exits 0"; else echo "  FAIL green: exit code $rc"; fail=1; fi
-expect_count "green: emits only on change"    3 '^CI ' "$out"
-expect       "green: excluded check dropped"  '"total":3' "$out"
-expect       "green: pending counted"         '"pending":2' "$out"
-expect       "green: CANCELLED is a failure"  '"failures":["test"]' "$out"
-expect       "green: unresolved thread seen"  '"unresolved":1' "$out"
-expect       "green: DONE line"               "DONE: all checks green and threads resolved" "$out"
+if [[ $rc -eq 0 ]]; then echo "  ok   green: exits 0"; else
+  echo "  FAIL green: exit code $rc"
+  fail=1
+fi
+expect_count "green: emits only on change" 3 '^CI ' "$out"
+expect "green: excluded check dropped" '"total":3' "$out"
+expect "green: pending counted" '"pending":2' "$out"
+expect "green: CANCELLED is a failure" '"failures":["test"]' "$out"
+expect "green: unresolved thread seen" '"unresolved":1' "$out"
+expect "green: DONE line" "DONE: all checks green and threads resolved" "$out"
 
 # --- scenario 2: until=merged — keeps watching past green, exits on MERGED
 export FIXDIR="$workdir/fix2"
 mkdir -p "$FIXDIR"
-cat > "$FIXDIR/pr-1.json" <<'J'
+cat >"$FIXDIR/pr-1.json" <<'J'
 {"state":"OPEN","statusCheckRollup":[{"name":"test","status":"COMPLETED","conclusion":"SUCCESS"}]}
 J
-cat > "$FIXDIR/pr-2.json" <<'J'
+cat >"$FIXDIR/pr-2.json" <<'J'
 {"state":"MERGED","statusCheckRollup":[{"name":"test","status":"COMPLETED","conclusion":"SUCCESS"}]}
 J
-cat > "$FIXDIR/th-1.json" <<'J'
-{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}
+cat >"$FIXDIR/th-1.json" <<'J'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
 J
+cp "$FIXDIR/th-1.json" "$FIXDIR/th-2.json"
 
 out=$(bash "$SCRIPT" 1 owner repo "require-approval,check-approval" merged 2>&1)
 rc=$?
-[[ $rc -eq 0 ]] || { echo "  FAIL merged: exit code $rc"; fail=1; }
-expect "merged: survives green state"  '| PR OPEN' "$out"
-expect "merged: DONE on merge"         "DONE: merged" "$out"
+[[ $rc -eq 0 ]] || {
+  echo "  FAIL merged: exit code $rc"
+  fail=1
+}
+expect "merged: survives green state" '| PR OPEN' "$out"
+expect "merged: DONE on merge" "DONE: merged" "$out"
+
+# --- scenario 3: paginates review threads past the first 100
+export FIXDIR="$workdir/fix3"
+mkdir -p "$FIXDIR"
+cat >"$FIXDIR/pr-1.json" <<'J'
+{"state":"OPEN","statusCheckRollup":[{"name":"test","status":"COMPLETED","conclusion":"SUCCESS"}]}
+J
+cp "$FIXDIR/pr-1.json" "$FIXDIR/pr-2.json"
+
+jq -cn '{
+  data: {repository: {pullRequest: {reviewThreads: {
+    nodes: [range(100) | {isResolved: true}],
+    pageInfo: {hasNextPage: true, endCursor: "@opaque-cursor"}
+  }}}}
+}' >"$FIXDIR/th-1-1.json"
+cat >"$FIXDIR/th-1-2.json" <<'J'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+J
+jq -cn '{
+  data: {repository: {pullRequest: {reviewThreads: {
+    nodes: [range(100) | {isResolved: true}],
+    pageInfo: {hasNextPage: true, endCursor: "cursor-2"}
+  }}}}
+}' >"$FIXDIR/th-2-1.json"
+cat >"$FIXDIR/th-2-2.json" <<'J'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+J
+
+out=$(bash "$SCRIPT" 1 owner repo 2>&1)
+rc=$?
+[[ $rc -eq 0 ]] || {
+  echo "  FAIL pagination: exit code $rc"
+  fail=1
+}
+expect "pagination: counts page 2" '"total":101' "$out"
+expect "pagination: sees thread 101" '"unresolved":1' "$out"
+expect "pagination: waits for resolution" "DONE: all checks green and threads resolved" "$out"
+expect "pagination: forwards @ cursor literally" "@opaque-cursor" "$(cat "$FIXDIR/after.log")"
+expect "pagination: forwards refreshed endCursor" "cursor-2" "$(cat "$FIXDIR/after.log")"
+
+# --- scenario 4: a later-page failure cannot become fake green
+export FIXDIR="$workdir/fix4"
+mkdir -p "$FIXDIR"
+cp "$workdir/fix3/pr-1.json" "$FIXDIR/pr-1.json"
+jq -cn '{
+  data: {repository: {pullRequest: {reviewThreads: {
+    nodes: [range(100) | {isResolved: true}],
+    pageInfo: {hasNextPage: true, endCursor: "missing-page"}
+  }}}}
+}' >"$FIXDIR/th-1-1.json"
+
+export PR_MONITOR_MAX_POLLS=1
+out=$(bash "$SCRIPT" 1 owner repo 2>&1)
+rc=$?
+[[ $rc -eq 1 ]] || {
+  echo "  FAIL page failure: exit code $rc"
+  fail=1
+}
+expect "page failure: times out" "[TIMEOUT] max polls reached" "$out"
+expect_count "page failure: never reports DONE" 0 '^DONE:' "$out"
+
+# --- scenario 5: repeated cursors fail instead of looping forever
+export FIXDIR="$workdir/fix5"
+mkdir -p "$FIXDIR"
+cp "$workdir/fix3/pr-1.json" "$FIXDIR/pr-1.json"
+cat >"$FIXDIR/th-1-1.json" <<'J'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":"repeat"}}}}}}
+J
+cp "$FIXDIR/th-1-1.json" "$FIXDIR/th-1-2.json"
+
+out=$(bash "$SCRIPT" 1 owner repo 2>&1)
+rc=$?
+[[ $rc -eq 1 ]] || {
+  echo "  FAIL cursor cycle: exit code $rc"
+  fail=1
+}
+expect "cursor cycle: times out" "[TIMEOUT] max polls reached" "$out"
+expect_count "cursor cycle: never reports DONE" 0 '^DONE:' "$out"
+
+# --- scenario 6: GraphQL partial data with errors cannot become fake green
+export FIXDIR="$workdir/fix6"
+mkdir -p "$FIXDIR"
+cp "$workdir/fix3/pr-1.json" "$FIXDIR/pr-1.json"
+cat >"$FIXDIR/th-1.json" <<'J'
+{"errors":[{"message":"partial failure"}],"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+J
+
+out=$(bash "$SCRIPT" 1 owner repo 2>&1)
+rc=$?
+[[ $rc -eq 1 ]] || {
+  echo "  FAIL GraphQL errors: exit code $rc"
+  fail=1
+}
+expect "GraphQL errors: times out" "[TIMEOUT] max polls reached" "$out"
+expect_count "GraphQL errors: never reports DONE" 0 '^DONE:' "$out"
+
+# --- scenario 7: malformed errors fields cannot masquerade as no errors
+malformed_index=0
+for malformed_errors in '{}' '""'; do
+  malformed_index=$((malformed_index + 1))
+  export FIXDIR="$workdir/fix7-$malformed_index"
+  mkdir -p "$FIXDIR"
+  cp "$workdir/fix3/pr-1.json" "$FIXDIR/pr-1.json"
+  jq -cn --argjson errors "$malformed_errors" '{
+    errors: $errors,
+    data: {repository: {pullRequest: {reviewThreads: {
+      nodes: [],
+      pageInfo: {hasNextPage: false, endCursor: null}
+    }}}}
+  }' >"$FIXDIR/th-1.json"
+
+  out=$(bash "$SCRIPT" 1 owner repo 2>&1)
+  rc=$?
+  [[ $rc -eq 1 ]] || {
+    echo "  FAIL malformed errors $malformed_index: exit code $rc"
+    fail=1
+  }
+  expect "malformed errors $malformed_index: times out" "[TIMEOUT] max polls reached" "$out"
+  expect_count "malformed errors $malformed_index: never reports DONE" 0 '^DONE:' "$out"
+done
+
+# --- scenario 8: unique cursors cannot make one poll fetch forever
+export FIXDIR="$workdir/fix8"
+mkdir -p "$FIXDIR"
+cp "$workdir/fix3/pr-1.json" "$FIXDIR/pr-1.json"
+for page in {1..100}; do
+  jq -cn --arg cursor "unique-$page" '{
+    data: {repository: {pullRequest: {reviewThreads: {
+      nodes: [],
+      pageInfo: {hasNextPage: true, endCursor: $cursor}
+    }}}}
+  }' >"$FIXDIR/th-1-$page.json"
+done
+
+out=$(bash "$SCRIPT" 1 owner repo 2>&1)
+rc=$?
+[[ $rc -eq 1 ]] || {
+  echo "  FAIL page limit: exit code $rc"
+  fail=1
+}
+expect "page limit: times out" "[TIMEOUT] max polls reached" "$out"
+expect "page limit: stops at 100 requests" "100" "$(cat "$FIXDIR/th.page")"
+expect_count "page limit: never reports DONE" 0 '^DONE:' "$out"
+export PR_MONITOR_MAX_POLLS=20
 
 echo
 if [[ $fail -eq 0 ]]; then echo "passed"; else echo "FAILED"; fi


### PR DESCRIPTION
## Summary

- paginate all review-thread pages instead of inspecting only the first 100
- fail closed on partial or malformed GraphQL responses, invalid cursors, and page-fetch failures
- pass opaque cursors as raw strings and cap each poll at 100 pages
- add hermetic coverage for the 101st thread, cursor forwarding, malformed errors, cycles, and page limits

## Tests

- `env XDG_CACHE_HOME=/private/tmp/dots-pr11-nix-cache nix shell nixpkgs#lua5_4 nixpkgs#direnv -c env LUA_COMPILER=luac just test`
- `shellcheck home/dot_claude/skills/pr-monitor/scripts/pr-monitor.sh tests/skills/pr-monitor/run-tests.sh`
- `shfmt -d -i 2 -ci home/dot_claude/skills/pr-monitor/scripts/pr-monitor.sh tests/skills/pr-monitor/run-tests.sh`
- `git diff --check`

## Dependency

Stacked on #220; only commit `7e41263` belongs to this PR.