### PR TITLE
feat(herdr): make concurrent agents distinguishable and wire session restore

### DIFF
--- a/home/dot_claude/settings.json.tmpl
+++ b/home/dot_claude/settings.json.tmpl
@@ -254,6 +254,18 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '{{ .chezmoi.homeDir }}/.claude/hooks/herdr-agent-state.sh' session",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/home/dot_config/herdr/config.toml
+++ b/home/dot_config/herdr/config.toml
@@ -34,9 +34,25 @@ height = "80%"
 switch_ascii_input_source_in_prefix = true
 pane_history = true
 
+# macOS: keep the IME candidate window anchored to the pane cursor for TUIs that
+# paint their own cursor. Scoped to Claude panes, so panes running an app that
+# hides the cursor without painting a replacement keep the default behavior.
+reveal_hidden_cursor_for_cjk_ime = true
+cjk_ime_agents = ["claude"]
+
 [ui]
 show_agent_labels_on_pane_borders = true
 hide_tab_bar_when_single_tab = true
+
+# Attention-queue ordering for the agent panel, chosen through the Settings TUI.
+# Recorded here so `chezmoi apply` does not revert it to the "spaces" default.
+agent_panel_sort = "priority"
+
+# Every pane here runs Claude, so the default ["agent"] row renders one identical
+# "claude" label per entry and the priority ordering above becomes unreadable. The
+# stripped terminal title carries the actual task, which is what distinguishes them.
+[ui.sidebar.agents.rows_by_agent]
+claude = [["state_icon", "workspace", "tab"], ["terminal_title_stripped"]]
 
 [ui.toast]
 delivery = "terminal"


### PR DESCRIPTION
## Why

Two gaps surfaced while auditing `herdr --default-config` against this repo's config and checking what the running herdr server actually reports over its API.

The agent sidebar could not tell concurrent agents apart. Every pane here runs Claude, so the default row layout `[["state_icon", "workspace", "tab"], ["agent"]]` printed one identical "claude" label per entry. `agent_panel_sort = "priority"` was already set, so herdr was ordering entries by who needs attention and then giving the reader nothing to distinguish them by. The distinguishing data was already in the API snapshot as `terminal_title_stripped`.

Agent session restore was silently inert. `[session] resume_agents_on_restore` defaults to true and reads as enabled, but it needs an official integration to report session refs, and `herdr integration status` showed `claude: not installed`. The API snapshot confirmed the consequence: no session-ref field on any of the five running agents, so a herdr server restart would have restored the panes and lost the conversations.

## What changed

**herdr config** — the Claude sidebar rows now show `terminal_title_stripped`, scoped through `rows_by_agent` so other agent kinds keep the default layout. Opted into `experimental.reveal_hidden_cursor_for_cjk_ime` with `cjk_ime_agents = ["claude"]`, which keeps the macOS IME candidate window tracking the pane cursor in TUIs that paint their own cursor. Also recorded `agent_panel_sort = "priority"`, which had been chosen through the Settings TUI and never written back, so a `chezmoi apply` would have reverted it to the `spaces` default.

**Claude settings template** — added the SessionStart hook that `herdr integration install claude` wires up.

```mermaid
sequenceDiagram
    participant CC as Claude Code
    participant Hook as herdr-agent-state.sh
    participant Srv as herdr server
    CC->>Hook: SessionStart (session_id, transcript_path)
    Hook->>Srv: pane.report_agent_session (unix socket)
    Note over Srv: stores session ref for restore
```

The path renders through `.chezmoi.homeDir`, not `$HOME`. herdr decides whether the hook is already wired by matching its own absolute-path spelling, so a `$HOME` form goes unrecognized and a reinstall appends a second entry that fires the hook twice per session. Both forms were tested in an isolated `HOME` before choosing.

## Verification

- `herdr server reload-config` returns `{"diagnostics":[],"status":"applied"}` for the config change. `status` is the signal here, not `diagnostics`: `herdr config check` reports `config: ok` even for a conflicting keybinding, and empty diagnostics do not imply the config took effect.
- The rendered template's `hooks.SessionStart` compares equal to what `herdr integration install claude` wrote, and the existing PreToolUse hooks still hold all 8 commands.
- `herdr integration status` now reports `claude: current (v7)`.
- Integration behavior was exercised in a throwaway `HOME` before touching the real one: existing hooks are preserved, reinstall is idempotent, and top-level key order is retained.
- `just fmt-check` and `just lint-zsh` pass. `just lint` still fails on the pre-existing missing-`luac` environment gap, unrelated to this change.

Not in this PR: the `herdr --skill` agent skill was deliberately declined. It exposes `herdr pane read`, `send-keys`, and `run` against arbitrary panes, which would let one agent drive another pane's shell and route around the PreToolUse guards this repo installs.

The pre-existing key-order and `_tag` drift between `~/.claude/settings.json` and the template is left untouched; applying it would push unrelated churn through this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
