### PR TITLE
fix: repair fresh install (devbox packages, forced locale, dead script ignores, pnpm PATH)

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -3,11 +3,13 @@
 **/*.pyc
 
 # macOS specific
+# Scripts are matched by target name, which has the run_* prefix stripped —
+# naming the source file here would never match. Verify with `chezmoi ignored`.
 {{ if ne .chezmoi.os "darwin" }}
 .config/karabiner/
 Library/
 homebrew/
-.chezmoiscripts/run_onchange_after_configure-macos-keyboard.sh
+.chezmoiscripts/configure-macos-keyboard.sh
 {{ end }}
 
 # Linux specific (servers don't need GUI terminal config)
@@ -34,9 +36,9 @@ homebrew/Brewfile.work
 {{ if .business_use }}
 .config/atcoder-cli-nodejs/
 .config/zsh/atcoder.zsh
-.chezmoiscripts/run_once_after_configure-atcoder-cli.sh
-.chezmoiscripts/run_once_after_create-atcoder-workspace.sh
-.chezmoiscripts/run_onchange_after_install-atcoder-tools.sh
+.chezmoiscripts/configure-atcoder-cli.sh
+.chezmoiscripts/create-atcoder-workspace.sh
+.chezmoiscripts/install-atcoder-tools.sh
 {{- if eq .chezmoi.os "darwin" }}
 Library/Preferences/atcoder-cli-nodejs
 {{- end }}

--- a/home/.chezmoiscripts/run_onchange_after_install-atcoder-tools.sh
+++ b/home/.chezmoiscripts/run_onchange_after_install-atcoder-tools.sh
@@ -15,6 +15,9 @@ if command -v acc >/dev/null 2>&1; then
   :
 elif command -v pnpm >/dev/null 2>&1; then
   echo "Installing atcoder-cli via pnpm..."
+  # This runs under bash, so modules/pnpm.zsh has not set PNPM_HOME here.
+  export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
+  export PATH="$PNPM_HOME/bin:$PATH"
   pnpm add -g atcoder-cli
 else
   echo "pnpm not found — skipping acc install" >&2

--- a/home/dot_config/zsh/modules/pnpm.zsh
+++ b/home/dot_config/zsh/modules/pnpm.zsh
@@ -4,9 +4,10 @@
 # Side-effects: export PNPM_HOME and prepend it to PATH (with dedup check)
 # Load-order:   free
 
-# pnpm setup
+# pnpm installs global binaries into $PNPM_HOME/bin, not $PNPM_HOME itself,
+# and refuses `pnpm add -g` outright when that directory is absent from PATH.
 export PNPM_HOME="$HOME/.local/share/pnpm"
 case ":$PATH:" in
-  *":$PNPM_HOME:"*) ;;
-  *) export PATH="$PNPM_HOME:$PATH" ;;
+  *":$PNPM_HOME/bin:"*) ;;
+  *) export PATH="$PNPM_HOME/bin:$PATH" ;;
 esac

--- a/home/dot_zshenv.tmpl
+++ b/home/dot_zshenv.tmpl
@@ -12,8 +12,16 @@ export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 # export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
 
 # Locale
-export LANG=en_US.UTF-8
-export LC_ALL=en_US.UTF-8
+# en_US.UTF-8 is always present on macOS but is not generated on a stock
+# Ubuntu/WSL2, where only C.UTF-8 exists — forcing it there makes every
+# child process warn and fall back to the C locale. glibc spells it
+# "en_US.utf8", macOS "en_US.UTF-8". LC_ALL is left unset so per-category
+# system settings still apply.
+if locale -a 2>/dev/null | grep -qiEx 'en_US\.utf-?8'; then
+  export LANG=en_US.UTF-8
+else
+  export LANG=C.UTF-8
+fi
 
 # Editor
 export EDITOR=nvim

--- a/install.sh
+++ b/install.sh
@@ -44,4 +44,13 @@ else
   chezmoi init --apply paveg/dots
 fi
 
+# Install the CLI tools declared by the rendered devbox global manifest.
+# Must run after chezmoi apply, which is what writes that manifest.
+echo "==> Installing CLI tools via devbox..."
+if ! devbox global install; then
+  echo "!!! devbox global install failed."
+  echo "!!! The dotfiles are applied, but CLI tools are missing."
+  echo "!!! Re-run it manually: devbox global install"
+fi
+
 echo "==> Done! Restart your shell or run: exec zsh"


### PR DESCRIPTION
## Why

A fresh WSL2 bootstrap through the one-liner (`curl … install.sh | bash`) produced a shell that errored on every startup with `unknown option: --zsh`, and `eza`, `bat`, `zoxide`, `nvim` and friends were all missing. Peeling that back surfaced four independent defects, each one invisible on macOS or silent by construction.

**The devbox profile was never populated.** It held exactly one package, `chezmoi`, while `devbox.json` declared 66. `install.sh` runs nix → devbox → chezmoi → `chezmoi init --apply` and stops there, never calling `devbox global install`. The README's "Manual Setup" section documents that step, so only the one-liner path drops it.

`PATH` was never the problem. `~/.zshenv` correctly places the devbox profile bin ahead of `/usr/bin`; the directory it pointed at was empty. That is also where `--zsh` came from — with no devbox `fzf`, the turbo-loaded init fell through to Debian's `/usr/bin/fzf` 0.44.1, which predates the `--zsh` flag.

**`LC_ALL` was forced to a locale that does not exist on Linux.** `en_US.UTF-8` always exists on macOS but is not generated on a stock Ubuntu, where only `C.UTF-8` is available, so every child process warned `setlocale: cannot change locale` and fell back to the C locale.

**Every `.chezmoiscripts` ignore pattern was dead.** `.chezmoiignore` already excluded the macOS keyboard script on non-darwin, but named the source file including its `run_onchange_after_` prefix. chezmoi matches scripts by *target* name, which has that prefix stripped, so the pattern never matched and `chezmoi apply` on Linux ran it anyway:

```
/tmp/1308368977.configure-macos-keyboard.sh: line 12: defaults: command not found
chezmoi: .chezmoiscripts/configure-macos-keyboard.sh: exit status 127
```

The same mistake affected the three AtCoder scripts in the `business_use` block, which would have run on a work machine.

**pnpm's global bin directory was never on PATH.** `modules/pnpm.zsh` put `$PNPM_HOME` there, but pnpm installs global binaries into `$PNPM_HOME/bin`. The parent holds nothing but that subdirectory, so an installed `acc` could never resolve — and pnpm 11 refuses `add -g` outright while the directory is missing, which broke the next `chezmoi apply`:

```
[ERROR] The configured global bin directory "/home/ryota/.local/share/pnpm/bin" is not in PATH
chezmoi: .chezmoiscripts/install-atcoder-tools.sh: exit status 1
```

Unlike the other three, this one is not Linux-specific — it would have kept `acc` unreachable on macOS too.

```mermaid
flowchart LR
    A[install.sh] --> B[nix]
    B --> C[devbox]
    C --> D[chezmoi]
    D --> E["chezmoi init --apply<br/>renders devbox.json"]
    E -.->|missing| F["devbox global install"]
    F --> G[66 CLI tools]
    style F stroke-dasharray: 4 4
```

## What changed

**`install.sh`** — calls `devbox global install` after `chezmoi init --apply`, which is the step that renders the manifest it reads. A failure warns and continues rather than tripping `set -e`, so a partial build on a slow link still leaves the dotfiles applied and tells the operator what to re-run.

**`home/dot_zshenv.tmpl`** — probes for `en_US.UTF-8` and falls back to `C.UTF-8`, instead of forcing it. `LC_ALL` is dropped entirely so per-category system settings still apply; `LC_ALL` overrides every `LC_*` category and is the wrong lever for picking a default.

The probe matches both spellings — glibc reports `en_US.utf8`, macOS reports `en_US.UTF-8` — so a naive exact match would have silently downgraded macOS to `C.UTF-8`. The pattern uses `-E` because `\?` is a GNU extension in BRE and BSD grep is not guaranteed to honor it. Cost: 1.6ms measured over 20 runs, about 3% of the repo's ~50ms startup target.

**`home/.chezmoiignore`** — the four `.chezmoiscripts` patterns now use target names. A comment records the rule and points at `chezmoi ignored` as the way to check it, since a wrong pattern here fails silently rather than erroring.

**`home/dot_config/zsh/modules/pnpm.zsh`** — puts `$PNPM_HOME/bin` on PATH. **`run_onchange_after_install-atcoder-tools.sh`** repeats that setup for itself, because chezmoi runs scripts under bash where the interactive zsh module has not been sourced.

## Verification

Machine state after running `devbox global install` (66/66 packages resolved):

```
$ script -qec 'zsh -i -c "sleep 4; command -v eza; command -v fzf; fzf --version"' /dev/null
…/devbox/global/default/.devbox/nix/profile/default/bin/eza
…/devbox/global/default/.devbox/nix/profile/default/bin/fzf
0.74.2 (refs/tags/v0.74.2)
```

The 4-second sleep matters: `fzf` is loaded through `zinit wait"2"`, so a bare `zsh -i -c exit` exits before the turbo plugin runs and cannot reproduce the `--zsh` error at all. No error appeared. `~/.cache/zsh/init/` now holds `fzf.zsh`, `atuin.zsh`, `zoxide.zsh` and `direnv.zsh`, where before only `mise.zsh` existed.

Locale, in a shell with the inherited values cleared:

```
$ env -u LANG -u LC_ALL zsh -c 'source ~/.zshenv; echo "LANG=[$LANG] LC_ALL=[${LC_ALL:-unset}]"; /bin/date'
LANG=[C.UTF-8] LC_ALL=[unset]
Thu Aug 13 04:12:25 JST 2026
```

No `setlocale` warning. The probe was also checked directly against both spellings and the near-misses:

| input | matches |
| :-- | :-- |
| `en_US.utf8` | yes |
| `en_US.UTF-8` | yes |
| `en_GB.utf8` | no |
| `C.utf8` | no |
| `en_US.iso88591` | no |

Script ignores, before and after. `chezmoi ignored | grep chezmoiscripts` returned nothing at all beforehand:

```
$ chezmoi ignored | grep chezmoiscripts          # linux, personal
.chezmoiscripts/configure-macos-keyboard.sh

$ chezmoi ignored --config <business fixture> | grep chezmoiscripts
.chezmoiscripts/configure-atcoder-cli.sh
.chezmoiscripts/configure-macos-keyboard.sh
.chezmoiscripts/create-atcoder-workspace.sh
.chezmoiscripts/install-atcoder-tools.sh
```

The `business_use` case was checked with `--config` pointing at a throwaway fixture rather than `chezmoi init`, which rewrites the real config even under `--dry-run`. `chezmoi data` still reports `business_use = False` afterwards.

pnpm, which directory actually has to be on PATH:

```
$ PNPM_HOME=~/.local/share/pnpm PATH="$PNPM_HOME:$PATH"     bash -c 'pnpm root -g'
[ERROR] The configured global bin directory "…/pnpm/bin" is not in PATH
$ PNPM_HOME=~/.local/share/pnpm PATH="$PNPM_HOME/bin:$PATH" bash -c 'pnpm root -g'
/home/ryota/.local/share/pnpm/global/v11
```

`chezmoi apply` then ran the AtCoder script to completion (exit 0), and the result resolves in a fresh interactive shell — `acc` 2.2.0 at `~/.local/share/pnpm/bin/acc`.

`just test` exits 0. `zsh -n` on the changed zsh sources (chezmoi syntax stripped where applicable), and `shellcheck` on both changed scripts, all pass.

## Notes

`gitstatus failed to initialize` showed up during diagnosis and is **not** a real defect — it is an artifact of running `zsh -i` without a TTY. Under `script -qec … /dev/null` it does not appear, and `gitstatusd-linux-x86_64 --version` returns v1.5.4 on its own.

Dropping the `LC_ALL` export does not clear it from shells that already inherited it; `exec $SHELL -l` preserves the process environment. Existing sessions need a genuinely fresh shell, or `tmux kill-server`. No `unset` was added, since that would also override a deliberate `LC_ALL`.

One unrelated breakage surfaced on the affected machine and was repaired there, not in this repo: the nix profile had `kubectl-1.36.3-man` installed without the `out` output, so the man pages were present and the binary was not. `devbox.lock` was correct, so this looks like two concurrent `devbox global install` processes racing on the same profile. `nix profile remove … kubectl` followed by a reinstall fixed it. Worth knowing that `nix profile` locking does not protect profile-generation consistency against concurrent devbox runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
