### PR TITLE
fix(devbox-brew): stop treating Node-bundled corepack as a nodejs duplicate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ CLI tools follow an availability waterfall — use the first layer that provides
 
 Out of the waterfall (always Homebrew): GUI apps (`cask`), Mac App Store (`mas`), VSCode extensions, and macOS-specific CLI that isn't portable (e.g. `vips`, `swiftlint`, `xcodegen`).
 
-After source changes, refresh with `chezmoi apply` followed by `devbox global install`, then inspect `devbox global list` for resolved-version changes. `brewbundle` refuses exact-name CLI overlaps from `brew`, `cargo`, `go`, `npm`, and `uv` with the authoritative rendered Devbox profile before replacing a tracked Brewfile. Go module paths are compared by their final component. Known providers are normalized (`git-delta` to `delta`, `corepack` to `nodejs`). It cannot detect other aliases or packages with different names, so review every dump manually.
+After source changes, refresh with `chezmoi apply` followed by `devbox global install`, then inspect `devbox global list` for resolved-version changes. `brewbundle` refuses exact-name CLI overlaps from `brew`, `cargo`, `go`, `npm`, and `uv` with the authoritative rendered Devbox profile before replacing a tracked Brewfile. Go module paths are compared by their final component. Known providers are normalized (`git-delta` to `delta`). Runtime-bundled CLIs are not treated as duplicates: every Node distribution ships `corepack`, so `brew bundle dump` reports it wherever Node exists and it says nothing about who owns the runtime. It cannot detect other aliases or packages with different names, so review every dump manually.
 
 ## Authoring rules & skills
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,10 @@ Homebrew owns GUI/host-specific exceptions. `brewbundle` dumps to a temporary
 file and refuses to replace the tracked Brewfile when an exact CLI entry from
 `brew`, `cargo`, `go`, `npm`, or `uv` is already owned by the authoritative
 rendered Devbox profile. Go module paths use their final component for this
-comparison. Known providers are normalized (`git-delta` to `delta`, `corepack`
-to `nodejs`). Other aliases or differently named packages still require manual
+comparison. Known providers are normalized (`git-delta` to `delta`). Runtime-bundled
+CLIs are not treated as duplicates: every Node distribution ships `corepack`, so
+`brew bundle dump` reports it wherever Node exists and it says nothing about who
+owns the runtime. Other aliases or differently named packages still require manual
 review.
 
 ## Features

--- a/home/dot_config/zsh/features/devbox-brew.zsh
+++ b/home/dot_config/zsh/features/devbox-brew.zsh
@@ -163,9 +163,7 @@ brewbundle() {
     -e 's/^[[:space:]]*(brew|cargo|npm|uv) "([^"]+)".*/\2/p' \
     -e 's/^[[:space:]]*go "([^"]*\/)?([^/"]+)".*/\2/p' \
     "$dumped_brewfile" |
-    sed \
-      -e 's/^corepack$/nodejs/' \
-      -e 's/^git-delta$/delta/' |
+    sed -e 's/^git-delta$/delta/' |
     LC_ALL=C sort -u >"$homebrew_entries"; then
     echo "Could not read CLI package entries from the temporary Brewfile." >&2
     rm -rf "$temp_dir"

--- a/tests/zsh/devbox-brew.test.sh
+++ b/tests/zsh/devbox-brew.test.sh
@@ -106,7 +106,7 @@ run_success_case() {
   local source_override="$2"
   local business_use="$3"
   local expected_brewfile="$4"
-  local dump_content='brew "openssl@3"'
+  local dump_content="${5:-brew \"openssl@3\"}"
   local -a environment=(
     env
     -u CHEZMOI_SOURCE_DIR
@@ -267,11 +267,14 @@ run_success_case "repo-root override, personal" "$source_repo" personal "$source
 run_success_case "repo-root override, business" "$source_repo" business "$source_root/homebrew/Brewfile.work"
 run_success_case "resolved-root override, personal" "$source_root" personal "$source_root/homebrew/Brewfile"
 run_success_case "resolved-root override, business" "$source_root" business "$source_root/homebrew/Brewfile.work"
+# Every Node distribution ships corepack in its global node_modules, so `brew
+# bundle dump` reports it on any machine that has Node at all. Treating it as a
+# duplicate of the Devbox nodejs package would block brewbundle unconditionally.
+run_success_case "node-bundled corepack, personal" unset personal "$source_root/homebrew/Brewfile" 'npm "corepack"'
 run_overlap_case personal brew protobuf
 run_overlap_case business brew colima
 run_overlap_case business cargo atuin
 run_overlap_case business cargo git-delta delta
-run_overlap_case business npm corepack nodejs
 run_overlap_case personal go github.com/fullstorydev/grpcurl/cmd/grpcurl grpcurl
 run_overlap_case personal npm pnpm
 run_overlap_case personal uv yamllint


### PR DESCRIPTION
## Why

`brewbundle` was refusing every run:

```
Refusing to update .../home/homebrew/Brewfile: Homebrew CLI entries overlap with the rendered Devbox profile:
  - nodejs
```

The overlap did not come from Homebrew. Every Node distribution ships `corepack` in its global `node_modules`, so `brew bundle dump` reports `npm "corepack"` on any machine that has Node at all. `devbox-brew.zsh` normalized that to `nodejs`, which then collided with the `nodejs@24` entry in the Devbox profile.

That made the guard unsatisfiable rather than selective — the condition is true whenever Node exists, which on this setup is always.

## Evidence it is unconditional

Pointing PATH at the Devbox profile first does not help. `npm root -g` resolves into the nix store and the dump still carries the line:

```
$ env PATH="$devbox_bin:$PATH" npm root -g
/nix/store/b1h0af3yb3z9jz048phclcqw6ihiww67-nodejs-24.12.0/lib/node_modules
$ env PATH="$devbox_bin:$PATH" brew bundle dump --force --file="$tmp"
$ grep -n '^npm ' "$tmp"
118:npm "corepack"
```

Both runtimes on this machine bundle it:

| Runtime | Global `node_modules` |
| --- | --- |
| vite-plus node 24.18.1 | `corepack`, `npm` |
| Devbox nodejs 24.12.0 | `corepack`, `npm`, textlint packages |

## Why removing the mapping costs nothing

Homebrew's Node formula is canonically `node` (`nodejs` is only an alias, so `brew bundle dump` writes `brew "node"`), and no `node` → `nodejs` normalization exists. The `corepack` → `nodejs` mapping was therefore the only path by which `nodejs` could ever be flagged, and that path always fires. Deleting it and adding a `nodejs` exception are equivalent in detection power — deleting is one line smaller and does not silently defeat a future, correct `node` → `nodejs` rule.

Unavoidable either way: a deliberate `npm i -g corepack` is byte-identical to the bundled one in the dump, so no implementation can distinguish them.

## What changed

- `home/dot_config/zsh/features/devbox-brew.zsh` — drop the `s/^corepack$/nodejs/` normalization.
- `tests/zsh/devbox-brew.test.sh` — `run_success_case` takes an optional dump-content argument; `run_overlap_case business npm corepack nodejs` is replaced by a case asserting `npm "corepack"` does **not** block.
- `CLAUDE.md` / `README.md` — the normalization list no longer claims `corepack` → `nodejs`.

## Verification

| Step | Result |
| --- | --- |
| Red (test change only, old implementation) | stops with the production symptom `- nodejs` |
| Green | `PASS: node-bundled corepack, personal`; all 24 devbox-brew cases pass |
| `just test` | `✓ All checks passed!` (exit 0) |
| Real `brewbundle` against a scratch Brewfile | `Updated: …/home/homebrew/Brewfile` (exit 0) |

`corepack` was the only overlap — reproducing the `comm -12` from `devbox-brew.zsh:180` with it filtered out yields an empty set, so this alone unblocks the command.

## Notes for after merge

- `chezmoi apply` is required before `brewbundle` works from a normal shell. The end-to-end run above used the `CHEZMOI_SOURCE_DIR` branch; an ordinary invocation reads the applied `~/.config/zsh/features/devbox-brew.zsh`.
- The first successful `brewbundle` will produce a large Brewfile diff (~69 insertions / 71 deletions here): comment lines, tap reformatting, `uv "online-judge-tools"`, and formulae added while the guard was blocking updates. That is accumulated drift and deserves its own review pass — deliberately not included here.
- Still open, out of scope: `brew install node` is not detected by the guard at all, because the extracted name `node` never matches the Devbox `nodejs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
