### PR TITLE
feat(rules): add schema design rule

### DIFF
--- a/home/dot_claude/rules/schema-design.md
+++ b/home/dot_claude/rules/schema-design.md
@@ -1,0 +1,14 @@
+# Schema Design
+
+Applies when deciding any durable shape that is expensive to change later — persisted-data formats (JSON documents, DB schemas), API shapes (request/response bodies), config/file formats, and infrastructure configuration (IaC resources, network layout).
+
+## Agreement gate
+
+Before implementing, always present a concise before/after sample of the shape (current vs proposed; "none" if new) and get the user's agreement. A prose description does not count — show the actual sample (for infrastructure, the config diff or topology sketch).
+
+## Shape principles (data shapes)
+
+- Don't persist what can be derived from other stored data
+- Keys repeated inside arrays stay short — their cost is paid per element
+- A fixed-arity, immutable structure becomes a tuple, not a keyed object
+- Design enums for orthogonality: one axis per enum; don't fold independent axes into combined values


### PR DESCRIPTION
## 概要

データの永続化形式や API 形状など、後から変更するコストが高い形状の決定に関する常時ロード型ルール `home/dot_claude/rules/schema-design.md` を追加します。

## 内容

**Agreement gate** — 形状を決める際は必ず簡潔な before/after サンプル（新規なら none → 提案形）を提示してユーザーの合意を取る。散文での説明は不可。インフラ構成の場合は config diff またはトポロジー図を示す。

**Shape principles (data shapes)** — 他から導出できるものは永続化しない / array 内で繰り返されるキーは短く / 固定長・不変な構造は tuple 化 / enum は直交性を保つ。

## 備考

適用条件は列挙ではなく「変更コストが高い durable な形状」という判定基準で書き、アプリのデータ形式に限らずインフラ構成変更にも適用されるようにしています。合意ゲートは汎用、shape principles はデータ形状限定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdFD7yQAm5j8Sm1icGMb45