### PR TITLE
feat(gh): declare gh CLI extensions and agent skills

### DIFF
--- a/home/.chezmoiscripts/run_onchange_after_install-gh-extensions-and-skills.sh
+++ b/home/.chezmoiscripts/run_onchange_after_install-gh-extensions-and-skills.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Install the gh CLI extensions and agent skills this setup relies on. Both sit
+# outside the devbox/mise/Homebrew waterfall because gh vendors them itself —
+# extensions under ~/.local/share/gh/extensions, skills under ~/.claude/skills —
+# so without this list they never reach a new machine.
+#
+# Upstream releases are not tracked: the script re-runs only when its own
+# contents change, so upgrades need `gh extension upgrade` / `gh skill update`.
+#
+# Triggered on chezmoi apply when this script changes.
+
+set -euo pipefail
+
+extensions=(
+  babarot/gh-infra
+  github/gh-stack
+)
+
+# "<repository> <skill>" pairs, installed for Claude Code at user scope.
+skills=(
+  "github/gh-stack gh-stack"
+)
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh not found — skipping gh extension and skill install" >&2
+  exit 0
+fi
+
+# Both installers hit the API, so an unauthenticated first-run apply would abort
+# here instead of reaching run_once_setup-gh-auth.sh.
+if ! gh auth status >/dev/null 2>&1; then
+  echo "gh is not authenticated — skipping gh extension and skill install" >&2
+  exit 0
+fi
+
+installed_extensions="$(gh extension list 2>/dev/null | awk -F'\t' '{print $2}')"
+
+for extension in "${extensions[@]}"; do
+  if grep -qxF "$extension" <<<"$installed_extensions"; then
+    continue
+  fi
+  echo "Installing gh extension: $extension"
+  gh extension install "$extension"
+done
+
+# gh skill install exits non-zero when the skill is already present, so each one
+# needs a presence check before install rather than a tolerated failure.
+installed_skills="$(gh skill list 2>/dev/null | awk -F'\t' '$2 == "claude-code" { print $1 }')"
+
+for skill in "${skills[@]}"; do
+  read -r repository name <<<"$skill"
+  if grep -qxF "$name" <<<"$installed_skills"; then
+    continue
+  fi
+  echo "Installing gh skill: $repository $name"
+  gh skill install "$repository" "$name" --agent claude-code --scope user
+done


### PR DESCRIPTION
## Why

`gh` vendors its extensions under `~/.local/share/gh/extensions` and its agent skills under `~/.claude/skills`. Neither path is reachable through the devbox / mise / Homebrew waterfall, so nothing in this repo knew they existed — `babarot/gh-infra` was installed by hand and would simply be missing on a new machine.

This adds a single declaration point so `chezmoi apply` installs them.

## What lands

`home/.chezmoiscripts/run_onchange_after_install-gh-extensions-and-skills.sh`, darwin/linux alike (no `.chezmoiignore` entry — `gh` comes from devbox on both).

| Kind | Entry |
| --- | --- |
| extension | `babarot/gh-infra` (already installed, recorded so the list matches reality) |
| extension | `github/gh-stack` — official GitHub CLI extension for stacked PRs |
| skill | `github/gh-stack` `gh-stack`, installed for Claude Code at user scope |

## Multi-machine behaviour

`run_onchange_` compares a hash of the script contents against chezmoi's state DB:

- new machine, no recorded hash — runs on the first `chezmoi apply`;
- existing machine, an entry added to a list — hash changes, so it re-runs;
- existing machine, list unchanged — skipped, which is correct because the tools are already present.

What it deliberately does **not** do is track upstream releases. A new `gh-stack` version does not change this file, so upgrades stay a manual `gh extension upgrade` / `gh skill update`.

## Guards

- `gh` missing — skip with a message rather than fail the apply.
- `gh` unauthenticated — skip, so a first-run apply reaches `run_once_setup-gh-auth.sh` instead of aborting on an API call.
- Already installed — checked before installing. Both `gh extension install` and `gh skill install` exit non-zero when the target exists, so tolerating the failure would have meant swallowing real errors too.

## No skill re-declaration needed

`settings.json.tmpl`'s `skillOverrides` is opt-out only — the 18 entries there are all `"off"`. Claude Code discovers `~/.claude/skills/*/SKILL.md` by presence, so `gh-stack` is live with no further wiring. Turning it off later is one line.

`home/dot_claude/skills/` carries no `exact_` prefix, so `chezmoi apply` leaves gh-installed skills alone; `agents-sdk`, `cloudflare`, and the `firecrawl-*` set already coexist there the same way.

## Verification

| Step | Result |
| --- | --- |
| `shellcheck` / `shfmt -d -i 2 -ci` | clean |
| `chezmoi --source=. managed --include=scripts` | `.chezmoiscripts/install-gh-extensions-and-skills.sh` present |
| First run | installed `gh stack v0.1.0` and the `gh-stack` skill |
| Re-run with everything present | no output, exit 0 |
| Presence check | matches `gh-stack`, falls through for an unknown name |
| `just quality-gate` | passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
