### PR TITLE
chore(homebrew): drop glowm and its tap

### DIFF
--- a/home/homebrew/Brewfile
+++ b/home/homebrew/Brewfile
@@ -1,4 +1,3 @@
-tap "atani/tap"
 tap "homebrew/bundle"
 tap "k1low/tap", "https://github.com/k1LoW/homebrew-tap"
 tap "stripe/stripe-cli", trusted: true
@@ -52,8 +51,6 @@ brew "vips"
 brew "xcodegen"
 # UNIX shell (command interpreter)
 brew "zsh"
-# Glow-like Markdown CLI with Mermaid diagrams (iTerm2/Kitty inline images + PDF)
-brew "atani/tap/glowm", trusted: true
 # mo is a Markdown viewer that opens .md files in a browser.
 brew "k1low/tap/mo", trusted: true
 # Stripe CLI utility


### PR DESCRIPTION
## Why

glowm was trialled for a herdr `prefix+m` Markdown/mermaid preview. That work was abandoned — PR #194 was closed with "glowmは採用を取りやめたので不要" — but the binary stayed installed, so when #227 refreshed the Brewfile from machine state it recorded glowm and its tap as part of the declared setup.

`brewbundle` is a snapshot of what is installed, not a statement of what should be. It has no way to know an adoption was called off, and its overlap guard only checks for Devbox duplicates. So an abandoned tool quietly came back as configuration.

## What changed

`brew uninstall glowm` and `brew untap atani/tap`, then `brewbundle`:

```
-tap "atani/tap"
-# Glow-like Markdown CLI with Mermaid diagrams (iTerm2/Kitty inline images + PDF)
-brew "atani/tap/glowm", trusted: true
```

Three lines, because #227 already absorbed the rest of the accumulated drift. The tap went too — glowm was the only formula it served.

## Related cleanup

The two herdr branches this came from are deleted: `feat/herdr-glowm-md-preview` (PR #194, closed) and `feat/herdr-hunk-diff-review` (never opened, `prefix+d` hunk diff review). The latter is recoverable from `e3446c5` if it is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
