### PR TITLE
fix(skills): empirical friction fixes from transcript mining

### DIFF
--- a/home/dot_claude/skills/codex-subagent/SKILL.md
+++ b/home/dot_claude/skills/codex-subagent/SKILL.md
@@ -20,10 +20,11 @@ Use Codex as a bounded worker. Claude remains the coordinator: choose the task, 
    - Use the default read-only mode for investigation, planning, explanation, code review, and second opinions.
    - Add `--write` only when the user explicitly requested implementation and Codex owns a clearly scoped set of changes. Do not let Claude and Codex edit the same files concurrently.
 3. Describe the outcome and completion bar, then give only context and constraints that change the work. Include file paths or symbols already known; do not prescribe a detailed process or make Codex rediscover context Claude already has. Never copy secrets, credentials, or unrelated conversation history into the prompt.
-4. Run the dispatcher once. It checks the CLI, applies the selected sandbox, adds the worker contract, uses an ephemeral Codex session, and prints only Codex's final report. It inherits the configured Codex model and reasoning effort; control those with Codex configuration rather than prose such as "think harder."
+4. Write the task to a scratch file (in the session scratchpad directory) with the Write tool, then run the dispatcher once with `--task-file`. It checks the CLI, applies the selected sandbox, adds the worker contract, uses an ephemeral Codex session, and prints only Codex's final report. It inherits the configured Codex model and reasoning effort; control those with Codex configuration rather than prose such as "think harder."
 
-```bash
-bash "${CLAUDE_SKILL_DIR}/scripts/dispatch.sh" --cd "$PWD" <<'CODEX_TASK'
+Task file content:
+
+```
 <goal>
 State the user-visible outcome Codex should produce.
 </goal>
@@ -40,10 +41,21 @@ State what is in scope, what must remain unchanged, and any evidence requirement
 State what Claude needs back: conclusions, path-and-line evidence, changes,
 verification output, material risks, or blockers.
 </output>
-CODEX_TASK
 ```
 
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/dispatch.sh" --task-file <scratch>/codex-task.md --cd "$PWD"
+```
+
+A heredoc on stdin also works, but worktree-isolated sessions refuse heredocs and stdin redirects as unverifiable — the task file is the form that runs everywhere.
+
 For an explicitly requested implementation, add `--write` before `--cd` and name the files or subsystem Codex owns in `<constraints>`.
+
+## Execution model (set expectations before dispatching)
+
+- Dispatches routinely exceed ten minutes. Always launch the dispatcher with `run_in_background`; a foreground call hits the Bash timeout and forces a retry.
+- No interim progress is observable by design: the dispatcher discards Codex's streaming output and emits only the final report, so the background output file stays empty until completion. Do not poll it for progress; keep working on other things until the completion notification arrives, then read the background task's output file — that is where the final report lands.
+- Tell the user at dispatch time that Codex is running in the background with nothing to show until it finishes — this silent wait is expected, not a hang.
 
 ## Review the return
 

--- a/home/dot_claude/skills/codex-subagent/scripts/dispatch.sh
+++ b/home/dot_claude/skills/codex-subagent/scripts/dispatch.sh
@@ -2,13 +2,14 @@
 set -euo pipefail
 
 usage() {
-  printf 'Usage: %s [--write] [--cd DIR]\n' "${0##*/}" >&2
-  printf 'Read the Codex task from standard input.\n' >&2
+  printf 'Usage: %s [--write] [--cd DIR] [--task-file FILE]\n' "${0##*/}" >&2
+  printf 'Read the Codex task from --task-file, or from standard input.\n' >&2
 }
 
 sandbox_mode='read-only'
 permission_text='Read-only: do not create, edit, delete, or rename files, and do not perform external writes or other state-changing actions.'
 workdir='.'
+task_source=''
 
 while (($# > 0)); do
   case "$1" in
@@ -23,6 +24,14 @@ while (($# > 0)); do
         exit 64
       fi
       workdir=$2
+      shift 2
+      ;;
+    --task-file)
+      if (($# < 2)); then
+        usage
+        exit 64
+      fi
+      task_source=$2
       shift 2
       ;;
     -h|--help)
@@ -57,7 +66,15 @@ cleanup() {
 }
 trap cleanup EXIT HUP INT TERM
 
-cat >"$task_file"
+if [[ -n "$task_source" ]]; then
+  if [[ ! -r "$task_source" ]]; then
+    printf 'codex-subagent: task file is not readable: %s\n' "$task_source" >&2
+    exit 66
+  fi
+  cat "$task_source" >"$task_file"
+else
+  cat >"$task_file"
+fi
 if [[ ! -s "$task_file" ]]; then
   printf 'codex-subagent: task prompt is empty.\n' >&2
   exit 64

--- a/home/dot_claude/skills/japanese-ai-writing-proofreader/SKILL.md
+++ b/home/dot_claude/skills/japanese-ai-writing-proofreader/SKILL.md
@@ -12,18 +12,21 @@ Four passes, mechanical first. The textlint and rhythm-lint passes exist because
 
 ## Scale
 
-Utilitarian prose — PR bodies, commit messages, changelog entries, short README/doc sections — gets Pass 1 and Pass 3 only: Pass 2's statistics are calibrated on full documents and mean nothing at that size, and Pass 4's structural checks have no room to fire. Articles and standalone documents get all four passes regardless of length. When in doubt, run the full pipeline.
+Scale by size, not artifact type. Short utilitarian prose — commit messages, changelog entries, a few-line PR body or README tweak — gets Pass 1 and Pass 3 only: Pass 2's statistics are calibrated on full documents and mean nothing at that size, and a few lines leave Pass 4 nothing to check. But a long PR/issue body (目安: 40 行超, or more than one heading) is document-sized — run the full pipeline on it; routing PR bodies around Pass 4 (情報の出し順, buried conclusions, 整合性) by artifact type is what let 「読みづらい」 re-requests through minutes after a clean proofread. Articles and standalone documents get all four passes regardless of length. When in doubt, run the full pipeline.
 
 ## Mode
 
 - **report** (default for text the user wrote): list findings with before/after suggestions; change nothing
-- **fix** (default for Claude-drafted text, or when the user asks for 修正): apply the fixes, then summarize what changed by category. When the target is a file, edit it in place AND show the corrected text (or the changed passages, for long files) in the response; when it is pasted text, return the corrected text in full (no config probe needed — go straight to the fallback)
+- **fix** (default for Claude-drafted text, or when the user asks for 修正): apply the fixes, then summarize what changed by category. When the target is a file, edit it in place AND show the corrected text (or the changed passages, for long files) in the response; when it is pasted text, return the corrected text in full (no project-config probe needed — go straight to Pass 1's bundled fallback config)
 
 When unclear which applies, ask.
 
 ## Scope guards
 
 - Never touch code blocks, command output, quoted text (`>`), or verbatim excerpts — flag issues inside them at most
+- Table data cells are near-verbatim: fix plain 誤字 inside them, nothing more. Prose crammed into cells is a structural finding (see below), not a rewrite target
+- When invoked on a diff or with named target sections, touch only those parts — the surrounding existing text is context, not a target. Callers don't need to restate this in arguments
+- **Structure is a finding, not a rewrite target**: when the dominant problems are structural — prose stuffed into table cells, a document far longer than its content, buried conclusions, a flow that wants a diagram — report them and recommend running technical-writing (構成・文量・図示 live there) instead of polishing sentences harder. A clean sentence-level pass does not make a structurally unreadable document readable
 - **Say only what the source says**: a replacement may use only information already present in the text. Cutting padding is the job; replacing 「継続的な改善」 with 「値のチューニング」, or a vague plan with a specific one the draft never stated, invents commitments on the author's behalf
 - **Tone down the author's stance, don't delete it**: 「非常に大きな成果であると考えております」 is hype wrapped around a real evaluation. Reduce it to 「大きな成果だと考えています」 — same claim, less ceremony. The replacement must not smuggle in a new premise either（「想定した効果が出ました」 would assert a prior expectation the text never stated）. Deleting the sentence removes the author's judgment, which is theirs to make; delete only when nothing survives the padding
 - **Voice preservation**: if the text has an intentional style (e.g. article-writing's style profiles — 括弧ツッコミ, 取り消し線, 「普通に」, casual fragments), those devices are NOT findings. Proofreading removes AI-smell, not personality. The protection covers the device itself, not errors inside it: real 誤字・誤用 inside a device are still findings; orthography preferences inside one are LOW at most. When the caller has an active style profile (e.g. invoked from article-writing), read that profile before judging anything as a finding.
@@ -82,6 +85,7 @@ VIEW='"検出\(.findings|length)件（うち info \([.findings[]|select(.severit
 
 uv run $LINT --json <file> > $TMP/lint-1.json
 jq -r "$VIEW" $TMP/lint-1.json
+echo "$TMP"   # the fix-mode baseline re-run needs this path literally
 ```
 
 Add `--genre essay|tech|business` when the genre is clear — it switches to calibrated per-genre thresholds and reduces false positives. Dependencies (sudachipy) resolve automatically via PEP 723 inline metadata; no venv setup needed.
@@ -90,7 +94,7 @@ Add `--genre essay|tech|business` when the genre is clear — it switches to cal
 - Exit code is 0 regardless of finding count (this is a lint, not a gate); 1 only on input errors
 - Open `$TMP/lint-1.json` directly only when one finding needs its `related_lines`; the jq view is the working set. If an excerpt doesn't match the document you're proofreading, you read another run's output — check the JSON's `.file` field
 - The script's `severity` and this skill's 重要度 are separate scales that happen to share a word. Map by the Output section's definitions: a script `critical` is normally IMPORTANT here (it marks a pattern, not broken meaning); a `warn` is IMPORTANT when it points at a specific passage and LOW when it reports a whole-document statistic such as burstiness; `info` goes to the LOW aggregate line
-- In fix mode, after applying fixes, re-run **this pass** once with `--baseline $TMP/lint-1.json`, writing to `$TMP/lint-2.json`. The jq view shows the `new` and `persisting` rows; resolved items move out of `.findings` into `.baseline`, so read their count separately: `jq -r '.baseline.summary | "resolved \(.resolved) / new \(.new) / persisting \(.persisting)"' $TMP/lint-2.json`. Report what persists with your reason for leaving it rather than starting another round, then delete the JSONs with plain `rm "$TMP"/lint-*.json`（`rm -rf` は環境によって hook に拒否される）
+- In fix mode, after applying fixes, re-run **this pass** once with `--baseline <dir>/lint-1.json`, writing to `<dir>/lint-2.json` — `<dir>` is the literal path the first run echoed. The re-run is a new shell call, so `TMP` no longer exists（an unexpanded `$TMP/` writes to the filesystem root）; re-declare `LINT` and `VIEW` in the same invocation. The jq view shows the `new` and `persisting` rows; resolved items move out of `.findings` into `.baseline`, so read their count separately: `jq -r '.baseline.summary | "resolved \(.resolved) / new \(.new) / persisting \(.persisting)"' $TMP/lint-2.json`. Report what persists with your reason for leaving it rather than starting another round, then delete the JSONs with plain `rm "$TMP"/lint-*.json`（`rm -rf` は環境によって hook に拒否される）
 - If `uv` is unavailable, skip this pass; Pass 4's manual checks are the fallback
 - If `jq` is unavailable, drop `--json` and the redirect and run the script bare — the human-readable format carries the same findings at roughly 3× the size of the jq view
 

--- a/home/dot_claude/skills/pr-description/SKILL.md
+++ b/home/dot_claude/skills/pr-description/SKILL.md
@@ -4,10 +4,11 @@ description: >-
   Rewrite an existing PR's description into a fixed layout (overview → mermaid →
   review guide → notes → links), with a per-commit verification table that cuts
   the reviewer's tracking cost. Use when asked to 「PR description を更新して」
-  「PR 本文を書いて」「PR 説明を簡潔に」「mermaid を使って PR をまとめて」,
+  「PR 本文を書いて」「PR 説明を簡潔に」「PR description を簡潔に」
+  「mermaid を使って PR をまとめて」,
   "rewrite the PR description", or after stacking commits on a pipeline PR.
-  Args: <PR URL or number> [-R owner/repo] [extra context]
-argument-hint: "<PR URL or number> [-R owner/repo]"
+  Args: <PR URL or number>... [-R owner/repo] [extra context]
+argument-hint: "<PR URL or number>... [-R owner/repo]"
 ---
 
 # pr-description
@@ -16,13 +17,15 @@ argument-hint: "<PR URL or number> [-R owner/repo]"
 
 Rewrite the body of an existing PR into a layout reviewers can verify commit by commit. Creating a new PR is out of scope (that belongs to code-flow:commit-push-pr).
 
+Multiple PRs in one invocation are fine: run Steps 1–4 for each PR in turn. Ask the language question (Step 2) once and reuse the answer for the whole batch.
+
 ## Workflow
 
 ### Step 1: Gather current state and resolve the PR template
 
 ```bash
 gh pr view <N> -R <owner/repo> --json title,body,commits --jq '{title, body, commits: [.commits[].messageHeadline]}'
-gh pr diff <N> -R <owner/repo> --stat   # understand the change before writing verification steps; drop --stat to read hunks
+gh pr diff <N> -R <owner/repo> --name-only   # understand the change before writing verification steps; drop --name-only to read hunks (--stat does not exist in gh)
 ```
 
 - If the existing body contains **auto-generated blocks** (`<!-- code-flow-usage-json:start -->` … `end -->`, bot `<details>` blocks, etc.), set them aside and re-append them verbatim at the end of the new body. Never delete them
@@ -50,7 +53,7 @@ Formatting discipline:
 
 ### Step 3: Apply (always via body-file)
 
-**Write the body to a scratch file with the Write tool and pass it via `--body-file`.** Never embed it inline through a heredoc — backtick escaping corrupts fences (details: `~/.claude/rules/gh-pr-body.md`).
+**Write the body to a scratch file (in the session scratchpad directory) with the Write tool and pass it via `--body-file`.** Never embed it inline through a heredoc — backtick escaping corrupts fences (details: `~/.claude/rules/gh-pr-body.md`).
 
 ```bash
 gh pr edit <N> -R <owner/repo> --body-file <scratch>/pr-body.md
@@ -61,7 +64,7 @@ gh pr edit <N> -R <owner/repo> --body-file <scratch>/pr-body.md
 Fetch the body back and confirm the fences are intact before reporting completion:
 
 ````bash
-gh pr view <N> -R <owner/repo> --json body -q '.body' | awk '/^\\`/ {print NR": "$0}'   # zero output = OK
+gh pr view <N> -R <owner/repo> --json body -q '.body' | grep -n '^\\`'   # zero output = OK (no $-sigils here: argument splicing rewrites them)
 gh pr view <N> -R <owner/repo> --json body -q '.body' | grep -n '^```mermaid'          # opening fence present (skip if no mermaid)
 ````
 
@@ -75,4 +78,4 @@ If any fence line starts with a backslash, fix the local file and re-push it.
 - [ ] Mermaid uses real-name labels and ≤10 nodes (or was deliberately omitted)
 - [ ] Every "How to verify" entry in the review guide is actionable
 - [ ] No mid-paragraph line breaks in prose
-- [ ] Ran both Step 4 verification commands and included the results in the completion report
+- [ ] Ran the Step 4 verification commands (the mermaid fence check only when a mermaid is present) and included the results in the completion report

--- a/home/dot_claude/skills/technical-writing/SKILL.md
+++ b/home/dot_claude/skills/technical-writing/SKILL.md
@@ -31,6 +31,18 @@ Fix the target reader first; ask when the request and the repo don't say.
 
 The same fact reads differently per reader. If you had to guess the reader, state the assumption when delivering.
 
+## Revision mode (existing documents)
+
+When the input is an existing document or PR/issue body（「簡潔に」「読みやすく」「ゴチャついている」）, diagnose the structure before touching any sentence — the recurring complaint behind these requests is shape and volume, not word choice. Run this checklist against the whole document first:
+
+- **文量**: can it say the same at half the length? Cut duplicated background, work logs, and restated context before polishing what remains（実例: 109 行の PR body が内容を失わず 56 行になった）
+- **表と散文の役割**: tables hold enumerable short facts; reasoning that ended up in table cells moves back to prose, and enumerable facts buried in prose become a table
+- **情報の出し順**: conclusion first, per the Structure section below
+- **図示**: apply the Diagrams trigger（互いに作用する要素が 3 つ以上）— offer the mermaid diagram unprompted instead of waiting to be asked
+- **用語**: run the terminology sweep (Terminology section)
+
+Only after the structure settles do sentence-level edits pay off.
+
 ## Structure: conclusion first
 
 Open every document and every section with the sentence the reader came for. Background earns a place only when it changes what the reader does next.
@@ -72,7 +84,7 @@ Prefer the shortest sentence that keeps the meaning:
 | 削除を実行する必要があります   | 削除してください |
 | 〜という点に留意する必要がある | 〜に注意         |
 
-- Apply the shared norms' one-register-per-document rule. In this domain: README・設計文書は だ・である、手順書・ガイドは です・ます が目安（existing repo docs win）. Source memos leak casual or 依頼 register（「〜してほしい」「しくじったら」）; convert to the document's register（「〜すること」「失敗した場合」）.
+- Apply the shared norms' one-register-per-document rule. In this domain: README・設計文書は だ・である、手順書・ガイドは です・ます が目安（existing repo docs win）. Source memos leak casual or 依頼 register（「〜してほしい」「しくじったら」）; convert to the document's register（「〜すること」「失敗した場合」）. The worked examples in this file illustrate structure, not register — re-cast them into the target document's register when borrowing（手順書なら です・ます に直す）.
 - Short paragraphs (2–4 sentences) with a blank line between logical units; tables for enumerable facts, numbered lists for sequences, prose for reasoning. Where prose works, prefer prose over decorated lists.
 
 ## Terminology and notation
@@ -84,6 +96,8 @@ Prefer the shortest sentence that keeps the meaning:
 | コードに実在する識別子 | backticks, exactly as written in code — grep must hit | `cache_ttl_seconds`, `CacheClient`, `POST /api/v1/cache/invalidate`            |
 
 Unify variants within a document（サーバ／サーバー等）, following the repo's existing choice.
+
+**Sweep, don't just consult**: after drafting or revising, scan the prose for bare English common-concept words left untranslated（service・workflow・tenant・patch・repository・schema → サービス・ワークフロー・テナント・パッチ・リポジトリ・スキーマ）. Boundary with 固有名詞: a word naming a specific product feature keeps its official spelling（GitHub の Issue / PR、Terraform の plan）; the same word as a general concept in running prose becomes カタカナ. When neither reading is clearly right, ask instead of guessing.
 
 ## Diagrams
 
@@ -101,5 +115,5 @@ Technical-writing specific: when a source memo and the code disagree, the code w
 
 ## Finishing pass
 
-- The always-loaded rules still apply: `~/.claude/rules/japanese-writing.md` (non-negotiables) and `markdown-formatting.md` (Semantic Line Breaks).
+- The always-loaded rules still apply: `~/.claude/rules/japanese-writing.md` (non-negotiables) and `markdown-formatting.md` (line-break policy — Semantic Line Breaks only where the repo opts in, never as the default).
 - Invoke the japanese-ai-writing-proofreader skill only when the user explicitly asks for 校正 — its full pipeline costs more than most documents warrant, and the always-loaded rules already hold the prose baseline.

--- a/justfile
+++ b/justfile
@@ -160,6 +160,7 @@ test-skill-scripts:
     @echo "Running skill script tests..."
     @bash tests/skills/pr-monitor/run-tests.sh
     @bash tests/skills/context-diet/run-tests.sh
+    @bash tests/skills/codex-subagent/run-tests.sh
 
 # Run skill fetcher tests
 test-skills:

--- a/tests/skills/codex-subagent/run-tests.sh
+++ b/tests/skills/codex-subagent/run-tests.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Tests for home/dot_claude/skills/codex-subagent/scripts/dispatch.sh
+#
+# Stubs `codex` via PATH; the stub records the assembled prompt and writes a
+# minimal final message to the --output-last-message file, so dispatch.sh can
+# be exercised without the real CLI.
+set -uo pipefail
+cd "$(dirname "$0")" || exit 1
+SCRIPT="$(cd ../../.. && pwd)/home/dot_claude/skills/codex-subagent/scripts/dispatch.sh"
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+mkdir -p "$workdir/bin"
+
+cat >"$workdir/bin/codex" <<'FAKE'
+#!/usr/bin/env bash
+out=""
+prev=""
+for arg in "$@"; do
+  [[ $prev == --output-last-message ]] && out=$arg
+  prev=$arg
+done
+cat >"$CODEX_STUB_PROMPT"
+printf 'STATUS: DONE\nRESULT: stub result\n' >"$out"
+FAKE
+chmod +x "$workdir/bin/codex"
+
+export PATH="$workdir/bin:$PATH"
+export CODEX_STUB_PROMPT="$workdir/prompt.txt"
+
+pass=0
+fail=0
+check() {
+  local name=$1 expected=$2 actual=$3
+  if [[ "$actual" == "$expected" ]]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $name (expected: $expected, actual: $actual)" >&2
+  fi
+}
+
+# 1. stdin (heredoc) path keeps working
+: >"$CODEX_STUB_PROMPT"
+output=$(bash "$SCRIPT" --cd "$workdir" <<<'task-via-stdin' 2>&1)
+check "stdin: exit 0" 0 $?
+check "stdin: final message printed" 0 "$(grep -q 'STATUS: DONE' <<<"$output"; echo $?)"
+check "stdin: task reached codex" 0 "$(grep -q 'task-via-stdin' "$CODEX_STUB_PROMPT"; echo $?)"
+check "stdin: contract wraps task" 0 "$(grep -q '<subagent_contract>' "$CODEX_STUB_PROMPT"; echo $?)"
+
+# 2. --task-file reads the task from a file (no stdin needed)
+: >"$CODEX_STUB_PROMPT"
+printf 'task-via-file\n' >"$workdir/task.md"
+output=$(bash "$SCRIPT" --task-file "$workdir/task.md" --cd "$workdir" </dev/null 2>&1)
+check "task-file: exit 0" 0 $?
+check "task-file: final message printed" 0 "$(grep -q 'STATUS: DONE' <<<"$output"; echo $?)"
+check "task-file: task reached codex" 0 "$(grep -q 'task-via-file' "$CODEX_STUB_PROMPT"; echo $?)"
+
+# 3. --task-file with a missing file fails with a clear error
+output=$(bash "$SCRIPT" --task-file "$workdir/nope.md" --cd "$workdir" </dev/null 2>&1)
+status=$?
+check "missing task-file: nonzero exit" 1 "$(((status == 0)) && echo 0 || echo 1)"
+check "missing task-file: names the path" 0 "$(grep -q 'nope.md' <<<"$output"; echo $?)"
+
+# 4. empty task is rejected
+output=$(bash "$SCRIPT" --cd "$workdir" </dev/null 2>&1)
+check "empty task: exit 64" 64 $?
+
+echo "codex-subagent dispatch tests: $pass passed, $fail failed"
+((fail == 0)) || exit 1


### PR DESCRIPTION
## Why

Empirical prompt tuning over the last month of session transcripts (13 projects, 2026-07-07..08-06): every skill invocation was cross-checked against what the user did next, and the recurring friction patterns were fixed at the source. Three Explore agents mined the transcripts; each fix below is tied to observed recurrence, and every subagent claim acted on was verified against primary sources (`gh` 2.96.0 flag set, `dispatch.sh` source, the SKILL.md lines in question). A fresh reading-check agent then cold-read the edited files and its comprehension findings were folded in.

## What changed

**codex-subagent** — 0 of 12 recorded dispatches completed in the foreground (runs routinely exceed 10 min), and worktree-isolated sessions refuse the mandated stdin heredoc. `dispatch.sh` gains `--task-file` as the primary invocation (TDD: new stubbed-codex test suite, 10 cases, wired into `just test-skill-scripts`), and SKILL.md documents the execution model: `run_in_background`, no interim output by design, read the output file on completion.

**pr-description** — `gh pr diff --stat` does not exist (4/4 invocations burned a failed call; now `--name-only`); the Step 4 awk carried a literal `$0` that argument splicing rewrites before the body reaches the agent (now `grep -n`, no `$`-sigil); adds the trigger phrasing the user actually types, multi-PR invocations, and checklist alignment for the mermaid-omitted case.

**japanese-ai-writing-proofreader / technical-writing** — the dominant pattern (5 recurrences) was a clean sentence-level pass followed minutes later by 「読みづらい」「簡潔に」 re-requests. The proofreader now scales by length instead of artifact type (40+ line PR/issue bodies get the full pipeline), hands structural findings off to technical-writing, covers table cells and diff scope in the scope guards, and fixes a latent `$TMP` re-expansion break in the fix-mode baseline re-run. technical-writing gains a revision-mode checklist (volume, table vs prose roles, conclusion first, unprompted mermaid offer, terminology sweep with a 固有名詞/一般概念 boundary).

Not in this PR: `daily-kickoff` fixes went to the live `~/.claude/skills/` copy (business content, intentionally outside this repo).

## Verification

- `just test-skill-scripts` — all pass, including the new codex-subagent suite (10/10; Red confirmed before implementation)
- `just fmt-check`, `bash -n dispatch.sh`, `just test-skills` fixture regression — all green
- `just lint` fails on a pre-existing `luac`-missing environment issue unrelated to this change

Full investigation log (evidence quotes, rejected false positives): `.ai/skill-friction-mining-2026-08.md` (local, untracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
