### PR TITLE
feat(skills): add grill-me interview skill with write-down phase (ADR 0005)

### DIFF
--- a/docs/adr/0005-grill-me-single-skill-with-write-down.md
+++ b/docs/adr/0005-grill-me-single-skill-with-write-down.md
@@ -1,0 +1,45 @@
+# 0005. grill-me: single inline skill with a post-confirmation write-down phase
+
+## Status
+
+Accepted — 2026-08-15.
+
+## Context
+
+The user wanted a `grill-me` equivalent of [mattpocock/skills](https://github.com/mattpocock/skills) in this repo, extended so that what a session settles is written to disk — technical decisions as ADRs, everything else to a recommended directory (`docs/adr` etc.).
+
+The reference is a three-skill family: `grilling` (the round-based interview primitive, model-invocable), `grill-me` (a one-line user-invoked front door: "Run a `/grilling` session", stateless, writes nothing), and `grill-with-docs` (the same front door plus `domain-modeling`, which writes `CONTEXT.md` glossary terms inline during the session and offers ADRs behind a three-gate test). Its own docs list two recurring failures: a wrapper skill that names another skill does not reliably cause it to load, producing an improvised question dump; and "where did all my other decisions go?" — the glossary is not a spec, most answers fail the ADR gate, and the rest lives only in the conversation.
+
+Repo constraints: skills are English (`CLAUDE.md`), ADRs follow `~/.claude/rules/harness-engineering.md` (English, `NNNN-short-description.md`, Status / Context / Decision / Consequences), design docs already have a home under `docs/superpowers/specs/`, and `~/.agents/skills` symlinks to `~/.claude/skills` so Codex reads the same skill (hence `agents/openai.yaml` stays).
+
+## Decision
+
+Ship **one** skill, `home/dot_claude/skills/grill-me/SKILL.md`, user-invoked only (`disable-model-invocation: true`), with two strictly ordered phases:
+
+- **Interview** — the reference `grilling` mechanics inlined verbatim in spirit: design tree, frontier, rounds, `❓ Qn` + `➡️ recommendation` format, facts looked up by the agent (Explore sub-agent) vs decisions put to the user, opt-in one-question-at-a-time pacing, ungrillable items parked as "needs prototype", and a confirmation gate before anything is written.
+- **Write-down** — after confirmation only. Decisions passing the three-gate test (hard to reverse, surprising without context, real trade-off) become one ADR each in the repo's existing ADR directory (`docs/adr/` if none). Everything else settled — scope, behaviour, rejected options, open and ungrillable items — becomes one design doc per session in the repo's existing spec/design directory (`docs/superpowers/specs/`, `docs/specs/`, `docs/design/`, `docs/rfcs/`, `design/`; `docs/design/YYYY-MM-DD-<topic>.md` if none; ask outside a repo). Target paths are shown and approved as the final round before writing.
+
+### Rejected alternatives
+
+- **Primitive + front door split (`grilling` / `grill-me` / `grill-with-docs`)**: mirrors the reference but reintroduces its "wrapper never loaded the primitive" failure, and nothing else in this repo would consume the primitive. If a second consumer appears, extract the interview section then.
+- **Inline writing during the interview (`CONTEXT.md` glossary as in `grill-with-docs`)**: an abandoned session leaves half-written files, and this repo has no glossary practice to feed. Writing once after confirmation matches the repo's existing show-the-shape-before-committing habit.
+- **Stateless (`grill-me` verbatim)**: the user's explicit requirement was that the settled result lands on disk.
+
+## Consequences
+
+### Positive
+
+- One file to read; no cross-skill loading dependency, so the interview format is followed or the failure is obvious.
+- Precise answers survive the session: the design doc template says to copy numeric defaults, ordering guarantees, and negative requirements verbatim instead of softening them into prose.
+- ADR output already conforms to the house format and numbering, so a session's ADR slots straight into `docs/adr/`.
+
+### Negative / accepted trade-offs
+
+- The interview cannot be reused by another skill without either duplicating text or extracting a primitive later. Accepted: no consumer today.
+- Directory detection is a fixed preference list; a repo with an unusual layout must tell the skill where to write (the final "confirm targets" round is the escape hatch).
+- The default round-based pacing differs from `~/.claude/rules/workflow.md`'s "one question at a time" brainstorm style. Accepted: rounds are the point of grilling; the skill switches on request.
+
+### Verification
+
+- `just test` green with the new skill present (format check covers the SKILL.md).
+- An independent sub-agent executed the skill on a sample topic and produced a numbered round in the specified format without answering its own decision questions or writing files.

--- a/home/dot_claude/skills/grill-me/SKILL.md
+++ b/home/dot_claude/skills/grill-me/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: grill-me
+description: >
+  Relentless round-based interview that sharpens a plan, decision, or idea until user and agent share one understanding, then writes the settled result down — technical trade-offs as ADRs, everything else as a design doc in the repo's convention. Use on 「グリルして」「詰めて」「壁打ちして」「仕様を固めたい」「設計を詰めたい」 or "grill me". Not for executing a plan that already exists.
+
+disable-model-invocation: true
+---
+
+# Grill Me
+
+Interview the user relentlessly until you reach a shared understanding, then write that understanding down. Two phases, strictly in order: **interview** (nothing is written), then **write-down** (only after the user confirms). Never implement anything in this skill.
+
+Start from whatever the user has — a loose idea is enough; producing the sharp version is what the session is for. Do not build a plan and ask the user to nod at it.
+
+## Phase 1 — Interview
+
+Map the subject as a **design tree**: every decision branches into the decisions that hang off it.
+
+Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled — the questions you can ask _now_ without guessing at answers you haven't heard yet. Ask the whole frontier in one round: number each question and give your recommended answer. Then wait for the user's answers before the next round. A question whose answer depends on another question still open in this round belongs to a _later_ round. Independent questions all belong in the current round, even if some feel like details — the frontier is defined by dependencies, not by importance.
+
+Format every question like this:
+
+```
+❓ **Q1** - **<question title>**: <question body — may be several paragraphs, may list options>
+
+➡️ <your recommended answer, with a one-clause reason>
+```
+
+Each round of answers reshapes the tree — settled decisions push the frontier outward and unblock what depended on them. Recompute the frontier and ask the next round. Count rounds, not questions: many questions in few rounds is the intended shape.
+
+### Facts are yours, decisions are the user's
+
+Finding _facts_ is your job, never the user's. When a frontier question needs a fact from the environment (filesystem, git history, existing docs, tools), dispatch a read-only sub-agent (Explore) or look it up yourself — never ask the user for something you could find. Don't block on it: a running exploration is an unsettled prerequisite, so only the questions downstream of it wait; ask the rest of the frontier now.
+
+The _decisions_ are the user's — put each one to them and wait. Answering your own decision questions breaks the skill; it is not a liberal interpretation of it. "I don't know" is a real answer: record it as open.
+
+### Steering
+
+- If the user asks for one question at a time, switch to that pacing for the rest of the session.
+- Some questions are **ungrillable** — how something should look or feel, which of two layouts reads better. Talking cannot settle them. Say so, park the question as "needs a prototype", and move on rather than rephrasing it round after round.
+- If the frontier keeps growing instead of shrinking, the scope is too large. Say so and propose splitting the subject before continuing.
+
+### Done gate
+
+The interview is done when the frontier is empty — every branch visited, nothing left silently assumed. Then present a compact summary of every settled decision and open item, and ask the user to confirm the understanding is shared. Do not write files or act until they confirm.
+
+## Phase 2 — Write-down
+
+Only after confirmation. Route what was settled to durable files; the conversation is not a durable place.
+
+### What goes where
+
+| What resolved                                                                                                                        | Where it lands                 |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| A technical decision that is **hard to reverse**, **surprising without context**, and **the result of a real trade-off** (all three) | One ADR per decision           |
+| Everything else that was settled — scope, behaviour, non-technical decisions, rejected options, open/ungrillable items               | One design doc for the session |
+| Nothing settled beyond restating the obvious                                                                                         | Say so and write nothing       |
+
+Most decisions fail the three-gate test; a session that yields one design doc and zero ADRs is normal.
+
+### ADR
+
+- Directory: the repo's existing ADR directory (`docs/adr/`, `docs/decisions/`, `adr/`, or wherever existing ADRs already live). If none exists, create `docs/adr/`.
+- Numbering: highest existing `NNNN` + 1; filename `NNNN-short-description.md`.
+- Format and language: follow `~/.claude/rules/harness-engineering.md` — English, sections Status / Context / Decision / Consequences. Read the existing ADRs first and match their house style; cite prior ADRs the decision builds on or supersedes.
+
+### Design doc
+
+- Directory: follow the repo's existing convention — look for `docs/superpowers/specs/`, `docs/specs/`, `docs/design/`, `docs/rfcs/`, `design/`, in that order of preference, and match the naming pattern of the files already there. If none exists, create `docs/design/` and name the file `YYYY-MM-DD-<topic>.md`.
+- Outside a git repo, there is no convention to follow — ask the user for a path.
+- Language: match the neighbouring docs; if there are none, use the language the user ran the session in. Prose is unwrapped (one paragraph per line).
+- Template:
+
+```markdown
+# <Topic>
+
+## Context
+
+<what was grilled and why, 1–3 sentences>
+
+## Decisions
+
+<numbered; one entry per settled question: what was decided, why, and which alternatives were rejected. Precise answers stay precise — numeric defaults, ordering guarantees, negative requirements are copied verbatim, not softened into prose.>
+
+## Open questions
+
+<unresolved answers ("I don't know") and ungrillable items marked "needs prototype">
+
+## Out of scope
+
+<what the user explicitly excluded>
+
+## Related decisions
+
+<links to the ADRs written this session, if any>
+```
+
+### Confirm targets before writing
+
+The output paths are themselves decisions. As the final round, show the exact list of files you intend to create (path + one-line purpose) and wait for approval. Then write them, and print the paths.
+
+## Stop here
+
+Do not implement, plan the implementation, or open a PR. Point the user at the next step in one line (e.g. write a plan from the design doc) and stop.

--- a/home/dot_claude/skills/grill-me/agents/openai.yaml
+++ b/home/dot_claude/skills/grill-me/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Grill Me"
+  short_description: "Sharpen a plan through interview"
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Summary

- Add `home/dot_claude/skills/grill-me/SKILL.md`: a user-invoked (`disable-model-invocation: true`) port of the round-based grilling interview from [mattpocock/skills](https://github.com/mattpocock/skills) — design tree, frontier rounds, `❓ Qn` / `➡️ recommendation` format, facts looked up by the agent vs decisions put to the user, confirmation gate.
- Add a **write-down phase** after confirmation: decisions passing the three-gate test (hard to reverse / surprising without context / real trade-off) become one ADR each in the repo's ADR dir; everything else settled becomes one design doc in the repo's existing spec/design dir (`docs/superpowers/specs/` here; `docs/design/` fallback). Output paths are approved as the final round before writing.
- Keep `agents/openai.yaml` so Codex (via `~/.agents/skills` → `~/.claude/skills`) sees the same skill.
- Add `docs/adr/0005-grill-me-single-skill-with-write-down.md` recording why this is one inline skill (not the reference's primitive + front-door split) and why writing happens once after confirmation.

## Verification

- `just test` green.
- New Markdown files pass `oxfmt --check` directly (`just fmt-check` uses `git ls-files`, so untracked files are not covered until added).
- An independent sonnet sub-agent executed the skill on a sample topic: produced a numbered round in the specified format, looked up repo facts itself, answered no decision questions on its own, wrote no files. Its two reported ambiguities (independent "detail" questions belong in the current round; `➡️` may carry a one-clause reason) were folded back into the skill text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)