### PR TITLE
feat(work): manage fdev tools and GitHub auth with Aqua

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ home/dot_local/share/devbox/global/default/devbox.lock
 .claude/
 .firecrawl/
 
+# Work-only ghtkn GitHub App configuration must not enter this public repository
+home/dot_config/ghtkn/
+
 # Python tooling caches (pytest harness under tests/skills/)
 __pycache__/
 .pytest_cache/

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -22,6 +22,7 @@ homebrew/
 
 # Work-specific files on personal machines
 {{ if not .business_use }}
+.config/aquaproj-aqua/
 .config/git/freee
 .config/colima/
 homebrew/Brewfile.work

--- a/home/.chezmoiscripts/run_after_link-aqua-tools.sh.tmpl
+++ b/home/.chezmoiscripts/run_after_link-aqua-tools.sh.tmpl
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+{{- if .business_use }}
+aqua_config="${XDG_CONFIG_HOME:-$HOME/.config}/aquaproj-aqua/aqua.yaml"
+
+if ! command -v aqua >/dev/null 2>&1; then
+  echo "aqua not found — skipping global tool links" >&2
+  exit 0
+fi
+
+if [[ ! -f "$aqua_config" ]]; then
+  echo "Aqua global config not found: $aqua_config" >&2
+  exit 0
+fi
+
+AQUA_CONFIG="$aqua_config" aqua install --only-link
+{{- end }}

--- a/home/dot_claude/settings.json.tmpl
+++ b/home/dot_claude/settings.json.tmpl
@@ -148,7 +148,9 @@
     }
   },
   "skipDangerousModePermissionPrompt": true,
+{{- end }}
   "mcpServers": {
+{{- if not .business_use }}
     "textlint": {
       "command": "textlint",
       "args": ["--mcp"]
@@ -156,8 +158,26 @@
     "1password": {
       "command": "1password-mcp"
     }
-  },
+{{- else }}
+    "fdev-helmfile": {
+      "command": "fdev-mcp-server",
+      "args": ["server", "helmfile"],
+      "env": {
+        "AQUA_GLOBAL_CONFIG": "{{ .chezmoi.homeDir }}/.config/aquaproj-aqua/aqua.yaml",
+        "HELM_BIN": "{{ .chezmoi.homeDir }}/.local/share/aquaproj-aqua/bin/helm",
+        "HELMFILE_COMMAND": "{{ .chezmoi.homeDir }}/.local/share/aquaproj-aqua/bin/helmfile"
+      }
+    },
+    "fdev-terraform": {
+      "command": "fdev-mcp-server",
+      "args": ["server", "terraform"],
+      "env": {
+        "AQUA_GLOBAL_CONFIG": "{{ .chezmoi.homeDir }}/.config/aquaproj-aqua/aqua.yaml",
+        "TERRAFORM_COMMAND": "{{ .chezmoi.homeDir }}/.local/share/aquaproj-aqua/bin/terraform"
+      }
+    }
 {{- end }}
+  },
   "alwaysThinkingEnabled": true,
   "switchModelsOnFlag": false,
   "worktree": {

--- a/home/dot_config/aquaproj-aqua/aqua.yaml
+++ b/home/dot_config/aquaproj-aqua/aqua.yaml
@@ -1,0 +1,12 @@
+---
+# Global work tools.
+# Helm and Helmfile follow C-FO/clusterops; Terraform follows C-FO/aws-infra.
+registries:
+  - type: standard
+    ref: v4.513.0
+
+packages:
+  - name: helm/helm@v3.17.0
+  - name: helmfile/helmfile@v0.171.0
+  - name: hashicorp/terraform@v1.14.3
+  - name: suzuki-shunsuke/ghtkn@v0.3.3

--- a/home/dot_config/zsh/features/ghtkn-gh.zsh
+++ b/home/dot_config/zsh/features/ghtkn-gh.zsh
@@ -1,0 +1,33 @@
+# ghtkn-gh.zsh — provide short-lived GitHub credentials to gh
+# Provides:     gh wrapper
+# Requires:     gh, ghtkn
+# Side-effects: invokes `ghtkn get` for each gh command without an explicit token
+
+if (( $+aliases[gh] )); then
+  unalias gh
+fi
+
+function gh {
+  emulate -L zsh
+  setopt local_options no_xtrace
+
+  # Preserve explicit credentials supplied by automation or the caller.
+  if [[ -n ${GH_TOKEN:-} || -n ${GITHUB_TOKEN:-} ]]; then
+    command gh "$@"
+    return
+  fi
+
+  if (( ! $+commands[ghtkn] )); then
+    print -u2 -- "gh: ghtkn is required when no explicit GitHub token is set"
+    return 127
+  fi
+
+  local token
+  token="$(command ghtkn get)" || return
+  if [[ -z "$token" ]]; then
+    print -u2 -- "gh: ghtkn returned an empty token; refusing to run gh"
+    return 1
+  fi
+
+  GH_TOKEN="$token" command gh "$@"
+}

--- a/home/dot_config/zsh/init/mise.zsh
+++ b/home/dot_config/zsh/init/mise.zsh
@@ -8,9 +8,11 @@
 # Must be activated before auto_mux to ensure the multiplexer is in PATH
 if command -v mise &>/dev/null; then
   _mise_cache="$ZSH_INIT_CACHE/mise.zsh"
+  # `mise activate` embeds the current PATH in its output. Include that input
+  # in the fingerprint so adding or removing a tool path invalidates the cache.
   if _zsh_command_cache_prepare \
     "$_mise_cache" \
-    "mise-activate-v1" \
+    "mise-activate-v2|path=${PATH}" \
     mise \
     activate zsh; then
     source "$_mise_cache"

--- a/home/dot_local/share/devbox/global/default/devbox.json.tmpl
+++ b/home/dot_local/share/devbox/global/default/devbox.json.tmpl
@@ -33,8 +33,10 @@
     "peco@latest",
     "kubectl@latest",
     "k9s@latest",
+{{- if not .business_use }}
     "kubernetes-helm@latest",
     "helmfile@latest",
+{{- end }}
     "eksctl@latest",
     "argocd@latest",
     "stern@latest",

--- a/home/dot_zshenv.tmpl
+++ b/home/dot_zshenv.tmpl
@@ -148,6 +148,9 @@ export GITLEAKS_CONFIG="$XDG_CONFIG_HOME/gitleaks/config.toml"
 # =============================================================================
 export BUSINESS_USE=1
 export COLIMA_HOME="$XDG_CONFIG_HOME/colima"
+export AQUA_GLOBAL_CONFIG="$XDG_CONFIG_HOME/aquaproj-aqua/aqua.yaml"
+export AQUA_GHTKN_ENABLED=true
+export PATH="$XDG_DATA_HOME/aquaproj-aqua/bin:$PATH"
 
 # Corporate TLS inspection CA: wire palo-root.pem (in Homebrew's cert store)
 # into common SSL env vars so curl/Node/Python/Ruby-OpenSSL trust certificates

--- a/home/homebrew/Brewfile.work
+++ b/home/homebrew/Brewfile.work
@@ -1,6 +1,7 @@
 tap "k1low/tap"
 brew "gmp"
 brew "actionlint"
+brew "aqua"
 brew "openssl@3"
 brew "xz"
 brew "awscli"

--- a/home/private_dot_zshrc.tmpl
+++ b/home/private_dot_zshrc.tmpl
@@ -27,6 +27,9 @@
 # Features: order-independent (function definitions)
 # =============================================================================
 {{ include "dot_config/zsh/features/ghq-fzf.zsh" }}
+{{- if .business_use }}
+{{ include "dot_config/zsh/features/ghtkn-gh.zsh" }}
+{{- end }}
 {{ include "dot_config/zsh/features/git-branch-fzf.zsh" }}
 {{ include "dot_config/zsh/features/branch-cleanup.zsh" }}
 {{ include "dot_config/zsh/features/kube.zsh" }}

--- a/tests/devbox/render-and-assert.sh
+++ b/tests/devbox/render-and-assert.sh
@@ -78,6 +78,8 @@ ncdu@latest
 hyperfine@latest
 vhs@latest
 yamllint@latest
+kubernetes-helm@latest
+helmfile@latest
 EOF
 
 cat >"$scratch_dir/expected-business-only" <<'EOF'

--- a/tests/hooks/settings-wiring.test.sh
+++ b/tests/hooks/settings-wiring.test.sh
@@ -127,6 +127,32 @@ assert_profile_wiring() {
   )"
   [[ -z "$allow_output" ]] ||
     fail "$profile configured credential hook emitted a decision for a benign command"
+
+  if [[ "$business_use" == "true" ]]; then
+    jq -e '
+      (.mcpServers | keys) == ["fdev-helmfile", "fdev-terraform"]
+      and .mcpServers["fdev-helmfile"].command == "fdev-mcp-server"
+      and .mcpServers["fdev-helmfile"].args == ["server", "helmfile"]
+      and (.mcpServers["fdev-helmfile"].env.AQUA_GLOBAL_CONFIG
+        | endswith("/.config/aquaproj-aqua/aqua.yaml"))
+      and (.mcpServers["fdev-helmfile"].env.HELM_BIN
+        | endswith("/.local/share/aquaproj-aqua/bin/helm"))
+      and (.mcpServers["fdev-helmfile"].env.HELMFILE_COMMAND
+        | endswith("/.local/share/aquaproj-aqua/bin/helmfile"))
+      and .mcpServers["fdev-terraform"].command == "fdev-mcp-server"
+      and .mcpServers["fdev-terraform"].args == ["server", "terraform"]
+      and (.mcpServers["fdev-terraform"].env.AQUA_GLOBAL_CONFIG
+        | endswith("/.config/aquaproj-aqua/aqua.yaml"))
+      and (.mcpServers["fdev-terraform"].env.TERRAFORM_COMMAND
+        | endswith("/.local/share/aquaproj-aqua/bin/terraform"))
+    ' "$rendered" >/dev/null ||
+      fail "$profile settings do not pin fdev MCP commands to Aqua"
+  else
+    jq -e '
+      (.mcpServers | keys) == ["1password", "textlint"]
+    ' "$rendered" >/dev/null ||
+      fail "$profile settings contain unexpected MCP servers"
+  fi
 }
 
 for profile in personal business; do

--- a/tests/zsh/generated-cache-consumers.test.sh
+++ b/tests/zsh/generated-cache-consumers.test.sh
@@ -275,6 +275,24 @@ cmp -s "$mise_lkg" "$mise_cache" ||
   fail "mise activation failure changed LKG bytes"
 pass "mise rejects partial activation and preserves LKG"
 
+mise_extra_path="$mise_root/extra-bin"
+mkdir -p "$mise_extra_path"
+env \
+  "PATH=$mise_bin:$mise_extra_path:/usr/bin:/bin" \
+  "HELPER=$helper" \
+  "MISE_SOURCE=$mise_source" \
+  "ZSH_INIT_CACHE=$mise_root/cache" \
+  "FAKE_LOG=$mise_log" \
+  zsh -f -c '
+    set -e
+    source "$HELPER"
+    source "$MISE_SOURCE"
+    [[ "$PR7_MISE_ACTIVATED" == v1 ]]
+  '
+grep -Fq "mise-activate-v2|path=$mise_bin:$mise_extra_path:/usr/bin:/bin" "$mise_cache" ||
+  fail "mise cache fingerprint does not track its input PATH"
+pass "mise PATH changes invalidate the activation cache"
+
 plugin_root="$test_root/plugins"
 plugin_bin="$plugin_root/bin"
 plugin_cache="$plugin_root/cache/init"
@@ -458,7 +476,7 @@ for profile in personal business; do
     --override-data "$data" \
     execute-template --file "$repo_root/home/private_dot_zshrc.tmpl" >"$rendered"
   zsh -n "$rendered"
-  grep -Fq '"mise-activate-v1"' "$rendered" ||
+  grep -Fq '"mise-activate-v2|path=${PATH}"' "$rendered" ||
     fail "$profile render is missing validated mise activation"
   grep -Fq '"direnv-hook-v1"' "$rendered" ||
     fail "$profile render is missing validated direnv hook"

--- a/tests/zsh/ghtkn-gh.test.sh
+++ b/tests/zsh/ghtkn-gh.test.sh
@@ -233,11 +233,11 @@ render_profile() {
   data="{\"business_use\":$business_use,\"auto_tmux\":false,\"homebrew_prefix\":\"/opt/homebrew\",\"grafana_instance_id\":\"\",\"grafana_api_token\":\"\",\"grafana_sa_token\":\"\"}"
   env -u GH_TOKEN -u GITHUB_TOKEN \
     chezmoi \
-      --config "$chezmoi_config" \
-      --config-format json \
-      --source "$repo_root" \
-      --override-data "$data" \
-      execute-template --file "$zshrc_source" >"$rendered"
+    --config "$chezmoi_config" \
+    --config-format json \
+    --source "$repo_root" \
+    --override-data "$data" \
+    execute-template --file "$zshrc_source" >"$rendered"
   zsh -n "$rendered"
 }
 

--- a/tests/zsh/ghtkn-gh.test.sh
+++ b/tests/zsh/ghtkn-gh.test.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Verify the business-only gh wrapper without consulting real credentials.
+set -euo pipefail
+
+# Never inherit or inspect credentials from the shell running this test.
+unset GH_TOKEN GITHUB_TOKEN
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/../.." && pwd -P)"
+feature_source="$repo_root/home/dot_config/zsh/features/ghtkn-gh.zsh"
+zshrc_source="$repo_root/home/private_dot_zshrc.tmpl"
+
+for required_command in chezmoi chmod cp grep mkdir zsh; do
+  command -v "$required_command" >/dev/null 2>&1 || {
+    echo "required command not found: $required_command" >&2
+    exit 1
+  }
+done
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/dots-ghtkn-gh.XXXXXX")"
+cleanup() {
+  rm -rf -- "$test_root"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+pass() {
+  echo "PASS: $1"
+}
+
+fake_bin="$test_root/bin"
+gh_only_bin="$test_root/gh-only-bin"
+ghtkn_log="$test_root/ghtkn.log"
+gh_log="$test_root/gh.log"
+trace_log="$test_root/zsh.trace"
+mkdir -p "$fake_bin" "$gh_only_bin"
+
+cat >"$fake_bin/ghtkn" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${GHTKN_LOG:?}"
+
+case "${GHTKN_MODE:-success}" in
+  success)
+    printf '%s\n' "fake-ghtkn-token"
+    ;;
+  empty)
+    ;;
+  fail)
+    exit 42
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+EOF
+
+cat >"$fake_bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf 'args=%s\n' "$*"
+  printf 'GH_TOKEN=%s\n' "${GH_TOKEN-<unset>}"
+  printf 'GITHUB_TOKEN=%s\n' "${GITHUB_TOKEN-<unset>}"
+} >>"${GH_LOG:?}"
+EOF
+
+chmod +x "$fake_bin/ghtkn" "$fake_bin/gh"
+cp "$fake_bin/gh" "$gh_only_bin/gh"
+
+env -u GH_TOKEN -u GITHUB_TOKEN \
+  "PATH=$fake_bin:/usr/bin:/bin" \
+  "FEATURE_SOURCE=$feature_source" \
+  "GHTKN_LOG=$ghtkn_log" \
+  "GH_LOG=$gh_log" \
+  zsh -f -c '
+    source "$FEATURE_SOURCE"
+    gh api /user
+    [[ ! -v GH_TOKEN ]]
+    [[ ! -v GITHUB_TOKEN ]]
+  '
+
+grep -Fxq "get" "$ghtkn_log" ||
+  fail "wrapper did not request a token from ghtkn"
+grep -Fxq "args=api /user" "$gh_log" ||
+  fail "wrapper did not preserve gh arguments"
+grep -Fxq "GH_TOKEN=fake-ghtkn-token" "$gh_log" ||
+  fail "wrapper did not pass the short-lived token to gh"
+pass "short-lived token is scoped to the gh child process"
+
+: >"$ghtkn_log"
+: >"$gh_log"
+env -u GH_TOKEN -u GITHUB_TOKEN \
+  "PATH=$fake_bin:/usr/bin:/bin" \
+  "FEATURE_SOURCE=$feature_source" \
+  "GHTKN_LOG=$ghtkn_log" \
+  "GH_LOG=$gh_log" \
+  zsh -f -c '
+    set -x
+    source "$FEATURE_SOURCE"
+    gh api /user
+  ' >/dev/null 2>"$trace_log"
+
+if grep -Fq "fake-ghtkn-token" "$trace_log"; then
+  fail "short-lived token appeared in zsh xtrace output"
+fi
+pass "wrapper suppresses token-bearing xtrace output"
+
+: >"$ghtkn_log"
+: >"$gh_log"
+env -u GH_TOKEN -u GITHUB_TOKEN \
+  "PATH=$fake_bin:/usr/bin:/bin" \
+  "FEATURE_SOURCE=$feature_source" \
+  "GHTKN_LOG=$ghtkn_log" \
+  "GH_LOG=$gh_log" \
+  zsh -f -c '
+    alias gh="print aliased"
+    source "$FEATURE_SOURCE"
+    (( ! $+aliases[gh] ))
+    eval "gh api /user"
+  '
+
+grep -Fxq "get" "$ghtkn_log" ||
+  fail "wrapper did not run when a gh alias existed before sourcing"
+grep -Fxq "args=api /user" "$gh_log" ||
+  fail "pre-existing gh alias shadowed the wrapper"
+pass "pre-existing gh alias does not break or shadow the wrapper"
+
+: >"$ghtkn_log"
+: >"$gh_log"
+env -u GITHUB_TOKEN \
+  "GH_TOKEN=caller-token" \
+  "PATH=$fake_bin:/usr/bin:/bin" \
+  "FEATURE_SOURCE=$feature_source" \
+  "GHTKN_LOG=$ghtkn_log" \
+  "GH_LOG=$gh_log" \
+  zsh -f -c '
+    source "$FEATURE_SOURCE"
+    gh repo view
+    [[ "$GH_TOKEN" == "caller-token" ]]
+  '
+
+[[ ! -s "$ghtkn_log" ]] ||
+  fail "wrapper called ghtkn despite an explicit GH_TOKEN"
+grep -Fxq "GH_TOKEN=caller-token" "$gh_log" ||
+  fail "wrapper did not preserve the explicit GH_TOKEN"
+pass "explicit GH_TOKEN bypasses ghtkn"
+
+: >"$ghtkn_log"
+: >"$gh_log"
+env -u GH_TOKEN \
+  "GITHUB_TOKEN=caller-token" \
+  "PATH=$fake_bin:/usr/bin:/bin" \
+  "FEATURE_SOURCE=$feature_source" \
+  "GHTKN_LOG=$ghtkn_log" \
+  "GH_LOG=$gh_log" \
+  zsh -f -c '
+    source "$FEATURE_SOURCE"
+    gh repo view
+    [[ "$GITHUB_TOKEN" == "caller-token" ]]
+  '
+
+[[ ! -s "$ghtkn_log" ]] ||
+  fail "wrapper called ghtkn despite an explicit GITHUB_TOKEN"
+grep -Fxq "GITHUB_TOKEN=caller-token" "$gh_log" ||
+  fail "wrapper did not preserve the explicit GITHUB_TOKEN"
+pass "explicit GITHUB_TOKEN bypasses ghtkn"
+
+: >"$ghtkn_log"
+: >"$gh_log"
+env -u GH_TOKEN -u GITHUB_TOKEN \
+  "PATH=$fake_bin:/usr/bin:/bin" \
+  "FEATURE_SOURCE=$feature_source" \
+  "GHTKN_LOG=$ghtkn_log" \
+  "GH_LOG=$gh_log" \
+  "GHTKN_MODE=fail" \
+  zsh -f -c '
+    source "$FEATURE_SOURCE"
+    gh api /user
+  ' >/dev/null 2>&1 && fail "ghtkn failure unexpectedly succeeded"
+
+[[ ! -s "$gh_log" ]] ||
+  fail "wrapper ran gh after ghtkn failed"
+pass "ghtkn failure prevents gh execution"
+
+: >"$ghtkn_log"
+: >"$gh_log"
+env -u GH_TOKEN -u GITHUB_TOKEN \
+  "PATH=$fake_bin:/usr/bin:/bin" \
+  "FEATURE_SOURCE=$feature_source" \
+  "GHTKN_LOG=$ghtkn_log" \
+  "GH_LOG=$gh_log" \
+  "GHTKN_MODE=empty" \
+  zsh -f -c '
+    source "$FEATURE_SOURCE"
+    gh api /user
+  ' >/dev/null 2>&1 && fail "empty ghtkn response unexpectedly succeeded"
+
+[[ ! -s "$gh_log" ]] ||
+  fail "wrapper ran gh after ghtkn returned an empty token"
+pass "empty ghtkn response prevents gh execution"
+
+: >"$gh_log"
+env -u GH_TOKEN -u GITHUB_TOKEN \
+  "PATH=$gh_only_bin:/usr/bin:/bin" \
+  "FEATURE_SOURCE=$feature_source" \
+  "GH_LOG=$gh_log" \
+  zsh -f -c '
+    source "$FEATURE_SOURCE"
+    gh api /user
+  ' >/dev/null 2>&1 && fail "missing ghtkn unexpectedly succeeded"
+
+[[ ! -s "$gh_log" ]] ||
+  fail "wrapper ran gh without ghtkn"
+pass "missing ghtkn prevents gh execution"
+
+render_root="$test_root/rendered"
+chezmoi_config="$test_root/chezmoi.json"
+mkdir -p "$render_root"
+printf '{}\n' >"$chezmoi_config"
+
+render_profile() {
+  local profile="$1"
+  local business_use="$2"
+  local rendered="$render_root/$profile.zshrc"
+  local data
+
+  data="{\"business_use\":$business_use,\"auto_tmux\":false,\"homebrew_prefix\":\"/opt/homebrew\",\"grafana_instance_id\":\"\",\"grafana_api_token\":\"\",\"grafana_sa_token\":\"\"}"
+  env -u GH_TOKEN -u GITHUB_TOKEN \
+    chezmoi \
+      --config "$chezmoi_config" \
+      --config-format json \
+      --source "$repo_root" \
+      --override-data "$data" \
+      execute-template --file "$zshrc_source" >"$rendered"
+  zsh -n "$rendered"
+}
+
+render_profile personal false
+render_profile business true
+
+if grep -Fq "gh: ghtkn is required" "$render_root/personal.zshrc"; then
+  fail "personal zshrc unexpectedly contains the ghtkn gh wrapper"
+fi
+grep -Fq "gh: ghtkn is required" "$render_root/business.zshrc" ||
+  fail "business zshrc is missing the ghtkn gh wrapper"
+pass "wrapper is rendered only for the business profile"
+
+echo "All ghtkn gh wrapper tests passed."


### PR DESCRIPTION
## Summary

- install Aqua with Homebrew for the business profile and pin Helm, Helmfile, Terraform, and ghtkn in a global Aqua config
- point the business fdev Helmfile and Terraform MCP servers at Aqua-managed binaries
- add a business-only `gh` wrapper that obtains short-lived credentials from ghtkn without exporting them to the parent shell
- invalidate the cached `mise activate zsh` output when its input PATH changes

## Details

- keep Helm and Helmfile out of the business Devbox profile to avoid duplicate ownership
- fail closed when ghtkn is missing, fails, or returns an empty token
- preserve caller-provided `GH_TOKEN` and `GITHUB_TOKEN`
- exclude local ghtkn application configuration from this public repository
- keep the existing SSH-based Git configuration unchanged

## Tests

- `bash tests/hooks/settings-wiring.test.sh`
- `bash tests/devbox/render-and-assert.sh`
- `bash tests/zsh/generated-cache-consumers.test.sh`
- `tests/zsh/ghtkn-gh.test.sh`
- `shellcheck tests/devbox/render-and-assert.sh tests/hooks/settings-wiring.test.sh tests/zsh/generated-cache-consumers.test.sh tests/zsh/ghtkn-gh.test.sh`
- Aqua YAML parse, rendered script syntax check, `zsh -n`, and `git diff --check`
